### PR TITLE
D8CORE-1689 Allow custom blocks in layout builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,10 @@
                 "https://www.drupal.org/project/menu_link_weight/issues/2995896": "https://www.drupal.org/files/issues/2018-08-29/2995896-menu-admin-per-menu-support-fixes.patch"
             },
             "drupal/config_readonly": {
-              "https://www.drupal.org/project/config_readonly/issues/2892631": "https://www.drupal.org/files/issues/2018-04-01/config-readonly-2892631-18.patch"
+                "https://www.drupal.org/project/config_readonly/issues/2892631": "https://www.drupal.org/files/issues/2018-04-01/config-readonly-2892631-18.patch"
+            },
+            "drupal/paragraphs": {
+                "https://www.drupal.org/project/paragraphs/issues/2901390": "https://www.drupal.org/files/issues/2019-08-10/paragraphs-set_langcode_widgets-290139_updated.patch"
             }
         }
     }

--- a/tests/behat/features/Paragraphs/Issue2901390.feature
+++ b/tests/behat/features/Paragraphs/Issue2901390.feature
@@ -1,0 +1,18 @@
+@api
+Feature: Layout Builder Paragraphs
+  In order to customize the layout
+  As a site manager
+  I should be able to create custom blocks from within layout builder.
+
+  @testthis
+  Scenario: Create Paragraphs In Layout Builder
+    Given I am logged in as a user with the "site_manager" role
+    And I am viewing a "stanford_page" with the title "Customized Layout Builder"
+    Then I click "Layout"
+    And I click "Add block"
+    Then I click "Create custom block"
+    And I fill in "Title" with "custom block"
+    And I fill in "Body" with "Lorem Ipsum Custom Block Text"
+    And I press "Add block"
+    Then I press "Save layout"
+    And I should see "Lorem Ipsum Custom Block Text"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed error when trying to save a custom block in the layout builder.
- patch added to the stack in https://github.com/SU-SWS/acsf-cardinalsites/pull/117

# Need Review By (Date)
- 3/19

# Urgency
- high

# Steps to Test
1. Checkout https://github.com/SU-SWS/acsf-cardinalsites/pull/117
1. Create a basic page
1. edit the layout for that page
1. add a custom block
1. when saving validate it doesn't throw an error.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
