### PR TITLE
D8CORE-826 layout library perms

### DIFF
--- a/config/sync/user.role.site_builder.yml
+++ b/config/sync/user.role.site_builder.yml
@@ -73,6 +73,7 @@ permissions:
   - 'bypass node access'
   - 'cancel account'
   - 'change own username'
+  - 'choose layout for node stanford_page'
   - 'configure all stanford_page node layout overrides'
   - 'configure any layout'
   - 'configure editable stanford_page node layout overrides'

--- a/config/sync/user.role.site_developer.yml
+++ b/config/sync/user.role.site_developer.yml
@@ -98,6 +98,7 @@ permissions:
   - 'bypass node access'
   - 'cancel account'
   - 'change own username'
+  - 'choose layout for node stanford_page'
   - 'configure all stanford_page node layout overrides'
   - 'configure any layout'
   - 'configure editable stanford_page node layout overrides'

--- a/config/sync/user.role.site_manager.yml
+++ b/config/sync/user.role.site_manager.yml
@@ -35,6 +35,7 @@ permissions:
   - 'assign stanford_student role'
   - 'cancel account'
   - 'change own username'
+  - 'choose layout for node stanford_page'
   - 'configure editable stanford_page node layout overrides'
   - 'create and edit custom blocks'
   - 'create file media'

--- a/src/StanfordProfilePermissions.php
+++ b/src/StanfordProfilePermissions.php
@@ -42,6 +42,9 @@ class StanfordProfilePermissions implements ContainerInjectionInterface {
 
   /**
    * Returns an array of layout_builder per node type permissions.
+   *
+   * @return array
+   *   A key => value array of permissions for changing layout on specific node types.
    */
   public function permissions() {
     $permissions = [];

--- a/src/StanfordProfilePermissions.php
+++ b/src/StanfordProfilePermissions.php
@@ -40,6 +40,9 @@ class StanfordProfilePermissions implements ContainerInjectionInterface {
     $this->entityTypeManager = $entity_manager;
   }
 
+  /**
+   * Returns an array of layout_builder per node type permissions.
+   */
   public function permissions() {
     $permissions = [];
     $display_storage = $this->entityTypeManager->getStorage('entity_view_display');

--- a/src/StanfordProfilePermissions.php
+++ b/src/StanfordProfilePermissions.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\stanford_profile;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class StanfordProfilePermissions
+ *
+ * @package Drupal\stanford_profile
+ */
+class StanfordProfilePermissions implements ContainerInjectionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * Entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static($container->get('entity_type.manager'));
+  }
+
+  /**
+   * StanfordProfilePermissions constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_manager
+   *   Entity type manager service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_manager) {
+    $this->entityTypeManager = $entity_manager;
+  }
+
+  public function permissions() {
+    $permissions = [];
+    $display_storage = $this->entityTypeManager->getStorage('entity_view_display');
+
+    /** @var \Drupal\Core\Entity\Display\EntityDisplayInterface $display */
+    foreach ($display_storage->loadMultiple() as $display) {
+      if ($display->getThirdPartySetting('layout_library', 'enable')) {
+        $entity_type = $display->getTargetEntityTypeId();
+        $entity_bundle = $display->getTargetBundle();
+
+        $permissions["choose layout for $entity_type $entity_bundle"] = [
+          'title' => $this->t('Can choose the layout from the layout library on %entity_type: %entity_bundle', [
+            '%entity_type' => $entity_type,
+            '%entity_bundle' => $entity_bundle,
+          ]),
+        ];
+      }
+    }
+
+    return $permissions;
+  }
+
+}

--- a/stanford_profile.permissions.yml
+++ b/stanford_profile.permissions.yml
@@ -1,0 +1,2 @@
+permission_callbacks:
+  - Drupal\stanford_profile\StanfordProfilePermissions::permissions

--- a/stanford_profile.profile
+++ b/stanford_profile.profile
@@ -6,6 +6,10 @@
  */
 
 use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Access\AccessResult;
 
 /**
  * Implements hook_ENTITY_TYPE_insert().
@@ -16,4 +20,21 @@ function stanford_profile_menu_link_content_presave(MenuLinkContent $entity) {
   if ($entity->isNew()) {
     $entity->set('expanded', TRUE);
   }
+}
+
+/**
+ * Implements hook_field_widget_form_alter().
+ */
+/**
+ * Implements hook_entity_field_access().
+ */
+function stanford_profile_entity_field_access($operation, FieldDefinitionInterface $field_definition, AccountInterface $account, FieldItemListInterface $items = NULL) {
+  if ($field_definition->getName() == 'layout_selection') {
+    $entity_type = $field_definition->getTargetEntityTypeId();
+    $bundle = $field_definition->getTargetBundle();
+    if (!$account->hasPermission("choose layout for $entity_type $bundle")) {
+      return AccessResult::forbidden();
+    }
+  }
+  return AccessResult::neutral();
 }

--- a/stanford_profile.profile
+++ b/stanford_profile.profile
@@ -23,13 +23,10 @@ function stanford_profile_menu_link_content_presave(MenuLinkContent $entity) {
 }
 
 /**
- * Implements hook_field_widget_form_alter().
- */
-/**
  * Implements hook_entity_field_access().
  */
 function stanford_profile_entity_field_access($operation, FieldDefinitionInterface $field_definition, AccountInterface $account, FieldItemListInterface $items = NULL) {
-  if ($field_definition->getName() == 'layout_selection') {
+  if ($field_definition->getType() == 'entity_reference' && $field_definition->getSetting('handler') == 'layout_library') {
     $entity_type = $field_definition->getTargetEntityTypeId();
     $bundle = $field_definition->getTargetBundle();
     if (!$account->hasPermission("choose layout for $entity_type $bundle")) {

--- a/tests/behat/features/Users/Roles.feature
+++ b/tests/behat/features/Users/Roles.feature
@@ -18,23 +18,33 @@ Feature: Roles
     Given I am logged in as a user with the "Contributor" role
     And I am on "admin/content"
     Then I should get a "200" HTTP response
+    And I am on "/node/add/stanford_page"
+    And I should not see "Layout"
 
   Scenario: Check I can log in as the Site Editor role
     Given I am logged in as a user with the "Site Editor" role
     And I am on "admin/content"
     Then I should get a "200" HTTP response
+    And I am on "/node/add/stanford_page"
+    And I should not see "Layout"
 
   Scenario: Check I can log in as the Site Manager role
     Given I am logged in as a user with the "Site Manager" role
     And I am on "admin/content"
     Then I should get a "200" HTTP response
+    And I am on "/node/add/stanford_page"
+    And I should see "Layout"
 
   Scenario: Check I can log in as the Site Builder role
     Given I am logged in as a user with the "Site Builder" role
     And I am on "admin/content"
     Then I should get a "200" HTTP response
+    And I am on "/node/add/stanford_page"
+    And I should see "Layout"
 
   Scenario: Check I can log in as the Site Developer role
     Given I am logged in as a user with the "Site Developer" role
     And I am on "admin/content"
     Then I should get a "200" HTTP response
+    And I am on "/node/add/stanford_page"
+    And I should see "Layout"

--- a/tests/src/Kernel/StanfordProfilePermissionsTest.php
+++ b/tests/src/Kernel/StanfordProfilePermissionsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\Tests\stanford_profile\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\layout_builder\Entity\LayoutBuilderEntityViewDisplay;
+use Drupal\node\Entity\NodeType;
+use Drupal\stanford_profile\StanfordProfilePermissions;
+
+/**
+ * Class StanfordProfilePermissionsTest.
+ *
+ * @group stanford_profile
+ * @coversDefaultClass \Drupal\stanford_profile\StanfordProfilePermissions
+ */
+class StanfordProfilePermissionsTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'node',
+    'layout_discovery',
+    'layout_builder',
+    'layout_library',
+    'path_alias',
+    'user',
+    'field',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->installSchema('system', ['key_value_expire']);
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('entity_view_display');
+
+    NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
+    /** @var \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display */
+    $display = LayoutBuilderEntityViewDisplay::create([
+      'targetEntityType' => 'node',
+      'bundle' => 'article',
+      'mode' => 'default',
+      'status' => TRUE,
+    ])
+      ->enableLayoutBuilder()
+      ->setOverridable();
+    $display->setThirdPartySetting('layout_library', 'enable', TRUE);
+    $display->save();
+  }
+
+  /**
+   * Test permissions are returned.
+   */
+  public function testPermissions() {
+    $permission_class = StanfordProfilePermissions::create(\Drupal::getContainer());
+    $permissions = $permission_class->permissions();
+    $this->assertCount(1, $permissions);
+    $this->assertArrayHasKey('choose layout for node article', $permissions);
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added permissions for roles to choose a layout from the layout library

# Need Review By (Date)
- 11/26

# Urgency
- medium

# Steps to Test
1. checkout this branch
1. clear cache & `drush cim`
1. verify contributor users dont see the layout choices on the basic page but site managers do see the select list.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
