### PR TITLE
D8CORE-1664

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,16 @@ behat: &behat
     - store_artifacts:
         path: /var/www/html/artifacts
 
+back_to_dev: &back_to_dev
+  <<: *defaults
+  steps:
+    - checkout
+    - run:
+        name: Back to dev
+        command: |
+          composer global require SU-SWS/stanford-caravan:dev-8.x-1.x
+          ~/.composer/vendor/bin/sws-caravan back-to-dev ${CIRCLE_TAG} ${CIRCLE_WORKING_DIRECTORY}
+
 codeception: &codeception
   <<: *defaults
   steps:
@@ -77,12 +87,24 @@ jobs:
     <<: *code_coverage
   run-behat:
     <<: *behat
+  run-back-to-dev:
+    <<: *back_to_dev
   run-codeception:
     <<: *codeception
 
 # Declare a workflow that runs all of our jobs in parallel.
 workflows:
   version: 2
+  after_release:
+    jobs:
+      - run-back-to-dev:
+          filters:
+            tags:
+              only:
+                - /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*).*?$/
+            branches:
+              ignore:
+                - /.*/
   tests:
     jobs:
       - run-coverage

--- a/.github/workflows/tag_commits_to_master.yml
+++ b/.github/workflows/tag_commits_to_master.yml
@@ -1,18 +1,18 @@
-name: Tag Commits to Master
+# .github/workflows/release.yml
+name: Release
+
 on:
-  push:
-    branches:
-      - master
+  pull_request:
+    types: closed
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-      with:
-        fetch-depth: '0'
-    - name: Bump version and push tag
-      uses: anothrNick/github-tag-action@1.19.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        WITH_V: false
-        DEFAULT_BUMP: patch
+      - name: Tag
+        uses: K-Phoen/semver-release-action@master
+        with:
+          release_branch: master
+          tag_format: "%major%.%minor%.%patch%"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag_commits_to_master.yml
+++ b/.github/workflows/tag_commits_to_master.yml
@@ -1,0 +1,18 @@
+name: Tag Commits to Master
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: '0'
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@1.19.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: false
+        DEFAULT_BUMP: patch

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ Steps to build a new release:
 - Update the `composer.json` file to use the latest tagged release of all `su-sws` packages, eliminating the `@dev` dependencies.
 - Commit your changes to the release branch.
 - Make a PR to merge your release branch into `master`
-- When the PR is merged to `master`, a new tag will be created automatically, bumping the version by 1 semver patch by default.  If you wish, you may bump a minor or major version by including the text `#minor` or `#major` in the PR.
-- The github action is built from: (github-tag-bump)[https://github.com/marketplace/actions/github-tag-bump], and further documentation is available there.
+- Give the PR a semver-compliant label, e.g., (`patch`, `minor`, `major`)
+- When the PR is merged to `master`, a new tag will be created automatically, bumping the version by the semver label.
+- The github action is built from: (semver-release-action)[https://github.com/K-Phoen/semver-release-action], and further documentation is available there.
 
 
 Troubleshooting

--- a/README.md
+++ b/README.md
@@ -30,13 +30,15 @@ Releases
 
 Steps to build a new release:
 - Checkout the latest commit from the `8.x-1.x` branch.
-- Create a new branch, e.g., `release-8.1.6`.
-- Update the `composer.json` file to use the latest tagged release of all `su-sws` packages, eliminating the `@dev` dependencies.
-- Commit your changes to the release branch.
+- Create a new branch for the release.
+- Commit any necessary changes to the release branch.
+  -  These may include, but are not necessarily limited to:
+    - Update the version in any `info.yml` files, including in any submodules.
+    - Update the CHANGELOG to reflect the changes made in the new release.
 - Make a PR to merge your release branch into `master`
-- Give the PR a semver-compliant label, e.g., (`patch`, `minor`, `major`)
+- Give the PR a semver-compliant label, e.g., (`patch`, `minor`, `major`).  This may happen automatically via Github actions (if a labeler action is configured).
 - When the PR is merged to `master`, a new tag will be created automatically, bumping the version by the semver label.
-- The github action is built from: (semver-release-action)[https://github.com/K-Phoen/semver-release-action], and further documentation is available there.
+- The github action is built from: [semver-release-action](https://github.com/K-Phoen/semver-release-action), and further documentation is available there.
 
 
 Troubleshooting

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Stanford Profile](https://github.com/SU-SWS/stanford_profile)
 ##### 8.x
 
-Maintainers: [Mike Decker](https://github.com/pookmish), [sherakama](https://github.com/sherakama)  
+Maintainers: [Mike Decker](https://github.com/pookmish), [sherakama](https://github.com/sherakama)
 
 Changelog: [Changelog.md](CHANGELOG.md)
 
@@ -24,6 +24,18 @@ Configuration
 ---
 
 Nothing special needed.
+
+Releases
+---
+
+Steps to build a new release:
+- Checkout the latest commit from the `8.x-1.x` branch.
+- Create a new branch, e.g., `release-8.1.6`.
+- Update the `composer.json` file to use the latest tagged release of all `su-sws` packages, eliminating the `@dev` dependencies.
+- Commit your changes to the release branch.
+- Make a PR to merge your release branch into `master`
+- When the PR is merged to `master`, a new tag will be created automatically, bumping the version by 1 semver patch by default.  If you wish, you may bump a minor or major version by including the text `#minor` or `#major` in the PR.
+- The github action is built from: (github-tag-bump)[https://github.com/marketplace/actions/github-tag-bump], and further documentation is available there.
 
 
 Troubleshooting

--- a/composer.json
+++ b/composer.json
@@ -99,15 +99,15 @@
         "drupal/webform": "^5.4",
         "drupal/xmlsitemap": "~1.0@alpha",
         "ext-imagick": "*",
-        "su-sws/jumpstart_ui": "^8.1.0",
-        "su-sws/nobots": "^8.1.0",
-        "su-sws/react_paragraphs": "^8.1.0",
-        "su-sws/stanford_basic": "^8.4.0",
-        "su-sws/stanford_date_formats": "^8.1.0",
-        "su-sws/stanford_fields": "^8.1.0",
-        "su-sws/stanford_image_styles": "^8.1.0",
-        "su-sws/stanford_ssp": "^8.1.1",
-        "su-sws/stanford_text_editor": "^8.1.0"
+        "su-sws/jumpstart_ui": "dev-8.x-1.x@dev",
+        "su-sws/nobots": "dev-8.x-2.x@dev",
+        "su-sws/react_paragraphs": "dev-8.x-1.x@dev",
+        "su-sws/stanford_basic": "dev-8.x-4.x@dev",
+        "su-sws/stanford_date_formats": "dev-8.x-1.x@dev",
+        "su-sws/stanford_fields": "dev-8.x-1.x@dev",
+        "su-sws/stanford_image_styles": "dev-8.x-1.x@dev",
+        "su-sws/stanford_ssp": "dev-8.x-1.x@dev",
+        "su-sws/stanford_text_editor": "dev-8.x-1.x@dev"
     },
     "extra": {
         "patches": {

--- a/composer.json
+++ b/composer.json
@@ -99,15 +99,15 @@
         "drupal/webform": "^5.4",
         "drupal/xmlsitemap": "~1.0@alpha",
         "ext-imagick": "*",
-        "su-sws/jumpstart_ui": "dev-8.x-1.x@dev",
-        "su-sws/nobots": "dev-8.x-2.x@dev",
-        "su-sws/react_paragraphs": "dev-8.x-1.x@dev",
-        "su-sws/stanford_basic": "dev-8.x-4.x@dev",
-        "su-sws/stanford_date_formats": "dev-8.x-1.x@dev",
-        "su-sws/stanford_fields": "dev-8.x-1.x@dev",
-        "su-sws/stanford_image_styles": "dev-8.x-1.x@dev",
-        "su-sws/stanford_ssp": "dev-8.x-1.x@dev",
-        "su-sws/stanford_text_editor": "dev-8.x-1.x@dev"
+        "su-sws/jumpstart_ui": "dev-8.x-1.x",
+        "su-sws/nobots": "dev-8.x-2.x",
+        "su-sws/react_paragraphs": "dev-8.x-1.x",
+        "su-sws/stanford_basic": "dev-8.x-4.x",
+        "su-sws/stanford_date_formats": "dev-8.x-1.x",
+        "su-sws/stanford_fields": "dev-8.x-1.x",
+        "su-sws/stanford_image_styles": "dev-8.x-1.x",
+        "su-sws/stanford_ssp": "dev-8.x-1.x",
+        "su-sws/stanford_text_editor": "dev-8.x-1.x"
     },
     "extra": {
         "patches": {

--- a/tests/behat/features/Paragraphs/WYSIWYG.feature
+++ b/tests/behat/features/Paragraphs/WYSIWYG.feature
@@ -94,7 +94,7 @@ Feature: WYSIWYG Paragraph
     And I wait for element ".dropzone"
     Then I drop "../../assets/images/logo.jpg" file into dropzone
     And I press "Upload and Continue"
-    And I wait 1 seconds
+    And I for element "input[name*='alt']"
     And I fill in "Alternative text" with "Stanford Logo"
     Then I click the ".ui-dialog-buttonset button:contains('Save and insert')" element
     And I wait for AJAX to finish

--- a/tests/behat/features/Paragraphs/WYSIWYG.feature
+++ b/tests/behat/features/Paragraphs/WYSIWYG.feature
@@ -94,7 +94,7 @@ Feature: WYSIWYG Paragraph
     And I wait for element ".dropzone"
     Then I drop "../../assets/images/logo.jpg" file into dropzone
     And I press "Upload and Continue"
-    And I for element "input[name*='alt']"
+    And I wait for element "input[name*='alt']"
     And I fill in "Alternative text" with "Stanford Logo"
     Then I click the ".ui-dialog-buttonset button:contains('Save and insert')" element
     And I wait for AJAX to finish


### PR DESCRIPTION


# READY FOR REVIEW

# Summary
- Changed composer to use @dev versions of su-sws packages, added tag_commits_to_master github action, updated readme.
- This PR establishes the `8.x-1.x` branch as our development branch, and changes the release process.
- The new process is to cut a release branch from the latest commit on `8.x-1.x` branch.  Then, update the composer.json file to require the latest tagged versions of the SU-SWS packages, eliminating the `@dev` dependencies.  Then, open a PR to merge the release branch to `master`.  Upon a successful merge to `master`, a new tag will be created to bump the semver here by 1 patch increment.  If you wish to bump it by a minor or major version, include the text `#minor` or `#major` in the PR for the release branch.

# Needed By (Date)
- for 1.1.0 release

# Urgency
- Medium.

# Steps to Test

1. Use this branch in your stack repo.  Run a `composer update --prefer-source`.  Observe that it correctly pulls in the dev versions of our SU-SWS packages.
2. Once merged, open a PR to merge to `master`.  Note that a new semver patch tag is correctly applied.

# Affected Projects or Products
- it indirectly affects acsf-cardinalsites, and because it's pulling in dev versions, it also indirectly affects the SU-SWS dependencies called for in the composer.json

# Associated Issues and/or People
- D8CORE-1664, D8CORE-1475

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
