### PR TITLE
Set home link to the home node for default content

### DIFF
--- a/content/menu_link_content/26a314fe-33aa-4660-b06a-97b26dc75baf.json
+++ b/content/menu_link_content/26a314fe-33aa-4660-b06a-97b26dc75baf.json
@@ -57,7 +57,7 @@
     ],
     "link": [
         {
-            "uri": "internal:\/",
+            "uri": "entity:node\/1",
             "title": "",
             "options": []
         }
@@ -69,7 +69,7 @@
     ],
     "rediscover": [
         {
-            "value": true
+            "value": false
         }
     ],
     "weight": [

--- a/stanford_profile.info.yml
+++ b/stanford_profile.info.yml
@@ -182,7 +182,6 @@ default_content:
     - e18a741f-7d86-492a-a02f-7ca73989ca13
   paragraph:
     - 18a7d9f1-59fe-4b56-b1d8-f18326c26810
-    - 5395f779-e884-4429-a533-a6712bd4eb32
     - 572fb79d-9b65-43c3-aff4-1ff37514ad41
     - 6896f410-41a6-403a-b296-839079683ee6
     - 8f7b2d0f-f883-43c8-9782-5e8b88fd98dc


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Set the node to be the home menu link: this displays the link info on the node form
- removed line of paragraph uuid that was removed.

# Need Review By (Date)
- :man_shrugging: 

# Urgency
- low

# Steps to Test
1. checkout this branch
1. run a fresh install
1. on the home page click edit
1. validate the menu setting on the node show that it is in the menu.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
