### PR TITLE
Added stanford media library to node form since react doesnt add it

### DIFF
--- a/modules/stanford_profile_styles/stanford_profile_styles.libraries.yml
+++ b/modules/stanford_profile_styles/stanford_profile_styles.libraries.yml
@@ -3,6 +3,8 @@ node_form:
   css:
     theme:
       dist/css/stanford_profile_styles.admin.node_form.css: {}
+  dependencies:
+    - stanford_media/admin
 
 field_widgets:
   version: VERSION


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- stanford_media css changes the media library icon. but react widgets don't load that css outside the ckeditor iframe. so we add it to the form level.

# Need Review By (Date)
- 2/28

# Urgency
- medium

# Steps to Test
1. checkout this branch
1. clear cache
1. create/edit a basic page
1. add a text area paragraph and verify the media library icon doesn't contain a musical note.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
