### PR TITLE
D8CORE-1153: Remove h6 from stanford_text formats

### DIFF
--- a/config/sync/filter.format.stanford_html.yml
+++ b/config/sync/filter.format.stanford_html.yml
@@ -52,7 +52,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <h6 id class> <a class href hreflang data-entity-substitution data-entity-type data-entity-uuid title name> <div class> <p class> <table> <caption> <tbody class> <thead> <tfoot> <th scope class> <td class> <tr> <sup> <sub> <i class> <hr> <drupal-media data-entity-type data-entity-uuid data-align data-caption data-* alt>'
+      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <a class href hreflang data-entity-substitution data-entity-type data-entity-uuid title name> <div class> <p class> <table> <caption> <tbody class> <thead> <tfoot> <th scope class> <td class> <tr> <sup> <sub> <i class> <hr> <drupal-media data-entity-type data-entity-uuid data-align data-caption data-* alt>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_htmlcorrector:

--- a/tests/behat/assets/documents/WYSIWYG.html
+++ b/tests/behat/assets/documents/WYSIWYG.html
@@ -19,6 +19,9 @@
 <h5>
   Level 05 Heading
 </h5>
+<h6>
+  Level 06 Heading
+</h6>
 
 <p>A small paragraph to <em>emphasis</em> and show <strong>important</strong>
   bits.</p>

--- a/tests/behat/assets/documents/WYSIWYG.html
+++ b/tests/behat/assets/documents/WYSIWYG.html
@@ -19,9 +19,6 @@
 <h5>
   Level 05 Heading
 </h5>
-<h6>
-  Level 06 Heading
-</h6>
 
 <p>A small paragraph to <em>emphasis</em> and show <strong>important</strong>
   bits.</p>

--- a/tests/behat/features/Paragraphs/WYSIWYG.feature
+++ b/tests/behat/features/Paragraphs/WYSIWYG.feature
@@ -32,7 +32,7 @@ Feature: WYSIWYG Paragraph
     And I should see an "h3:contains('Level 03 Heading')" element
     And I should see an "h4:contains('Level 04 Heading')" element
     And I should see an "h5:contains('Level 05 Heading')" element
-    And I should see an "h6:contains('Level 06 Heading')" element
+    And I should not see an "h6:contains('Level 06 Heading')" element
 
     # Text Tags
     And I should see an "p:contains('A small paragraph')" element


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removes h6 from the options in the format bar in wysiwyg

# Review By (Date)
- Jan 29th

# Urgency
- Low

# Steps to Test

1. Check out this branch
2. Install site or import config (or manually edit the setting in the ui)
3. Clear cache
4. Review format drop down in wysiwyg editor on stanford_page wysiwyg component

# Affected Projects or Products
- D8CORE

# Associated Issues and/or People
- D8CORE-1153
- github.com/SU-SWS/stanford_text_editor/pull/13

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)