### PR TITLE
D8CORE-492 Circle Image Style

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "su-sws/stanford_basic": "dev-8.x-4.x",
         "su-sws/stanford_date_formats": "dev-8.x-1.x",
         "su-sws/stanford_fields": "dev-8.x-1.x",
-        "su-sws/stanford_image_styles": "dev-8.x-1.x",
+        "su-sws/stanford_image_styles": "dev-D8CORE-492-circle-image-style",
         "su-sws/stanford_media": "dev-8.x-1.x",
         "su-sws/stanford_paragraph_types": "dev-8.x-2.x",
         "su-sws/stanford_ssp": "dev-8.x-1.x",

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "su-sws/stanford_basic": "dev-8.x-4.x",
         "su-sws/stanford_date_formats": "dev-8.x-1.x",
         "su-sws/stanford_fields": "dev-8.x-1.x",
-        "su-sws/stanford_image_styles": "dev-D8CORE-492-circle-image-style",
+        "su-sws/stanford_image_styles": "dev-8.x-1.x",
         "su-sws/stanford_media": "dev-8.x-1.x",
         "su-sws/stanford_paragraph_types": "dev-8.x-2.x",
         "su-sws/stanford_ssp": "dev-8.x-1.x",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -46,11 +46,13 @@ module:
   file: 0
   file_mdm: 0
   file_mdm_exif: 0
+  file_mdm_font: 0
   filter: 0
   focal_point: 0
   hal: 0
   help: 0
   image: 0
+  image_effects: 0
   imagemagick: 0
   inline_entity_form: 0
   inline_form_errors: 0

--- a/config/sync/file_mdm_font.file_metadata_plugin.font.yml
+++ b/config/sync/file_mdm_font.file_metadata_plugin.font.yml
@@ -1,0 +1,9 @@
+configuration:
+  cache:
+    override: false
+    settings:
+      enabled: true
+      expiration: 172800
+      disallowed_paths: {  }
+_core:
+  default_config_hash: o53U_2I-21Es-9iqxeUMDRcRxN0spL1OiHuAVQhh2oI

--- a/config/sync/image.style.stanford_circle.yml
+++ b/config/sync/image.style.stanford_circle.yml
@@ -1,0 +1,35 @@
+uuid: ff7acff1-4307-4c82-8610-e76db3b05b71
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+    - image_effects
+name: stanford_circle
+label: Circle
+effects:
+  0b2a1b5b-65aa-4c03-ad55-f0d64e9414d1:
+    uuid: 0b2a1b5b-65aa-4c03-ad55-f0d64e9414d1
+    id: focal_point_scale_and_crop
+    weight: -10
+    data:
+      width: 140
+      height: 140
+      crop_type: focal_point
+  716304f7-4bc8-4c20-b3da-a8f0e50ee7dd:
+    uuid: 716304f7-4bc8-4c20-b3da-a8f0e50ee7dd
+    id: image_effects_mask
+    weight: -8
+    data:
+      mask_image: modules/custom/stanford_image_styles/img/mask-image.png
+      mask_width: ''
+      mask_height: ''
+      placement: center-center
+      x_offset: ''
+      y_offset: ''
+  83015ef1-511a-465f-8385-cb64a345c3c8:
+    uuid: 83015ef1-511a-465f-8385-cb64a345c3c8
+    id: image_convert
+    weight: -9
+    data:
+      extension: png

--- a/config/sync/image_effects.settings.yml
+++ b/config/sync/image_effects.settings.yml
@@ -1,0 +1,14 @@
+color_selector:
+  plugin_id: html_color
+  plugin_settings:
+    html_color: {  }
+image_selector:
+  plugin_id: basic
+  plugin_settings:
+    basic: {  }
+font_selector:
+  plugin_id: basic
+  plugin_settings:
+    basic: {  }
+_core:
+  default_config_hash: eaXmaPSud65p-XhTwMIL9vKETD9zR3qNOMMa5EUuoNw

--- a/config/sync/stanford_media.settings.yml
+++ b/config/sync/stanford_media.settings.yml
@@ -1,4 +1,5 @@
 embeddable_image_styles:
+  - stanford_circle
   - large
   - medium
   - thumbnail


### PR DESCRIPTION
# READY FOR REVIEW
see https://github.com/SU-SWS/stanford_image_styles/pull/47

# Summary
- Add image_effects module
- added an image style that produces a 140px side circle image.

# Need Review By (Date)
- 9/25

# Urgency
- low

# Steps to Test
1. checkout this branch
1. `composer require su-sws/stanford_image_styles:dev-D8CORE-492-circle-image-style`
1. `drush cim -y`
1. create a basic page, add an image to the wysiwyg and choose the "Circle" image style
1. verify the resulting image is a circle.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
