### PR TITLE
D8CORE-1327: Change filter-format to allow for html entities.

### DIFF
--- a/config/sync/ds.field.su_site_name.yml
+++ b/config/sync/ds.field.su_site_name.yml
@@ -3,8 +3,8 @@ label: 'Site Name'
 ui_limit: 'stanford_local_footer|*'
 properties:
   content:
-    value: '[site:name]'
-    format: plain_text
+    value: "[site:name]"
+    format: stanford_minimal_html
 type: token
 type_label: 'Token field'
 entities:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changes filter format to `minimal` to allow for html entities 
- Currently, htmlentities are encoded and passed into the twig templates rendering `&` as `&amp;`

# Needed By (Date)
- Thursday

# Urgency
- Medium/Low

# Steps to Test

1. Set the site name to `Tom & Jerry`
2. Clear cache and review the local footer lockup
3. See double encoding of the `&`
4. Check out this branch and import config
5. Clear cache and see only once encoding of the `&`
6. Jen is working on fixing the twig template to handle the second encoding. 

# Affected Projects or Products
- D8CORE-1327

# Associated Issues and/or People
- D8CORE-1327
- FYI @jenbreese 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
