### PR TITLE
Set dropzone upload directory to `public`

### DIFF
--- a/config/sync/dropzonejs.settings.yml
+++ b/config/sync/dropzonejs.settings.yml
@@ -1,3 +1,3 @@
-tmp_upload_scheme: temporary
+tmp_upload_scheme: public
 _core:
   default_config_hash: k05zME-L0xvNO0Vr0DnL-jz6FXXihOp89a85E9jBFkg


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Set the file upload directory to `public` to help with the load balancer
- https://www.drupal.org/project/dropzonejs/issues/2916330#comment-13041849

# Need Review By (Date)
- ASAP

# Urgency
- HIGH

# Steps to Test
1. Checkout this this branch
1. drush cim -y
1. Validate you can still upload files

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
