### PR TITLE
8.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Stanford Profile
 
+8.x-1.2
+--------------------------------------------------------------------------------
+_Release Date: 2020-02-21
+
+- Resynced the media library view with the drupaDl core version (#105)
+- D8CORE-1393 Dont display page title block on 404 and 403 pages (#106)
+- D8CORE-106: Add Media with Caption paragraph. (#59)
+- D8CORE-1363: Dont show contextual links to users. (#108)
+- D8CORE-1262: Change "Related Text" to "Card Text". (#108)
+- D8CORE-1365: Moved banner to top banner field. (#108)
+- D8CORE-1394: Allow <br> tags. (#108)
+- D8CORE-1224: Add help text to layout selection field. (#108)
+- D8CORE-1326: Allow sitemanagers to view all unpublished content. (#108)
+- D8CORE-1313: Moving the ol and ul styles to the wysiwyg (#111)
+- Added stanford media library to node form since react doesnt add it (#113)
+
+
 8.x-1.1
 --------------------------------------------------------------------------------
 _Release Date: 2020-02-14_

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # [Stanford Profile](https://github.com/SU-SWS/stanford_profile)
-##### 8.x-1.2-dev
+##### 8.x-1.2
 
 Maintainers: [Mike Decker](https://github.com/pookmish), [sherakama](https://github.com/sherakama)  
 

--- a/modules/stanford_paragraph_card/stanford_paragraph_card.info.yml
+++ b/modules/stanford_paragraph_card/stanford_paragraph_card.info.yml
@@ -1,6 +1,6 @@
 name: "Stanford Paragraph Card"
 description: Adds helpers and modifications to the card paragraph type.
-version: 8.x-1.2-dev
+version: 8.x-1.2
 core_version_requirement: ^8 || ^9
 type: module
 project: Stanford

--- a/modules/stanford_profile_install/stanford_profile_install.info.yml
+++ b/modules/stanford_profile_install/stanford_profile_install.info.yml
@@ -1,6 +1,6 @@
 name: "Stanford Profile Install"
 description: A work around for the missing install hook on profiles with config sync
-version: 8.x-1.2-dev
+version: 8.x-1.2
 core_version_requirement: ^8 || ^9
 type: module
 project: Stanford

--- a/modules/stanford_profile_styles/stanford_profile_styles.info.yml
+++ b/modules/stanford_profile_styles/stanford_profile_styles.info.yml
@@ -1,6 +1,6 @@
 name: "Stanford Profile Styles"
 description: A module for theming
-version: 8.x-1.2-dev
+version: 8.x-1.2
 core_version_requirement: ^8 || ^9
 type: module
 project: Stanford

--- a/stanford_profile.info.yml
+++ b/stanford_profile.info.yml
@@ -1,6 +1,6 @@
 name: Stanford Profile
 description: Jumpstart Website Profile
-version: 8.x-1.2-dev
+version: 8.x-1.2
 type: profile
 project: Jumpstart
 core: 8.x

--- a/tests/behat/features/Paragraphs/WYSIWYG.feature
+++ b/tests/behat/features/Paragraphs/WYSIWYG.feature
@@ -165,4 +165,4 @@ Feature: WYSIWYG Paragraph
     And I wait 1 seconds
     Then I press "Continue"
     Then I press "Save"
-    And I should see 1 "a[href*='.txt']:contains('test.txt')" element in the "content" region
+    And I should see 1 "a[href*='.txt']:contains('Test TXT Document')" element in the "content" region


### PR DESCRIPTION
8.x-1.2
--------------------------------------------------------------------------------
_Release Date: 2020-02-21

- Resynced the media library view with the drupaDl core version (#105)
- D8CORE-1393 Dont display page title block on 404 and 403 pages (#106)
- D8CORE-106: Add Media with Caption paragraph. (#59)
- D8CORE-1363: Dont show contextual links to users. (#108)
- D8CORE-1262: Change "Related Text" to "Card Text". (#108)
- D8CORE-1365: Moved banner to top banner field. (#108)
- D8CORE-1394: Allow <br> tags. (#108)
- D8CORE-1224: Add help text to layout selection field. (#108)
- D8CORE-1326: Allow sitemanagers to view all unpublished content. (#108)
- D8CORE-1313: Moving the ol and ul styles to the wysiwyg (#111)
- Added stanford media library to node form since react doesnt add it (#113)