### PR TITLE
D8CORE-1792: Enabled a11y_checker for text editor.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,7 +137,7 @@
         "su-sws/stanford_fields": "^8.1.0",
         "su-sws/stanford_image_styles": "^8.1.0",
         "su-sws/stanford_ssp": "^8.1.1",
-        "su-sws/stanford_text_editor": "dev-D8CORE-1490-1"
+        "su-sws/stanford_text_editor": "dev-8.x-1.x"
     },
     "extra": {
         "patches": {

--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,7 @@
         "su-sws/stanford_fields": "^8.1.0",
         "su-sws/stanford_image_styles": "^8.1.0",
         "su-sws/stanford_ssp": "^8.1.1",
-        "su-sws/stanford_text_editor": "^8.1.0"
+        "su-sws/stanford_text_editor": "dev-D8CORE-1490-1"
     },
     "extra": {
         "patches": {

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,41 @@
         {
             "type": "package",
             "package": {
-                "name": "ckeditor-plugin/link",
-                "version": "4.13.1",
+                "name": "ckeditor-plugin/a11ychecker",
+                "version": "1.1.1",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/link/releases/link_4.13.1.zip",
+                    "url": "https://download.ckeditor.com/a11ychecker/releases/a11ychecker_1.1.1.zip",
+                    "type": "zip"
+                },
+                "require": {
+                    "composer/installers": "~1.0"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "ckeditor-plugin/balloonpanel",
+                "version": "4.14.0",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://download.ckeditor.com/balloonpanel/releases/balloonpanel_4.14.0.zip",
+                    "type": "zip"
+                },
+                "require": {
+                    "composer/installers": "~1.0"
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "ckeditor-plugin/link",
+                "version": "4.14.0",
+                "type": "drupal-library",
+                "dist": {
+                    "url": "https://download.ckeditor.com/link/releases/link_4.14.0.zip",
                     "type": "zip"
                 },
                 "require": {
@@ -29,10 +59,10 @@
             "type": "package",
             "package": {
                 "name": "ckeditor-plugin/fakeobjects",
-                "version": "4.13.1",
+                "version": "4.14.0",
                 "type": "drupal-library",
                 "dist": {
-                    "url": "https://download.ckeditor.com/fakeobjects/releases/fakeobjects_4.13.1.zip",
+                    "url": "https://download.ckeditor.com/fakeobjects/releases/fakeobjects_4.14.0.zip",
                     "type": "zip"
                 },
                 "require": {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -11,6 +11,8 @@ module:
   chosen: 0
   chosen_lib: 0
   ckeditor: 0
+  ckeditor_a11ychecker: 0
+  ckeditor_balloonpanel: 0
   ckeditor_fixed_toolbar: 0
   color: 0
   components: 0

--- a/config/sync/editor.editor.stanford_html.yml
+++ b/config/sync/editor.editor.stanford_html.yml
@@ -52,6 +52,8 @@ settings:
             - RemoveFormat
             - Source
             - PasteFromWord
+            - '-'
+            - A11ychecker
   plugins:
     drupallink:
       linkit_enabled: true

--- a/stanford_profile.info.yml
+++ b/stanford_profile.info.yml
@@ -15,6 +15,8 @@ install:
   - better_normalizers:better_normalizers
   - chosen:chosen
   - chosen:chosen_lib
+  - ckeditor_a11ychecker:ckeditor_a11ychecker
+  - ckeditor_a11ychecker:ckeditor_balloonpanel
   - components:components
   - config_filter:config_filter
   - config_merge:config_merge

--- a/tests/behat/features/DefaultContent.feature
+++ b/tests/behat/features/DefaultContent.feature
@@ -26,7 +26,7 @@ Feature: Default Content
     Given I am logged in as a user with the "site_manager" role
     And I am on "/admin/content/media"
     Then I should see 15 or more ".media-library-item img" elements
-    
+
   Scenario: XML Sitemap Loads
     Given I run cron
     And I am on "/sitemap.xml"

--- a/tests/behat/features/DefaultContent.feature
+++ b/tests/behat/features/DefaultContent.feature
@@ -26,7 +26,8 @@ Feature: Default Content
     Given I am logged in as a user with the "site_manager" role
     And I am on "/admin/content/media"
     Then I should see 15 or more ".media-library-item img" elements
-
+    
+  @experimental
   Scenario: XML Sitemap Loads
     Given I run cron
     And I am on "/sitemap.xml"

--- a/tests/behat/features/DefaultContent.feature
+++ b/tests/behat/features/DefaultContent.feature
@@ -27,7 +27,6 @@ Feature: Default Content
     And I am on "/admin/content/media"
     Then I should see 15 or more ".media-library-item img" elements
     
-  @experimental
   Scenario: XML Sitemap Loads
     Given I run cron
     And I am on "/sitemap.xml"


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Adds the accessibility checker to the ckeditor wysiwyg
- SEE: https://github.com/SU-SWS/acsf-cardinalsites/pull/134 

# Review By (Date)
- April 7th

# Urgency
- Low

# Steps to Test

1.  SEE: https://github.com/SU-SWS/acsf-cardinalsites/pull/134
2. Review code.

# Affected Projects or Products
- D8CORE

# Associated Issues and/or People
- D8CORE-1792
- D8CORE-1490

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
