### PR TITLE
D8CORE-386 Added google analytics config override

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
         "drupal/domain_301_redirect": "^1.0-alpha0",
         "drupal/ds": "~3.3",
         "drupal/environment_indicator": "^3.0",
+        "drupal/field_validation": "^1.0-alpha",
         "drupal/file_mdm": "~1.1",
         "drupal/google_analytics": "~2.1",
         "drupal/honeypot": "^1.27",

--- a/config/sync/config_pages.type.stanford_basic_site_settings.yml
+++ b/config/sync/config_pages.type.stanford_basic_site_settings.yml
@@ -30,6 +30,12 @@ third_party_settings:
       column: value
       config_name: system.site
       config_item: mail
+    ba5fafac-2f0e-4e9f-a27a-f3dfb9d8893e:
+      field: su_google_analytics
+      delta: 0
+      column: value
+      config_name: google_analytics.settings
+      config_item: account
 id: stanford_basic_site_settings
 label: 'Site Settings'
 context:

--- a/config/sync/core.entity_form_display.config_pages.stanford_basic_site_settings.default.yml
+++ b/config/sync/core.entity_form_display.config_pages.stanford_basic_site_settings.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - config_pages.type.stanford_basic_site_settings
+    - field.field.config_pages.stanford_basic_site_settings.su_google_analytics
     - field.field.config_pages.stanford_basic_site_settings.su_site_email
     - field.field.config_pages.stanford_basic_site_settings.su_site_name
     - field.field.config_pages.stanford_basic_site_settings.su_site_url
@@ -14,6 +15,14 @@ targetEntityType: config_pages
 bundle: stanford_basic_site_settings
 mode: default
 content:
+  su_google_analytics:
+    weight: 3
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   su_site_email:
     weight: 1
     settings:

--- a/config/sync/core.entity_view_display.config_pages.stanford_basic_site_settings.default.yml
+++ b/config/sync/core.entity_view_display.config_pages.stanford_basic_site_settings.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - config_pages.type.stanford_basic_site_settings
+    - field.field.config_pages.stanford_basic_site_settings.su_google_analytics
     - field.field.config_pages.stanford_basic_site_settings.su_site_email
     - field.field.config_pages.stanford_basic_site_settings.su_site_name
     - field.field.config_pages.stanford_basic_site_settings.su_site_url
@@ -14,6 +15,14 @@ targetEntityType: config_pages
 bundle: stanford_basic_site_settings
 mode: default
 content:
+  su_google_analytics:
+    weight: 3
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   su_site_email:
     weight: 2
     label: above

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -40,12 +40,14 @@ module:
   fakeobjects: 0
   field: 0
   field_ui: 0
+  field_validation: 0
   file: 0
   file_mdm: 0
   file_mdm_exif: 0
   file_mdm_font: 0
   filter: 0
   focal_point: 0
+  google_analytics: 0
   hal: 0
   help: 0
   image: 0

--- a/config/sync/field.field.config_pages.stanford_basic_site_settings.su_google_analytics.yml
+++ b/config/sync/field.field.config_pages.stanford_basic_site_settings.su_google_analytics.yml
@@ -1,0 +1,19 @@
+uuid: cb768a3d-5380-4c65-9188-7d67c4c7b74c
+langcode: en
+status: true
+dependencies:
+  config:
+    - config_pages.type.stanford_basic_site_settings
+    - field.storage.config_pages.su_google_analytics
+id: config_pages.stanford_basic_site_settings.su_google_analytics
+field_name: su_google_analytics
+entity_type: config_pages
+bundle: stanford_basic_site_settings
+label: 'Google Analytics Account'
+description: 'This ID is unique to each site you want to track separately, and is in the form of UA-xxxxxxx-yy. To get a Web Property ID, <a href="https://marketingplatform.google.com/about/analytics/">register your site with Google Analytics</a>, or if you already have registered your site, go to your Google Analytics Settings page to see the ID next to every site profile. Find more information in the documentation.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.config_pages.su_google_analytics.yml
+++ b/config/sync/field.storage.config_pages.su_google_analytics.yml
@@ -1,0 +1,21 @@
+uuid: 064e0b29-4e11-48d7-9373-23728d0c88c9
+langcode: en
+status: true
+dependencies:
+  module:
+    - config_pages
+id: config_pages.su_google_analytics
+field_name: su_google_analytics
+entity_type: config_pages
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field_validation.rule_set.config_pages_stanford_basic_site_settings.yml
+++ b/config/sync/field_validation.rule_set.config_pages_stanford_basic_site_settings.yml
@@ -1,0 +1,19 @@
+uuid: 405551a8-32cb-4fb8-b4b3-5a457e79c1d6
+langcode: en
+status: true
+dependencies: {  }
+name: config_pages_stanford_basic_site_settings
+label: 'config_pages stanford_basic_site_settings validation'
+entity_type: config_pages
+bundle: stanford_basic_site_settings
+field_validation_rules:
+  3f911d4d-a4fa-497c-a7e3-ee024e0005c7:
+    uuid: 3f911d4d-a4fa-497c-a7e3-ee024e0005c7
+    id: regex_field_validation_rule
+    title: 'Google Analytics'
+    weight: 1
+    field_name: su_google_analytics
+    column: value
+    error_message: 'A valid Google Analytics Web Property ID is case sensitive and formatted like UA-xxxxxxx-yy.'
+    data:
+      setting: /^UA-\d+-\d+$/

--- a/config/sync/google_analytics.settings.yml
+++ b/config/sync/google_analytics.settings.yml
@@ -1,0 +1,42 @@
+account: ''
+premium: false
+domain_mode: 0
+cross_domains: ''
+visibility:
+  request_path_mode: 0
+  request_path_pages: "/admin\r\n/admin/*\r\n/batch\r\n/node/add*\r\n/node/*/*\r\n/user/*/*"
+  user_role_mode: 1
+  user_role_roles:
+    contributor: contributor
+    site_manager: site_manager
+    site_editor: site_editor
+    site_builder: site_builder
+    site_developer: site_developer
+  user_account_mode: 0
+track:
+  outbound: true
+  mailto: true
+  files: true
+  files_extensions: '7z|aac|arc|arj|asf|asx|avi|bin|csv|doc(x|m)?|dot(x|m)?|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt(x|m)?|pot(x|m)?|pps(x|m)?|ppam|sld(x|m)?|thmx|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls(x|m|b)?|xlt(x|m)|xlam|xml|z|zip'
+  colorbox: true
+  linkid: false
+  urlfragments: false
+  userid: false
+  messages: {  }
+  site_search: false
+  adsense: false
+  displayfeatures: false
+privacy:
+  anonymizeip: true
+custom:
+  dimension: {  }
+  metric: {  }
+codesnippet:
+  create: {  }
+  before: ''
+  after: ''
+translation_set: false
+cache: false
+debug: false
+_core:
+  default_config_hash: SMk3vOyh4KT6rXnqkDcNQ51YGpJzRV5hyig5SSIfU6U

--- a/tests/behat/features/SystemSiteConfig.feature
+++ b/tests/behat/features/SystemSiteConfig.feature
@@ -15,6 +15,7 @@ Feature: System Site Config
     Then I should see the error message "1 error has been found: Google Analytics Account"
     Then I fill in "Google Analytics Account" with "UA-123456-12"
     And I press "Save"
+    And the cache has been cleared
     Then I am an anonymous user
     And I am on the homepage
     And I should see "Foo Bar Site"

--- a/tests/behat/features/SystemSiteConfig.feature
+++ b/tests/behat/features/SystemSiteConfig.feature
@@ -10,13 +10,18 @@ Feature: System Site Config
     Then I should not see "Foo Bar Site"
     And I am on "/admin/config/system/basic-site-settings"
     Then I fill in "Site Name" with "Foo Bar Site"
-    And I fill in "Google Analytics Account" with "UA-123456-12"
+    And I fill in "Google Analytics Account" with "abcdefg"
     And I press "Save"
-    Then I am on the homepage
+    Then I should see the error message "1 error has been found: Google Analytics Account"
+    Then I fill in "Google Analytics Account" with "UA-123456-12"
+    And I press "Save"
+    Then I am an anonymous user
+    And I am on the homepage
     And I should see "Foo Bar Site"
     And I should see "UA-123456-12"
-    Then I am on "/admin/config/system/basic-site-settings"
-    And I fill in "Site Name" with ""
+    Then I am logged in as a user with the "site_manager" role
+    And I am on "/admin/config/system/basic-site-settings"
+    Then I fill in "Site Name" with ""
     And I fill in "Google Analytics Account" with ""
     And I press "Save"
     Then I am on the homepage

--- a/tests/behat/features/SystemSiteConfig.feature
+++ b/tests/behat/features/SystemSiteConfig.feature
@@ -10,11 +10,14 @@ Feature: System Site Config
     Then I should not see "Foo Bar Site"
     And I am on "/admin/config/system/basic-site-settings"
     Then I fill in "Site Name" with "Foo Bar Site"
+    And I fill in "Google Analytics Account" with "UA-123456-12"
     And I press "Save"
     Then I am on the homepage
     And I should see "Foo Bar Site"
+    And I should see "UA-123456-12"
     Then I am on "/admin/config/system/basic-site-settings"
     And I fill in "Site Name" with ""
+    And I fill in "Google Analytics Account" with ""
     And I press "Save"
     Then I am on the homepage
     And I should not see "Foo Bar Site"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added google analytics config pages and override.

# Need Review By (Date)
- 11/6

# Urgency
- low

# Steps to Test
1. checkout this branch
1. config import
1. cache clear
1. go to `/admin/config/system/basic-site-settings` and enter some garbage text into the google analytics field
1. validate an error appears when you save
1. enter a valid format GA code
1. on the homepage as anonymous view the source and validate the GA code has been added at the top.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
