### PR TITLE
use an existing step definition

### DIFF
--- a/tests/behat/features/BasicPage.feature
+++ b/tests/behat/features/BasicPage.feature
@@ -39,5 +39,5 @@ Feature: Basic Page
     Given I am logged in as a user with the "Site Manager" role
     Given I am viewing a "stanford_page" with the title "I would like revisions"
     Then I am on "/i-would-like-revisions"
-    Then I press on the "Revisions" link
+    Then I click "Revisions"
     And the response status code should be 200


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- the step definition doesn't exist. use one that does
- the tests before weren't failing if a step definition was undefined. they do now.

# Need Review By (Date)
- asap

# Urgency
- medium

# Steps to Test
1. review test results and https://circleci.com/gh/SU-SWS/acsf-cardinalsites/2741?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

looks like previous tests didnt get marked as failure https://circleci.com/gh/SU-SWS/stanford_profile/1648?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
