### PR TITLE
D8CORE - bumping version of `views_bulk_operations`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,7 @@
         "drupal/ui_patterns": "~1.0",
         "drupal/view_unpublished": "^1.0@alpha",
         "drupal/views_block_filter_block": "^1.0@beta",
-        "drupal/views_bulk_operations": "^3.2",
+        "drupal/views_bulk_operations": "^3.6",
         "drupal/webform": "^5.4",
         "drupal/xmlsitemap": "~1.0@alpha",
         "ext-imagick": "*",


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- TL;DR - `views_bulk_operations` introduced an upgrade-path bug in version 3.4, which was causing problems completing a `drush updb`.  This was fixed with the 3.6 release, which was published this morning. Locking the version called for in the profile to 3.6 and above prevents us from being affected by the bug.

# Needed By (Date)
- By the 1.0.1 release

# Urgency
- This bug affects the upgrade path, and may interfere with stack upgrades going forward.

# Steps to Test

1. Install the stack with this updated requirement.
2. Check to make sure that `drush updb` completes correctly
3. Check to make sure that `views_bulk_operations` still works as expected.

# Affected Projects or Products
- This may affect views which set action preliminary configurations.  Those configurations would be dropped with the unmodified 3.4 upgrade, but will be preserved with this update.

# Associated Issues and/or People
- SMPI

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
