### PR TITLE
D8CORE-1289: Update homepage banner default content

### DIFF
--- a/content/paragraph/5395f779-e884-4429-a533-a6712bd4eb32.json
+++ b/content/paragraph/5395f779-e884-4429-a533-a6712bd4eb32.json
@@ -79,9 +79,9 @@
     ],
     "su_banner_body": [
         {
-            "value": "<p>To edit this page, add \"\/user\" to the end of your url, and login to Drupal<\/p>\r\n",
+            "value": "<p>To edit this page, <a href=\"\/saml_login\">log in with your SUNetID<\/a>. After you log in, return to the homepage, and use it as a template to begin building your site.<\/p>\r\n",
             "format": "stanford_minimal_html",
-            "processed": "<p>To edit this page, add \"\/user\" to the end of your url, and login to Drupal<\/p>"
+            "processed": "<p>To edit this page, <a href=\"\/saml_login\">log in with your SUNetID<\/a>. After you log in, return to the homepage, and use it as a template to begin building your site.<\/p>"
         }
     ],
     "su_banner_header": [


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Change default content to support mo' betta user workflow

# Needed By (Date)
- v1.0.0

# Criticality
- How critical is this PR on a 1-10 scale? 7/10
- It's the front door of our product

# Steps to Test

1. Check out this branch
2. Install this profile
3. Check that banner looks like this:
![2020-02-12-101639-screenshot](https://user-images.githubusercontent.com/821106/74364598-4e6b5b80-4d81-11ea-951f-df1d767a81af.jpg)
4. Check that the hyperlink sends you to SAML login

# Affected Projects or Products
- D8CORE

# Associated Issues and/or People
- JIRA ticket: D8CORE-1289

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)