### PR TITLE
D8CORE-1340 Use core link in wysiwyg for now

### DIFF
--- a/config/sync/editor.editor.stanford_html.yml
+++ b/config/sync/editor.editor.stanford_html.yml
@@ -28,8 +28,8 @@ settings:
         -
           name: Links
           items:
-            - Link
-            - Unlink
+            - DrupalLink
+            - DrupalUnlink
             - Anchor
         -
           name: Lists

--- a/src/Plugin/InstallTask/RouteRebuilder.php
+++ b/src/Plugin/InstallTask/RouteRebuilder.php
@@ -48,6 +48,7 @@ class RouteRebuilder extends InstallTaskBase implements ContainerFactoryPluginIn
    */
   public function runTask(array &$install_state) {
     $this->routeBuilder->rebuildIfNeeded();
+    node_access_rebuild();
   }
 
 }

--- a/tests/src/Kernel/Plugin/InstallTask/RouteRebuilderTest.php
+++ b/tests/src/Kernel/Plugin/InstallTask/RouteRebuilderTest.php
@@ -18,6 +18,8 @@ class RouteRebuilderTest extends KernelTestBase {
    */
   protected static $modules = [
     'system',
+    'node',
+    'user',
   ];
 
   /**
@@ -26,6 +28,9 @@ class RouteRebuilderTest extends KernelTestBase {
   protected function setUp() {
     parent::setUp();
     $this->setInstallProfile('stanford_profile');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installSchema('node', 'node_access');
     $this->container->set('router.builder', $this->createMock(RouteBuilderInterface::class));
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Use drupal cores link buttons for now so that media images can be linked.
- Rebuild node access on install.

# Need Review By (Date)
- asap

# Urgency
- high.

# Steps to Test
1. checkout this branch
1. `drush cim`
1. create a page with a wysiwyg and add an image
1. validate you can add a link to the image.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
