### PR TITLE
D8CORE-1282: Invalidate node page cache when new menu items are added…

### DIFF
--- a/stanford_profile.profile
+++ b/stanford_profile.profile
@@ -87,7 +87,7 @@ function stanford_profile_menu_link_content_presave(MenuLinkContent $entity) {
       $parent_item = array_pop($menu_link_content);
       $params = $parent_item->getUrlObject()->getRouteParameters();
       if (isset($params['node'])) {
-        CACHE::invalidateTags(['node:'  . $params['node']]);
+        Cache::invalidateTags(['node:' . $params['node']]);
       }
     }
   }

--- a/stanford_profile.profile
+++ b/stanford_profile.profile
@@ -85,8 +85,7 @@ function stanford_profile_menu_link_content_presave(MenuLinkContent $entity) {
     $menu_link_content = \Drupal::entityTypeManager()->getStorage($entity_name)->loadByProperties(['uuid' => $uuid]);
     if (is_array($menu_link_content)) {
       $parent_item = array_pop($menu_link_content);
-      $parent_url = $parent_item->getUrlObject();
-      $params = $parent_url->getRouteParameters();
+      $params = $parent_item->getUrlObject()->getRouteParameters();
       if (isset($params['node'])) {
         CACHE::invalidateTags(['node:'  . $params['node']]);
       }


### PR DESCRIPTION
… as children.

# READY FOR REVIEW 

# Summary
- Fixes bug where you add a menu item to a nested page and the parent node cache does not clear to display the sidebar menu.

# Needed By (Date)
- Thursday

# Urgency
- Medium, will affect all users when adding their first nested page.

# Steps to Test

1. Do a fresh build of stanford_profile on the 1.x branch
2. Create a new stanford_page under the `about` page
3. Using the main navigation click on the `about` link to go to the parent page
4. See no secondary sidebar menu
5. Check out this branch
6. Create a new stanford_page under the `resources` page
7. Using the main navigation click on the `resources` link to go to the parent page
8. See the secondary sidebar navigation with your new page there

I looked into the menu_block cache and it does clear out `config:system.menu.main` tags but somewhere in the render cache that isn't enough and the parent page isn't updated. If there is a better tag or context to clear please provide some insight. 

# Affected Projects or Products
- D8CORE

# Associated Issues and/or People
- D8CORE-1282

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
