### PR TITLE
D8CORE-260 Environment indicator configs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "drupal/default_content": "^1.0@alpha",
         "drupal/diff": "^1.0@RC",
         "drupal/ds": "~3.3",
+        "drupal/environment_indicator": "^3.0",
         "drupal/file_mdm": "~1.1",
         "drupal/google_analytics": "~2.1",
         "drupal/honeypot": "^1.27",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -11,6 +11,7 @@ module:
   chosen: 0
   chosen_lib: 0
   ckeditor: 0
+  color: 0
   components: 0
   config: 0
   config_distro: 0
@@ -36,6 +37,7 @@ module:
   entity_embed: 0
   entity_reference_revisions: 0
   entity_usage: 0
+  environment_indicator: 0
   externalauth: 0
   fakeobjects: 0
   field: 0

--- a/config/sync/environment_indicator.settings.yml
+++ b/config/sync/environment_indicator.settings.yml
@@ -1,0 +1,5 @@
+toolbar_integration:
+  toolbar: toolbar
+favicon: true
+_core:
+  default_config_hash: Bi0EyyiH6m5wpHRfxlKhqTIhAZayhRQudheDzAcrotU


### PR DESCRIPTION
# READY FOR REVIEW

This PR is merging into `D8CORE-457` due to the changing config directories. That PR is a dependency on this one

# Summary
- Environment indicator enabled

# Needed By (Date)
- end of sprint

# Urgency
- low

# Steps to Test
1. follow steps in https://github.com/SU-SWS/acsf-cardinalsites/pull/21

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
