### PR TITLE
D8CORE-1471: Allow site_manager to assign the site_manager role.

### DIFF
--- a/config/sync/user.role.site_manager.yml
+++ b/config/sync/user.role.site_manager.yml
@@ -31,6 +31,7 @@ permissions:
   - 'assign stanford_faculty role'
   - 'assign stanford_staff role'
   - 'assign stanford_student role'
+  - 'assign site_manager role'
   - 'cancel account'
   - 'change own username'
   - 'choose layout for node stanford_page'


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Allows site_managers to grant site_managers

# Review By (Date)
- March 10

# Urgency
- Low

# Steps to Test

1. Check out this branch
2. Install new site or import config
3. Log in as a site_manager and navigate to the user page
4. Assign a lower level user the site_manager role

# Affected Projects or Products
- D8CORE

# Associated Issues and/or People
- D8CORE-1471
- D8CORE-1473

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
