### PR TITLE
add stanford_page_layout_full only to stanford pages

### DIFF
--- a/modules/stanford_profile_styles/stanford_profile_styles.module
+++ b/modules/stanford_profile_styles/stanford_profile_styles.module
@@ -34,14 +34,13 @@ function stanford_profile_styles_page_attachments(array &$attachments) {
   // Check for our type and add library if a match.
   if ($node->getType() == "stanford_page") {
     $attachments['#attached']['library'][] = 'stanford_profile_styles/stanford_page';
-  }
 
-  // Check if stanford page is using a particular layout.
-  $layout_target = $node->get('layout_selection')->getValue('target_id');
-  if (isset($layout_target[0]['target_id']) && $layout_target[0]['target_id'] == "stanford_basic_page_full") {
-    $attachments['#attached']['library'][] = "stanford_profile_styles/stanford_page_layout_full";
+    // Check if stanford page is using a particular layout.
+    $layout_target = $node->get('layout_selection')->getValue();
+    if (isset($layout_target[0]['target_id']) && $layout_target[0]['target_id'] == "stanford_basic_page_full") {
+      $attachments['#attached']['library'][] = "stanford_profile_styles/stanford_page_layout_full";
+    }
   }
-
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed adding styles to a page that isn't a stanford_page

# Need Review By (Date)
- soon

# Urgency
- medium

# Steps to Test
1. create a new content type. no need to add any fields and all other default settings.
1. create a piece of content from that new content type
1. try to view and verify you can view the node page.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
