### PR TITLE
D8CORE-1024 Added missing config setting for simplesamlphp_auth

### DIFF
--- a/config/sync/simplesamlphp_auth.settings.yml
+++ b/config/sync/simplesamlphp_auth.settings.yml
@@ -27,3 +27,4 @@ secure: true
 httponly: false
 _core:
   default_config_hash: BuLah1nwoT5oUjn6XIuKnXkjcvdt5tDIGQ6gAflOY0s
+login_link_show: true


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- added missing setting in simplesamlphp_auth.settings config

# Need Review By (Date)
- 2/12

# Urgency
- medium

# Steps to test
see https://github.com/SU-SWS/stanford_basic/pull/124

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
https://github.com/SU-SWS/stanford_ssp/pull/83
https://github.com/SU-SWS/stanford_basic/pull/124