### PR TITLE
D8CORE-1370: Alter menu form and status messages for config_readonly users

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,9 @@
             },
             "drupal/menu_link_weight": {
                 "https://www.drupal.org/project/menu_link_weight/issues/2995896": "https://www.drupal.org/files/issues/2018-08-29/2995896-menu-admin-per-menu-support-fixes.patch"
+            },
+            "drupal/config_readonly": {
+              "https://www.drupal.org/project/config_readonly/issues/2892631": "https://www.drupal.org/files/issues/2018-04-01/config-readonly-2892631-18.patch"
             }
         }
     }

--- a/stanford_profile.profile
+++ b/stanford_profile.profile
@@ -160,7 +160,8 @@ function stanford_profile_form_menu_edit_form_alter(array &$form, FormStateInter
     return;
   }
 
-  // If the form is locked, hide the config you cannot change from users without the know how.
+  // If the form is locked, hide the config you cannot change from users without
+  // the know how.
   $access = \Drupal::currentUser()->hasPermission('Administer menus and menu items');
   $form['label']['#access'] = $access;
   $form['description']['#access'] = $access;

--- a/stanford_profile.profile
+++ b/stanford_profile.profile
@@ -13,6 +13,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeInterface;
+use Drupal\Core\Site\Settings;
 
 /**
  * Implements hook_install_tasks().
@@ -148,4 +149,25 @@ function stanford_profile_node_access(NodeInterface $node, $op, AccountInterface
     }
   }
   return AccessResult::neutral();
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function stanford_profile_form_menu_edit_form_alter(array &$form, FormStateInterface $form_state) {
+  $read_only = Settings::get('config_readonly', FALSE);
+  if (!$read_only) {
+    return;
+  }
+
+  // If the form is locked, hide the config you cannot change from users without the know how.
+  $access = \Drupal::currentUser()->hasPermission('Administer menus and menu items');
+  $form['label']['#access'] = $access;
+  $form['description']['#access'] = $access;
+  $form['id']['#access'] = $access;
+
+  // Remove the warning message if the user does not have access.
+  if (!$access) {
+    \Drupal::messenger()->deleteByType("warning");
+  }
 }


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Removes warning label and fields from form page where some items were editable and others were not.

# Review By (Date)
- Feb 26th

# Urgency
- Med/Low

# Steps to Test

1. Do a full site build with stanford_profile
2. Check out this branch and clear cache
3. Set `$settings['config_readonly'] = TRUE;` in your `local.settings.php` file.
4. Log in as a site_manager and edit the form at `/admin/structure/menu/manage/main`
5. Log in as an administrator and edit the form at `/admin/structure/menu/manage/main`

# Affected Projects or Products
- D8CORE

# Associated Issues and/or People
- D8CORE-1370

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
