### PR TITLE
D8CORE-329 Use bigpipe and quicklink

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,9 @@
         "su-sws/stanford_ssp": "dev-8.x-1.x",
         "su-sws/stanford_text_editor": "dev-8.x-1.x",
         "drupal/domain_301_redirect": "^1.0-alpha0",
-        "drupal/config_pages": "^2.6"
+        "drupal/config_pages": "^2.6",
+        "drupal/quicklink": "^1.2",
+        "drupal/big_pipe_sessionless": "^1.2"
     },
     "extra": {
         "patches": {

--- a/config/sync/config_split.config_split.dev.yml
+++ b/config/sync/config_split.config_split.dev.yml
@@ -15,7 +15,10 @@ module:
   acquia_purge: 0
   purge: 0
   purge_drush: 0
-  purge_ui: 0
+  purge_processor_cron: 0
+  purge_processor_lateruntime: 0
+  purge_queuer_coretags: 0
+  purge_tokens: 0
   update: 0
 theme: {  }
 blacklist: {  }

--- a/config/sync/config_split.config_split.prod.yml
+++ b/config/sync/config_split.config_split.prod.yml
@@ -15,7 +15,10 @@ module:
   acquia_purge: 0
   purge: 0
   purge_drush: 0
-  purge_ui: 0
+  purge_processor_cron: 0
+  purge_processor_lateruntime: 0
+  purge_queuer_coretags: 0
+  purge_tokens: 0
 theme: {  }
 blacklist: {  }
 graylist: {  }

--- a/config/sync/config_split.config_split.stage.yml
+++ b/config/sync/config_split.config_split.stage.yml
@@ -15,7 +15,10 @@ module:
   acquia_purge: 0
   purge: 0
   purge_drush: 0
-  purge_ui: 0
+  purge_processor_cron: 0
+  purge_processor_lateruntime: 0
+  purge_queuer_coretags: 0
+  purge_tokens: 0
 theme: {  }
 blacklist: {  }
 graylist: {  }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -5,6 +5,8 @@ module:
   allowed_formats: 0
   anchor_link: 0
   better_normalizers: 0
+  big_pipe: 0
+  big_pipe_sessionless: 0
   block: 0
   block_content: 0
   breakpoint: 0
@@ -74,6 +76,7 @@ module:
   options: 0
   page_cache: 0
   path: 0
+  quicklink: 0
   redirect: 0
   responsive_image: 0
   search: 0

--- a/config/sync/quicklink.settings.yml
+++ b/config/sync/quicklink.settings.yml
@@ -1,0 +1,15 @@
+no_load_when_authenticated: true
+no_load_when_session: true
+no_load_content_types: {  }
+ignore_admin_paths: true
+ignore_hashes: true
+ignore_ajax_links: true
+ignore_file_ext: true
+load_polyfill: true
+selector: ''
+url_patterns_to_ignore: "saml_login\r\nuser/*"
+prefetch_only_paths: ''
+allowed_domains: ''
+enable_debug_mode: false
+_core:
+  default_config_hash: P-Tl0WcQCXKJey6r3MO_gbsRi-tGXdnjdW_G3NYITKE


### PR DESCRIPTION
# READY FOR REVIEW
See https://github.com/SU-SWS/acsf-cardinalsites/pull/23

# Summary
- Use sessionless bigpipe - not 100% sure how much improvement this does but it doesnt hurt.
- Use quicklink module. 
   - This fetches other links into the browser for anonymous user during network idle time.
   - This does 2 things: prime varnish caches for those pages & prefetches for faster load times for the user
   - The traffic only occurs during idle time and each link appears to be only about 5KB of data (less than the favicon which is 34KB)
   - Quicklink doesnt appear to operate when on "slow 3g" speeds
- Fixed cache invalidation by enabling the required modules.

# Need Review By (Date)
- asap

# Urgency
- medium

# Steps to Test
1. review https://d8core329-dev.sites.stanford.edu/
1. edit/create a page
1. view that page logged out and ensure your changes are there
1. edit the page agiain, view logged out and ensure the changes are there. (this sometimes takes a few seconds)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
