### PR TITLE
D8CORE-1200 Prevent home page from being deleted

### DIFF
--- a/stanford_profile.profile
+++ b/stanford_profile.profile
@@ -11,6 +11,7 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_install_tasks().
@@ -85,4 +86,21 @@ function stanford_profile_contextual_links_alter(array &$links, $group, array $r
     unset($links['paragraphs_edit.delete_form']);
     unset($links['paragraphs_edit.clone_form']);
   }
+}
+
+/**
+ * Implements hook_node_access().
+ */
+function stanford_profile_node_access(NodeInterface $node, $op, AccountInterface $account) {
+  if ($op == 'delete') {
+    $site_config = \Drupal::config('system.site');
+    $node_urls = [$node->toUrl()->toString(), "/node/{$node->id()}"];
+
+    // If the node is configured to be the home page, 404, or 403, prevent the
+    // user from deleting.
+    if (array_intersect($node_urls, $site_config->get('page'))) {
+      return AccessResult::forbidden();
+    }
+  }
+  return AccessResult::neutral();
 }

--- a/stanford_profile.profile
+++ b/stanford_profile.profile
@@ -97,7 +97,8 @@ function stanford_profile_node_access(NodeInterface $node, $op, AccountInterface
     $node_urls = [$node->toUrl()->toString(), "/node/{$node->id()}"];
 
     // If the node is configured to be the home page, 404, or 403, prevent the
-    // user from deleting.
+    // user from deleting. Unfortunately this only works for roles without the
+    // "Bypass content access control" permission.
     if (array_intersect($node_urls, $site_config->get('page'))) {
       return AccessResult::forbidden();
     }

--- a/tests/behat/features/Users/Roles.feature
+++ b/tests/behat/features/Users/Roles.feature
@@ -20,6 +20,8 @@ Feature: Roles
     Then I should get a "200" HTTP response
     And I am on "/node/add/stanford_page"
     And I should not see "Layout"
+    Then I am on "/node/1/delete"
+    And I should get a 403 HTTP response
 
   Scenario: Check I can log in as the Site Editor role
     Given I am logged in as a user with the "Site Editor" role
@@ -27,6 +29,8 @@ Feature: Roles
     Then I should get a "200" HTTP response
     And I am on "/node/add/stanford_page"
     And I should not see "Layout"
+    Then I am on "/node/1/delete"
+    And I should get a 403 HTTP response
 
   Scenario: Check I can log in as the Site Manager role
     Given I am logged in as a user with the "Site Manager" role
@@ -34,6 +38,8 @@ Feature: Roles
     Then I should get a "200" HTTP response
     And I am on "/node/add/stanford_page"
     And I should see "Layout"
+    Then I am on "/node/1/delete"
+    And I should get a 403 HTTP response
 
   Scenario: Check I can log in as the Site Builder role
     Given I am logged in as a user with the "Site Builder" role
@@ -41,6 +47,8 @@ Feature: Roles
     Then I should get a "200" HTTP response
     And I am on "/node/add/stanford_page"
     And I should see "Layout"
+    Then I am on "/node/1/delete"
+    And I should get a 200 HTTP response
 
   Scenario: Check I can log in as the Site Developer role
     Given I am logged in as a user with the "Site Developer" role
@@ -48,3 +56,5 @@ Feature: Roles
     Then I should get a "200" HTTP response
     And I am on "/node/add/stanford_page"
     And I should see "Layout"
+    Then I am on "/node/1/delete"
+    And I should get a 200 HTTP response


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Prevent the home page, 404, and 403 nodes from being deleted.

# Need Review By (Date)
- 1/29

# Urgency
- medium

# Steps to Test
1. Checkout this branch.
1. clear caches
1. log in as a site manager
1. Attempt to delete the 404, 403, or home page.
1. validate you aren't able to do so.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
