### PR TITLE
D8CORE-1234: Add missing breakpoint for 2:1 card responsive image style.

### DIFF
--- a/config/sync/responsive_image.styles.card_2_1.yml
+++ b/config/sync/responsive_image.styles.card_2_1.yml
@@ -23,6 +23,16 @@ image_style_mappings:
     image_mapping_type: image_style
     image_mapping: card_1900x950
   -
+    breakpoint_id: stanford_image_styles.md
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: card_956x478
+  -
+    breakpoint_id: stanford_image_styles.md
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: card_1900x950
+  -
     breakpoint_id: stanford_image_styles.sm
     multiplier: 1x
     image_mapping_type: image_style


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Card image was not filling out the container at the MD breakpoint on interior pages.

# Review By (Date)
- Feb 12th

# Urgency
- Low

# Steps to Test

1. Put a card on an interior page and resize your browser until you see the whitespace gap
2. Check out this branch and import config (drush cim)
3. Clear caches and re-test the interior page to see gap-b-gone

# Affected Projects or Products
- Everywhere card is used

# Associated Issues and/or People
- D8CORE-1234
- Totally got ticket 1-2-3-4! woot.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)