### PR TITLE
D8CORE-875: Remove env indicator permissions from roles

### DIFF
--- a/config/sync/user.role.site_builder.yml
+++ b/config/sync/user.role.site_builder.yml
@@ -12,7 +12,6 @@ permissions:
   - 'access content overview'
   - 'access contextual links'
   - 'access entity usage statistics'
-  - 'access environment indicator'
   - 'access file_browser entity browser pages'
   - 'access files overview'
   - 'access image_browser entity browser pages'

--- a/config/sync/user.role.site_editor.yml
+++ b/config/sync/user.role.site_editor.yml
@@ -10,7 +10,6 @@ permissions:
   - 'access administration pages'
   - 'access content overview'
   - 'access contextual links'
-  - 'access environment indicator'
   - 'access file_browser entity browser pages'
   - 'access image_browser entity browser pages'
   - 'access media overview'

--- a/config/sync/user.role.site_manager.yml
+++ b/config/sync/user.role.site_manager.yml
@@ -10,7 +10,6 @@ permissions:
   - 'access administration pages'
   - 'access content overview'
   - 'access contextual links'
-  - 'access environment indicator'
   - 'access file_browser entity browser pages'
   - 'access image_browser entity browser pages'
   - 'access media overview'


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Non-administrator roles (Site Manager, Site Editor, Site Builder) have the "See environment indicator" permission. This is probably not useful for non-SWS users. (We don't want to give end-users the impression that they have dev/test environments.)

# Needed By (Date)
- ?

# Urgency
- Low

# Steps to Test

1. Check out this branch
2. Do a build
3. Log in as each of the roles without environment detection
4. Confirm they don't have it.

# Affected Projects or Products
- Launch

# Associated Issues and/or People
- D8CORE-875
- @jbickar 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)