### PR TITLE
D8CORE-1393 Dont display page title block on 404 and 403 pages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,6 +86,7 @@
         "drupal/paragraphs_edit": "^2.0@alpha",
         "drupal/pathauto": "^1.6",
         "drupal/redirect": "~1.0-beta1",
+        "drupal/response_code_condition": "^1.0",
         "drupal/role_delegation": "^1.0@beta",
         "drupal/rules": "^3.0@alpha",
         "drupal/seckit": "^1.0@alpha",

--- a/config/sync/block.block.stanford_basic_pagetitle.yml
+++ b/config/sync/block.block.stanford_basic_pagetitle.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
+    - response_code_condition
     - system
   theme:
     - stanford_basic
@@ -21,5 +22,10 @@ visibility:
   request_path:
     id: request_path
     pages: '/node/*'
+    negate: true
+    context_mapping: {  }
+  response_code:
+    id: response_code
+    response_codes: "404\r\n403"
     negate: true
     context_mapping: {  }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -85,6 +85,7 @@ module:
   path_alias: 0
   react_paragraphs: 0
   redirect: 0
+  response_code_condition: 0
   responsive_image: 0
   rest: 0
   role_delegation: 0

--- a/tests/behat/features/BasicPage.feature
+++ b/tests/behat/features/BasicPage.feature
@@ -25,3 +25,9 @@ Feature: Basic Page
     Then I press "Change parent (update list of weights)"
     And I press "Save"
     Then I should see "Another Behat Test Menu Item" in the "menu" region
+
+  Scenario: Count the number of H1 Tags
+    Given I am on "/this-doesnt-exist"
+    Then I should see 1 "h1" element
+    And I am on "/search/content?keys=stuff&search="
+    Then I should see 1 "h1" element

--- a/tests/behat/features/BasicPage.feature
+++ b/tests/behat/features/BasicPage.feature
@@ -29,5 +29,7 @@ Feature: Basic Page
   Scenario: Count the number of H1 Tags
     Given I am on "/this-doesnt-exist"
     Then I should see 1 "h1" element
+    And the response status code should be 404
     And I am on "/search/content?keys=stuff&search="
     Then I should see 1 "h1" element
+    And the response status code should be 200


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added response code condition to hide title block on 404 and 403 pages

# Need Review By (Date)
- 2/28

# Urgency
- high

# Steps to Test
1. `composer require su-sws/dev-D8CORE-1393`
1. `blt drupal:update`
1. navigate to any url that doesnt exist
1. validate only 1 page title
1. enter something in the search field at the top
1. validate the search page has a page title.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
