### PR TITLE
D8CORE-580: HSTS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,6 +84,7 @@
         "drupal/redirect": "~1.0-beta1",
         "drupal/role_delegation": "^1.0@beta",
         "drupal/rules": "^3.0@alpha",
+        "drupal/seckit": "^1.0@alpha",
         "drupal/ui_patterns": "~1.0",
         "drupal/view_unpublished": "^1.0@alpha",
         "drupal/views_block_filter_block": "^1.0@beta",

--- a/config/sync/config_split.config_split.dev.yml
+++ b/config/sync/config_split.config_split.dev.yml
@@ -19,6 +19,7 @@ module:
   purge_processor_lateruntime: 0
   purge_queuer_coretags: 0
   purge_tokens: 0
+  seckit: 0
   update: 0
 theme: {  }
 blacklist: {  }

--- a/config/sync/config_split.config_split.prod.yml
+++ b/config/sync/config_split.config_split.prod.yml
@@ -19,6 +19,7 @@ module:
   purge_processor_lateruntime: 0
   purge_queuer_coretags: 0
   purge_tokens: 0
+  seckit: 0
 theme: {  }
 blacklist: {  }
 graylist: {  }

--- a/config/sync/config_split.config_split.stage.yml
+++ b/config/sync/config_split.config_split.stage.yml
@@ -19,6 +19,7 @@ module:
   purge_processor_lateruntime: 0
   purge_queuer_coretags: 0
   purge_tokens: 0
+  seckit: 0
 theme: {  }
 blacklist: {  }
 graylist: {  }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -83,7 +83,6 @@ module:
   responsive_image: 0
   role_delegation: 0
   search: 0
-  seckit: 0
   serialization: 0
   shortcut: 0
   simplesamlphp_auth: 0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -83,6 +83,7 @@ module:
   responsive_image: 0
   role_delegation: 0
   search: 0
+  seckit: 0
   serialization: 0
   shortcut: 0
   simplesamlphp_auth: 0

--- a/stanford_profile.info.yml
+++ b/stanford_profile.info.yml
@@ -102,6 +102,7 @@ install:
   - pathauto:pathauto
   - redirect:redirect
   - role_delegation:role_delegation
+  - seckit: seckit
   - simplesamlphp_auth:simplesamlphp_auth
   - stanford_date_formats:stanford_date_formats
   - stanford_fields:stanford_fields

--- a/stanford_profile.info.yml
+++ b/stanford_profile.info.yml
@@ -102,7 +102,7 @@ install:
   - pathauto:pathauto
   - redirect:redirect
   - role_delegation:role_delegation
-  - seckit: seckit
+  - seckit:seckit
   - simplesamlphp_auth:simplesamlphp_auth
   - stanford_date_formats:stanford_date_formats
   - stanford_fields:stanford_fields


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Enable `seckit` at install time

# Needed By (Date)
- January 13, 2020

# Criticality
- How critical is this PR on a 1-10 scale? 7
- ISO wants it

# Steps to Test

1. See https://github.com/SU-SWS/acsf-cardinalsites/pull/48

# Affected Projects or Products
- D8 Core

# Associated Issues and/or People
- JIRA ticket: D8CORE-580
- Other PRs: https://github.com/SU-SWS/acsf-cardinalsites/pull/48

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)