### PR TITLE
D8CORE-1013 Allow classes on header elements

### DIFF
--- a/config/sync/crop.type.focal_point.yml
+++ b/config/sync/crop.type.focal_point.yml
@@ -4,8 +4,8 @@ status: true
 dependencies: {  }
 _core:
   default_config_hash: flCi9IdafdLXlJqvoHguutUOiC05-aynK4niYN4YZ3o
-label: 'Focal point'
 id: focal_point
+label: 'Focal point'
 description: 'Crop type used by Focal point module.'
 aspect_ratio: ''
 soft_limit_width: null

--- a/config/sync/filter.format.stanford_html.yml
+++ b/config/sync/filter.format.stanford_html.yml
@@ -52,7 +52,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id class> <h3 id> <h4 id> <h5 id> <h6 id> <a class href hreflang data-entity-substitution data-entity-type data-entity-uuid title name> <drupal-entity data-entity-type data-entity-uuid data-entity-embed-display data-entity-embed-display-settings data-align data-caption data-embed-button data-langcode alt title> <div class> <p class> <table> <caption> <tbody class> <thead> <tfoot> <th scope class> <td class> <tr> <sup> <sub> <i class> <hr> <drupal-media data-entity-type data-entity-uuid data-align data-caption data-* alt>'
+      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <h6 id class> <a class href hreflang data-entity-substitution data-entity-type data-entity-uuid title name> <div class> <p class> <table> <caption> <tbody class> <thead> <tfoot> <th scope class> <td class> <tr> <sup> <sub> <i class> <hr> <drupal-media data-entity-type data-entity-uuid data-align data-caption data-* alt>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_htmlcorrector:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Allow classes on header elements to allow the user to center them.
- also see https://github.com/SU-SWS/stanford_text_editor/pull/12

# Need Review By (Date)
- 1/29

# Urgency
- low

# Steps to Test
1. checkout branch
1. drush cim
1. create a page with a wysiwyg
1. add some text and make it an `h3`
1. validate you can center that text.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
