### PR TITLE
tag-8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Stanford Profile
 
+8.x-1.0
+--------------------------------------------------------------------------------
+_Release Date: 2020-02-05
+
+- Stable release!
+- Many configuration updates
+- Many style updates
+- Many new tests, both unit and behat.
+- D8CORE-938: Menu tweaks for primary and seconday navigation
+- D8CORE-1153: Removed H6 from stanford_text formats
+- D8CORE-1112: Page Authoring: style banner top
+- D8CORE-971: fix home and no 2nd menu
+- D8CORE-941: WYSIWYG Typography update and CKEditor styles
+- D8CORE-1175: Provide additional help information
+- D8CORE-931: Add anchor location for skip links to content layouts
+- D8CORE-1117: Switch ot React Paragraphs
+- D8CORE-1177: Override WYSIWYG text paragraph styles
+- D8CORE-1221: Dark paragraph type icons
+- D8CORE-1018: Adjust content and media menu item titles
+- D8CORE-1243: SAML role mapping config page
+- D8CORE-1028: line length fix
+
+
 8.x-1.0-alpha5
 --------------------------------------------------------------------------------
 _Release Date: 2020-01-23_

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # [Stanford Profile](https://github.com/SU-SWS/stanford_profile)
-##### Version: 8.x
+##### Version: 8.1.0
 
 Maintainers: [Mike Decker](https://github.com/pookmish), [sherakama](https://github.com/sherakama)  
 

--- a/modules/stanford_paragraph_card/stanford_paragraph_card.info.yml
+++ b/modules/stanford_paragraph_card/stanford_paragraph_card.info.yml
@@ -1,6 +1,6 @@
 name: "Stanford Paragraph Card"
 description: Adds helpers and modifications to the card paragraph type.
-version: 8.x-1.0-alpha5
+version: 8.x-1.0
 core_version_requirement: ^8 || ^9
 type: module
 project: Stanford

--- a/modules/stanford_profile_install/stanford_profile_install.info.yml
+++ b/modules/stanford_profile_install/stanford_profile_install.info.yml
@@ -1,6 +1,0 @@
-name: "Stanford Profile Install"
-description: A work around for the missing install hook on profiles with config sync
-version: 8.x-1.0-alpha5
-core_version_requirement: ^8 || ^9
-type: module
-project: Stanford

--- a/modules/stanford_profile_install/stanford_profile_install.install
+++ b/modules/stanford_profile_install/stanford_profile_install.install
@@ -1,6 +1,0 @@
-<?php
-
-/**
- * @file
- * stanford_profile_install.install
- */

--- a/modules/stanford_profile_styles/README.md
+++ b/modules/stanford_profile_styles/README.md
@@ -1,5 +1,5 @@
 # [Stanford Profile Styles](https://github.com/SU-SWS/stanford_profile/tree/8.x-1.x/modules/stanford_profile_styles)
-                      ##### Version: 8.x
+##### Version: 8.1.0
 
 Maintainers: [Mike Decker](https://github.com/pookmish), [sherakama](https://github.com/sherakama)  
 

--- a/modules/stanford_profile_styles/stanford_profile_styles.info.yml
+++ b/modules/stanford_profile_styles/stanford_profile_styles.info.yml
@@ -1,6 +1,6 @@
 name: "Stanford Profile Styles"
 description: A module for theming
-version: 8.x-1.0-alpha5
+version: 8.x-1.0
 core_version_requirement: ^8 || ^9
 type: module
 project: Stanford

--- a/stanford_profile.info.yml
+++ b/stanford_profile.info.yml
@@ -1,6 +1,6 @@
 name: Stanford Profile
 description: Jumpstart Website Profile
-version: 8.x-1.0-dev
+version: 8.x-1.0
 type: profile
 project: Jumpstart
 core: 8.x


### PR DESCRIPTION
8.x-1.0
--------------------------------------------------------------------------------
_Release Date: 2020-02-05

- Stable release!
- Many configuration updates
- Many style updates
- Many new tests, both unit and behat.
- D8CORE-938: Menu tweaks for primary and seconday navigation
- D8CORE-1153: Removed H6 from stanford_text formats
- D8CORE-1112: Page Authoring: style banner top
- D8CORE-971: fix home and no 2nd menu
- D8CORE-941: WYSIWYG Typography update and CKEditor styles
- D8CORE-1175: Provide additional help information
- D8CORE-931: Add anchor location for skip links to content layouts
- D8CORE-1117: Switch ot React Paragraphs
- D8CORE-1177: Override WYSIWYG text paragraph styles
- D8CORE-1221: Dark paragraph type icons
- D8CORE-1018: Adjust content and media menu item titles
- D8CORE-1243: SAML role mapping config page
- D8CORE-1028: line length fix