### PR TITLE
8.1.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Stanford Profile
 
+8.x-1.0-alpha2
+--------------------------------------------------------------------------------  
+_Release Date: 2019-11-13_
+
+- Require new modules: field_validation, layout_builder_restrictions
+- Updated version requirement for pathauto
+- New basic site settings for google google_analytics
+- Changed default layouts for stanford_page to new jumpstart_ui dynamic layouts
+- Enabled modules: field_validation, google_analytics, layout_builder_restrictions, path_alias
+- Updated primary and secondary navigation settings.
+
 8.x-1.0-alpha1
 --------------------------------------------------------------------------------  
 _Release Date: 2019-10-30_

--- a/modules/stanford_paragraph_card/stanford_paragraph_card.info.yml
+++ b/modules/stanford_paragraph_card/stanford_paragraph_card.info.yml
@@ -1,6 +1,6 @@
 name: "Stanford Paragraph Card"
 description: Adds helpers and modifications to the card paragraph type.
-version: 8.x-1.0-dev
+version: 8.x-1.0-alpha2
 core_version_requirement: ^8 || ^9
 type: module
 project: Stanford

--- a/modules/stanford_profile_config_overrides/stanford_profile_config_overrides.info.yml
+++ b/modules/stanford_profile_config_overrides/stanford_profile_config_overrides.info.yml
@@ -1,6 +1,0 @@
-name: "Stanford Profile Config Overrides"
-description: This can be removed after sites have disabled it.
-version: 8.x-1.0-dev
-core_version_requirement: ^8 || ^9
-type: module
-project: Stanford

--- a/modules/stanford_profile_install/stanford_profile_install.info.yml
+++ b/modules/stanford_profile_install/stanford_profile_install.info.yml
@@ -1,6 +1,6 @@
 name: "Stanford Profile Install"
 description: A work around for the missing install hook on profiles with config sync
-version: 8.x-1.0-dev
+version: 8.x-1.0-alpha2
 core_version_requirement: ^8 || ^9
 type: module
 project: Stanford

--- a/modules/stanford_profile_styles/stanford_profile_styles.info.yml
+++ b/modules/stanford_profile_styles/stanford_profile_styles.info.yml
@@ -1,6 +1,6 @@
 name: "Stanford Profile Styles"
 description: A module for theming
-version: 8.x-1.0-dev
+version: 8.x-1.0-alpha2
 core_version_requirement: ^8 || ^9
 type: module
 project: Stanford

--- a/stanford_profile.info.yml
+++ b/stanford_profile.info.yml
@@ -1,6 +1,6 @@
 name: Stanford Profile
 description: Jumpstart Website Profile
-version: 8.x-1.0-dev
+version: 8.x-1.0-alpha2
 type: profile
 project: Jumpstart
 core: 8.x


### PR DESCRIPTION
Release notes:

```
# What
- Alpha 2 Release
- Require new modules: field_validation, layout_builder_restrictions
- Updated version requirement for pathauto
- New basic site settings for google google_analytics
- Changed default layouts for stanford_page to new jumpstart_ui dynamic layouts
- Enabled modules: field_validation, google_analytics, layout_builder_restrictions, path_alias
- Updated primary and secondary navigation settings.

# So what
- New features and functionality.
- New versions

# Now what
- Deploy and run both database updates and config import

# New Requirements and Risks
- New version requirements
- Sensitivity around path and path_alias modules

# Diff
- https://github.com/SU-SWS/stanford_profile/compare/8.1.0-alpha.1...8.1.0-alpha.2
```