### PR TITLE
D8CORE-1708 D8CORE-1707: Disable menu items in toolbar.

### DIFF
--- a/config/sync/core.menu.static_menu_link_overrides.yml
+++ b/config/sync/core.menu.static_menu_link_overrides.yml
@@ -5,11 +5,5 @@ definitions:
     parent: admin_toolbar_tools.help
     expanded: false
     weight: -6
-  entity_reference_revisions__delete_orphans:
-    enabled: false
-    menu_name: admin
-    parent: system.admin_config_system
-    weight: 30
-    expanded: false
 _core:
   default_config_hash: jdY7AU0tU-QsjmiOw3W8vwpYMb-By--_MSFgbqKUTYM

--- a/config/sync/core.menu.static_menu_link_overrides.yml
+++ b/config/sync/core.menu.static_menu_link_overrides.yml
@@ -1,3 +1,15 @@
-definitions: {  }
+definitions:
+  system__db_update:
+    enabled: false
+    menu_name: admin
+    parent: admin_toolbar_tools.help
+    expanded: false
+    weight: -6
+  entity_reference_revisions__delete_orphans:
+    enabled: false
+    menu_name: admin
+    parent: system.admin_config_system
+    weight: 30
+    expanded: false
 _core:
   default_config_hash: jdY7AU0tU-QsjmiOw3W8vwpYMb-By--_MSFgbqKUTYM

--- a/config/sync/user.role.site_manager.yml
+++ b/config/sync/user.role.site_manager.yml
@@ -50,7 +50,6 @@ permissions:
   - 'delete any stanford_page content'
   - 'delete any video media'
   - 'delete media'
-  - 'delete orphan revisions'
   - 'delete own file media'
   - 'delete own image media'
   - 'delete own stanford_page content'

--- a/tests/behat/features/BasicPage.feature
+++ b/tests/behat/features/BasicPage.feature
@@ -37,7 +37,6 @@ Feature: Basic Page
   # Regression test for: D8CORE-1547
   Scenario: Access the revisions page
     Given I am logged in as a user with the "Site Manager" role
-    Given I am viewing a "stanford_page" with the title "I would like revisions"
-    Then I am on "/i-would-like-revisions"
+    And I am viewing a "stanford_page" with the title "I would like revisions"
     Then I click "Revisions"
     And the response status code should be 200


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Disables: "Run Updates" & "Delete orphaned composite" from admin toolbar menu

# Review By (Date)
- The next release would be nice.

# Urgency
- Low

# Steps to Test

1. Run an install or `drush cim` to get the latest
2. Validate that the menu items are disabled in the administration menu.

# Affected Projects or Products
- D8CORE

# Associated Issues and/or People
- D8CORE-1708
- D8CORE-1707

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
