### PR TITLE
D8CORE-322 Use domain redirect and config pages to allow custom domains

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "su-sws/stanford_paragraph_types": "dev-8.x-2.x",
         "su-sws/stanford_ssp": "dev-8.x-1.x",
         "su-sws/stanford_text_editor": "dev-8.x-1.x",
-        "drupal/domain_301_redirect": "dev-1.x#fd66e82fefff76fddc5968286108056cd17010a4",
+        "drupal/domain_301_redirect": "^1.0-alpha0",
         "drupal/config_pages": "^2.6"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,9 @@
         "su-sws/stanford_media": "dev-8.x-1.x",
         "su-sws/stanford_paragraph_types": "dev-8.x-2.x",
         "su-sws/stanford_ssp": "dev-8.x-1.x",
-        "su-sws/stanford_text_editor": "dev-8.x-1.x"
+        "su-sws/stanford_text_editor": "dev-8.x-1.x",
+        "drupal/domain_301_redirect": "dev-1.x#fd66e82fefff76fddc5968286108056cd17010a4",
+        "drupal/config_pages": "^2.6"
     },
     "extra": {
         "patches": {

--- a/config/sync/config_pages.type.stanford_basic_site_settings.yml
+++ b/config/sync/config_pages.type.stanford_basic_site_settings.yml
@@ -1,0 +1,16 @@
+uuid: b3e6e228-0d21-4c60-aee1-061149d51778
+langcode: en
+status: true
+dependencies: {  }
+id: stanford_basic_site_settings
+label: 'Site Settings'
+context:
+  show_warning: true
+  group:
+    language: false
+  fallback:
+    language: ''
+menu:
+  path: /admin/config/system/basic-site-settings
+  weight: 0
+  description: ''

--- a/config/sync/core.entity_form_display.config_pages.stanford_basic_site_settings.default.yml
+++ b/config/sync/core.entity_form_display.config_pages.stanford_basic_site_settings.default.yml
@@ -1,0 +1,24 @@
+uuid: f709ac08-679e-4bd4-947f-e2bf337d5bd8
+langcode: en
+status: true
+dependencies:
+  config:
+    - config_pages.type.stanford_basic_site_settings
+    - field.field.config_pages.stanford_basic_site_settings.su_site_url
+  module:
+    - link
+id: config_pages.stanford_basic_site_settings.default
+targetEntityType: config_pages
+bundle: stanford_basic_site_settings
+mode: default
+content:
+  su_site_url:
+    weight: 0
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+hidden:
+  label: true

--- a/config/sync/core.entity_view_display.config_pages.stanford_basic_site_settings.default.yml
+++ b/config/sync/core.entity_view_display.config_pages.stanford_basic_site_settings.default.yml
@@ -1,0 +1,27 @@
+uuid: 48020ae6-83c9-410d-8104-1c14da0d99c6
+langcode: en
+status: true
+dependencies:
+  config:
+    - config_pages.type.stanford_basic_site_settings
+    - field.field.config_pages.stanford_basic_site_settings.su_site_url
+  module:
+    - link
+id: config_pages.stanford_basic_site_settings.default
+targetEntityType: config_pages
+bundle: stanford_basic_site_settings
+mode: default
+content:
+  su_site_url:
+    weight: 0
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+hidden: {  }

--- a/config/sync/core.entity_view_mode.config_pages.full.yml
+++ b/config/sync/core.entity_view_mode.config_pages.full.yml
@@ -1,0 +1,12 @@
+uuid: 68b831ef-60a7-44a7-83d2-dbadd9a7feeb
+langcode: en
+status: true
+dependencies:
+  module:
+    - config_pages
+_core:
+  default_config_hash: VYERDzPNi1-oUm7KMLjol4oLcjbHr-onKbitt4dZuN0
+id: config_pages.full
+label: Full
+targetEntityType: config_pages
+cache: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -17,6 +17,7 @@ module:
   config_distro: 0
   config_filter: 0
   config_merge: 0
+  config_pages: 0
   config_readonly: 0
   config_split: 0
   config_update: 0
@@ -27,6 +28,7 @@ module:
   datetime_range: 0
   default_content: 0
   display_field_copy: 0
+  domain_301_redirect: 0
   dropzonejs: 0
   dropzonejs_eb_widget: 0
   dynamic_page_cache: 0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -83,6 +83,7 @@ module:
   stanford_image_styles: 0
   stanford_media: 0
   stanford_paragraph_types: 0
+  stanford_profile_config_overrides: 0
   stanford_profile_styles: 0
   stanford_ssp: 0
   stanford_text_editor: 0

--- a/config/sync/domain_301_redirect.settings.yml
+++ b/config/sync/domain_301_redirect.settings.yml
@@ -1,0 +1,6 @@
+enabled: 0
+domain: ''
+applicability: 0
+pages: ''
+_core:
+  default_config_hash: YKTwN3a8xbhMiZqrdA-aXUWmQBGHHBZc2nJZq059FKU

--- a/config/sync/field.field.config_pages.stanford_basic_site_settings.su_site_url.yml
+++ b/config/sync/field.field.config_pages.stanford_basic_site_settings.su_site_url.yml
@@ -1,0 +1,23 @@
+uuid: 5a7b79c2-212b-4f8f-85fc-fb8d6eb0e4b2
+langcode: en
+status: true
+dependencies:
+  config:
+    - config_pages.type.stanford_basic_site_settings
+    - field.storage.config_pages.su_site_url
+  module:
+    - link
+id: config_pages.stanford_basic_site_settings.su_site_url
+field_name: su_site_url
+entity_type: config_pages
+bundle: stanford_basic_site_settings
+label: 'Site URL'
+description: 'To redirect all traffic to a single url, input the stanford.edu url here.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 16
+  title: 0
+field_type: link

--- a/config/sync/field.storage.config_pages.su_site_url.yml
+++ b/config/sync/field.storage.config_pages.su_site_url.yml
@@ -1,0 +1,19 @@
+uuid: 2dbfbfa5-e067-4fbb-b5b0-869ccbde1e49
+langcode: en
+status: true
+dependencies:
+  module:
+    - config_pages
+    - link
+id: config_pages.su_site_url
+field_name: su_site_url
+entity_type: config_pages
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/user.role.site_manager.yml
+++ b/config/sync/user.role.site_manager.yml
@@ -23,6 +23,7 @@ permissions:
   - 'dropzone upload files'
   - 'edit any stanford_page content'
   - 'edit own stanford_page content'
+  - 'edit stanford_basic_site_settings config page entity'
   - 'revert stanford_page revisions'
   - 'view own unpublished content'
   - 'view stanford_page revisions'

--- a/modules/stanford_profile_config_overrides/src/Config/ConfigOverrides.php
+++ b/modules/stanford_profile_config_overrides/src/Config/ConfigOverrides.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\stanford_profile_config_overrides\Config;
+
+use Drupal\config_pages\ConfigPagesLoaderServiceInterface;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+
+/**
+ * Configuration overrides for the profile.
+ *
+ * @package Drupal\stanford_profile_config_overrides\Config
+ */
+class ConfigOverrides implements ConfigFactoryOverrideInterface {
+
+  /**
+   * @var \Drupal\config_pages\ConfigPagesLoaderServiceInterface
+   */
+  protected $configPages;
+
+  public function __construct(ConfigPagesLoaderServiceInterface $config_pages) {
+    $this->configPages = $config_pages;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function loadOverrides($names) {
+    if (in_array('domain_301_redirect.settings', $names)) {
+      $site_url = $this->configPages->getValue('stanford_basic_site_settings', 'su_site_url', 0, 'uri');
+
+      return [
+        'domain_301_redirect.settings' => [
+          'enabled' => !empty($site_url),
+          'domain' => str_replace('http://', 'https://', $site_url),
+        ],
+      ];
+    }
+    return [];
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getCacheSuffix() {
+    return 'ConfigOverrides';
+  }
+
+}

--- a/modules/stanford_profile_config_overrides/stanford_profile_config_overrides.info.yml
+++ b/modules/stanford_profile_config_overrides/stanford_profile_config_overrides.info.yml
@@ -1,0 +1,8 @@
+name: "Stanford Profile Config Overrides"
+description: Using config_pages module, override some config settings.
+version: 8.x-1.0-dev
+core_version_requirement: ^8 || ^9
+type: module
+project: Stanford
+dependencies:
+  - config_pages:config_pages

--- a/modules/stanford_profile_config_overrides/stanford_profile_config_overrides.services.yml
+++ b/modules/stanford_profile_config_overrides/stanford_profile_config_overrides.services.yml
@@ -1,0 +1,6 @@
+services:
+  stanford_profile_config_overrides.config_overrider:
+    class: Drupal\stanford_profile_config_overrides\Config\ConfigOverrides
+    arguments: ['@config_pages.loader']
+    tags:
+      - {name: config.factory.override}

--- a/modules/stanford_profile_config_overrides/tests/src/Unit/Config/ConfigOverridesTest.php
+++ b/modules/stanford_profile_config_overrides/tests/src/Unit/Config/ConfigOverridesTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\Tests\stanford_profile_config_overrides\Unit\Config;
+
+use Drupal\config_pages\ConfigPagesLoaderServiceInterface;
+use Drupal\stanford_profile_config_overrides\Config\ConfigOverrides;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Class ConfigOverridesTest
+ *
+ * @coversDefaultClass \Drupal\stanford_profile_config_overrides\Config\ConfigOverrides
+ * @group stanford_profile
+ */
+class ConfigOverridesTest extends UnitTestCase {
+
+  /**
+   * Service object to test.
+   *
+   * @var \Drupal\stanford_profile_config_overrides\Config\ConfigOverrides
+   */
+  protected $configOverrides;
+
+  /**
+   * Keyed array of values the config pages service will return.
+   *
+   * @var array
+   */
+  protected $configPagesValues = [];
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $mock_config_pages = $this->createMock(ConfigPagesLoaderServiceInterface::class);
+    $mock_config_pages->method('getValue')
+      ->will($this->returnCallback([$this, 'getConfigPagesValueCallback']));
+    $this->configOverrides = new ConfigOverrides($mock_config_pages);
+  }
+
+  /**
+   * Test the methods that dont do much.
+   */
+  public function testSimpleMethods() {
+    $this->assertEmpty($this->configOverrides->createConfigObject('', ''));
+    $this->assertEquals('ConfigOverrides', $this->configOverrides->getCacheSuffix());
+    $this->assertInstanceOf('Drupal\Core\Cache\CacheableMetadata', $this->configOverrides->getCacheableMetadata(''));
+  }
+
+  /**
+   * Test Domain 301 redirect config overrides.
+   */
+  public function testDomain301Redirect() {
+    $this->assertEmpty($this->configOverrides->loadOverrides([]));
+    $expected_array = [
+      'domain_301_redirect.settings' => [
+        'enabled' => FALSE,
+        'domain' => '',
+      ],
+    ];
+    $this->assertArrayEquals($expected_array, $this->configOverrides->loadOverrides(['domain_301_redirect.settings']));
+
+    $this->configPagesValues['stanford_basic_site_settings'] = ['su_site_url' => 'http://foo.bar'];
+    $expected_array = [
+      'domain_301_redirect.settings' => [
+        'enabled' => TRUE,
+        'domain' => 'https://foo.bar',
+      ],
+    ];
+    $this->assertArrayEquals($expected_array, $this->configOverrides->loadOverrides(['domain_301_redirect.settings']));
+  }
+
+  /**
+   * Mock config pages service value callback.
+   */
+  public function getConfigPagesValueCallback($type, $field_name) {
+    if (isset($this->configPagesValues[$type])) {
+      return $this->configPagesValues[$type][$field_name];
+    }
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Use config_pages module to create a page for users to set values for the site
- set up domain 301 redirect to redirect all traffic to a canonical url.

# Need Review By (Date)
- 9/25

# Urgency
- medium

# Steps to Test
1. `composer require su-sws/stanford_profile:dev-D8CORE-322-domain-redirect`
1. `drush cim -y`
1. navigate to `/admin/config/system/basic-site-settings`
1. enter a url. anything URL that is different from your current will work & save
1. view the site as anonymous
1. validate it redirects you off to the domain you configured

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
