### PR TITLE
D8CORE-153: Enable config_readonly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,60 +2,6 @@
 .idea
 .idea/**
 bin/
-!vendor/
-!docroot/**
-docroot/sites/test.cardinalsites.loc
-docroot/sites/devdocs.cardinalsites.loc
-!docroot/vendor/**
-!docroot/**/vendor/**
-!composer.json
-!docroot/**/composer.json
-!composer.lock
-!docroot/**/composer.lock
-!docroot/modules/**
-.git
-
-# Ignore configuration files that may contain sensitive information.
-local.settings.php
-local.sites.php
-local.drushrc.php
-local.drush.yml
-local.site.yml
-local.aliases.drushrc.php
-local.services.yml
-tests/behat/local.yml
-box/local.config.yml
-*.local
-local.blt.yml
-blt/src/Commands/LocalCommand.php
-simplesamlphp/config/local*
-
-# Ignore drupal core.
-docroot/core
-
-# Ignore paths that contain user-generated content.
-docroot/sites/*/files
-/files-private
-docroot/sites/*/private
-docroot/sites/simpletest
-/artifacts
-keys
-drush/sites
-
-# Ignore contrib modules. These should be created during build process.
-docroot/modules/contrib
-docroot/modules/custom
-docroot/themes/contrib
-docroot/themes/custom
-docroot/profiles/contrib
-docroot/profiles/custom
-docroot/libraries
-drush/Commands
-
-# Ignore stanford contrib items.
-docroot/modules/stanford
-docroot/themes/stanford
-docroot/profiles/stanford
 
 # Ignore custom theme build artifacts
 node_modules
@@ -162,9 +108,5 @@ atlassian-ide-plugin.xml
 #NPM
 npm-debug.log
 
-# Drush 9 Checksums
-drush/sites/.checksums
-
 # Deprecation detector rules
 .rules
-

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "drupal/chosen": "~2.4",
     "drupal/coffee": "~1.0@beta",
     "drupal/components": "~1.0",
+    "drupal/config_readonly": "~1.0@beta",
     "drupal/core": "~8.6",
     "drupal/default_content": "^1.0@alpha",
     "drupal/diff": "^1.0@RC",

--- a/config/install/core.extension.yml
+++ b/config/install/core.extension.yml
@@ -14,6 +14,7 @@ module:
   config_distro: 0
   config_filter: 0
   config_merge: 0
+  config_readonly: 0
   config_split: 0
   config_update: 0
   contextual: 0

--- a/stanford_profile.info.yml
+++ b/stanford_profile.info.yml
@@ -40,13 +40,14 @@ install:
   - admin_toolbar:admin_toolbar
   - admin_toolbar_links_access_filter:admin_toolbar_links_access_filter
   - admin_toolbar_tools:admin_toolbar_tools
-  - config_split:config_split
   - allowed_formats:allowed_formats
   - chosen:chosen
+  - config_readonly:config_readonly
+  - config_split:config_split
   - default_content
+  - nobots:nobots
   - pathauto:pathauto
   - redirect:redirect
-  - nobots:nobots
 
 dependencies:
   # Stanford functionality.

--- a/tests/behat/features/contrib/config_readonly.feature
+++ b/tests/behat/features/contrib/config_readonly.feature
@@ -6,7 +6,4 @@ Feature: Contrib - config_readonly
   @api
   Scenario: Ensure no configuration changes are possible through the UI.
     Given I am logged in as a user with the "Administrator" role
-    And the "config_readonly" module is enabled
-    # And I am on "admin/config/media/file-system"
-    # Then I check "Save configuration" button is disabled
-    # Then I should see the text "This form will not be saved because the configuration active store is read-only."
+    Then check that the "config_readonly" module is enabled

--- a/tests/behat/features/contrib/config_readonly.feature
+++ b/tests/behat/features/contrib/config_readonly.feature
@@ -1,0 +1,8 @@
+Feature: Contrib - config_readonly
+  In order to verify that contrib module config_readonly is working
+  As an administrative user
+  I should be not be able to administer settings when the module is active
+
+  @api
+  Scenario: Create a simple basic page.
+    Given I am logged in as a user with the "Administrator" role

--- a/tests/behat/features/contrib/config_readonly.feature
+++ b/tests/behat/features/contrib/config_readonly.feature
@@ -4,5 +4,9 @@ Feature: Contrib - config_readonly
   I should be not be able to administer settings when the module is active
 
   @api
-  Scenario: Create a simple basic page.
+  Scenario: Ensure no configuration changes are possible through the UI.
     Given I am logged in as a user with the "Administrator" role
+    And the "config_readonly" module is enabled
+    # And I am on "admin/config/media/file-system"
+    # Then I check "Save configuration" button is disabled
+    # Then I should see the text "This form will not be saved because the configuration active store is read-only."


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Enables config_readonly

# Needed By (Date)
- End of sprint

# Urgency
- Low

# Steps to Test

1. See https://github.com/SU-SWS/acsf-cardinalsites/pull/14

# Affected Projects or Products
- cardinalsites stack

# Associated Issues and/or People
- D8CORE-153
- https://github.com/SU-SWS/acsf-cardinalsites/pull/14

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)