### PR TITLE
fixed seckit split

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "type": "drupal-custom-profile",
     "license": "GPL-2.0+",
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "repositories": [
         {
             "type": "composer",
@@ -123,5 +124,9 @@
                 "https://www.drupal.org/project/paragraphs/issues/2901390": "https://www.drupal.org/files/issues/2019-08-10/paragraphs-set_langcode_widgets-290139_updated.patch"
             }
         }
+    },
+    "require-dev": {
+        "drupal/devel_php": "^1.1",
+        "drupal/devel": "^2.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -124,9 +124,5 @@
                 "https://www.drupal.org/project/paragraphs/issues/2901390": "https://www.drupal.org/files/issues/2019-08-10/paragraphs-set_langcode_widgets-290139_updated.patch"
             }
         }
-    },
-    "require-dev": {
-        "drupal/devel_php": "^1.1",
-        "drupal/devel": "^2.1"
     }
 }

--- a/config/sync/config_split.config_split.dev.yml
+++ b/config/sync/config_split.config_split.dev.yml
@@ -15,7 +15,6 @@ module:
   purge_processor_lateruntime: 0
   purge_queuer_coretags: 0
   purge_tokens: 0
-  seckit: 0
   update: 0
 theme: {  }
 blacklist: {  }

--- a/config/sync/config_split.config_split.local.yml
+++ b/config/sync/config_split.config_split.local.yml
@@ -9,7 +9,7 @@ folder: ../config/envs/local
 module:
   dblog: 0
   devel: 0
-  seckit: 0
+  devel_php: 0
 theme: {  }
 blacklist: {  }
 graylist: {  }

--- a/config/sync/config_split.config_split.prod.yml
+++ b/config/sync/config_split.config_split.prod.yml
@@ -15,7 +15,6 @@ module:
   purge_processor_lateruntime: 0
   purge_queuer_coretags: 0
   purge_tokens: 0
-  seckit: 0
 theme: {  }
 blacklist: {  }
 graylist: {  }

--- a/config/sync/config_split.config_split.stage.yml
+++ b/config/sync/config_split.config_split.stage.yml
@@ -15,7 +15,6 @@ module:
   purge_processor_lateruntime: 0
   purge_queuer_coretags: 0
   purge_tokens: 0
-  seckit: 0
 theme: {  }
 blacklist: {  }
 graylist: {  }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -90,6 +90,7 @@ module:
   rest: 0
   role_delegation: 0
   search: 0
+  seckit: 0
   serialization: 0
   shortcut: 0
   simplesamlphp_auth: 0


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- seckit was enabled for all split, so lets move it to the core.extension.yml

# Need Review By (Date)
- whenever

# Urgency
- low

# Steps to Test
1. `composer require su-sws/stanford_profile:dev-require-devs`
1. `composer require drupal/devel:^2.0 drupal/devel_php:^1.0 --dev`
1. `blt drupal:install`
1. validate local still installs with no error.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
