### PR TITLE
D8CORE-1197 Added google form media type

### DIFF
--- a/config/sync/core.entity_form_display.media.google_form.default.yml
+++ b/config/sync/core.entity_form_display.media.google_form.default.yml
@@ -1,0 +1,60 @@
+uuid: 84b810f0-d451-4792-b08e-09e64af9d278
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.google_form.field_media_google_form
+    - media.type.google_form
+  module:
+    - path
+id: media.google_form.default
+targetEntityType: media
+bundle: google_form
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_media_google_form:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 100
+    region: content
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_form_display.media.google_form.media_library.yml
+++ b/config/sync/core.entity_form_display.media.google_form.media_library.yml
@@ -1,0 +1,27 @@
+uuid: bcd212c6-bef7-4879-9b63-4f49ddebfe19
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.google_form.field_media_google_form
+    - media.type.google_form
+id: media.google_form.media_library
+targetEntityType: media
+bundle: google_form
+mode: media_library
+content:
+  name:
+    type: string_textfield
+    settings:
+      size: 60
+      placeholder: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_media_google_form: true
+  path: true
+  status: true
+  uid: true

--- a/config/sync/core.entity_view_display.media.google_form.default.yml
+++ b/config/sync/core.entity_view_display.media.google_form.default.yml
@@ -1,0 +1,26 @@
+uuid: bad0b056-8551-49ab-8133-ee953293b21e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.media.google_form.field_media_google_form
+    - media.type.google_form
+  module:
+    - stanford_media
+id: media.google_form.default
+targetEntityType: media
+bundle: google_form
+mode: default
+content:
+  field_media_google_form:
+    label: visually_hidden
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: google_form_formatter
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/sync/core.entity_view_display.media.google_form.media_library.yml
+++ b/config/sync/core.entity_view_display.media.google_form.media_library.yml
@@ -1,0 +1,30 @@
+uuid: c8647050-26bf-40f7-ac8a-9925691d2cc2
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.google_form.field_media_google_form
+    - image.style.medium
+    - media.type.google_form
+  module:
+    - image
+id: media.google_form.media_library
+targetEntityType: media
+bundle: google_form
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_style: medium
+      image_link: ''
+    weight: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_media_google_form: true
+  name: true
+  uid: true

--- a/config/sync/field.field.media.google_form.field_media_google_form.yml
+++ b/config/sync/field.field.media.google_form.field_media_google_form.yml
@@ -10,7 +10,7 @@ field_name: field_media_google_form
 entity_type: media
 bundle: google_form
 label: 'Google Form'
-description: ''
+description: 'Forms can only be embedded if they do <strong>not</strong> have any file upload fields. Please ensure your form doesn''t have any of these fields.'
 required: true
 translatable: true
 default_value: {  }

--- a/config/sync/field.field.media.google_form.field_media_google_form.yml
+++ b/config/sync/field.field.media.google_form.field_media_google_form.yml
@@ -1,0 +1,19 @@
+uuid: 261a9641-b807-4f52-ac12-f3451c4953f6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_google_form
+    - media.type.google_form
+id: media.google_form.field_media_google_form
+field_name: field_media_google_form
+entity_type: media
+bundle: google_form
+label: 'Google Form'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.media.field_media_google_form.yml
+++ b/config/sync/field.storage.media.field_media_google_form.yml
@@ -1,0 +1,21 @@
+uuid: c4986e94-7e3d-4dcf-86f9-62732bc30027
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_media_google_form
+field_name: field_media_google_form
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/media.type.google_form.yml
+++ b/config/sync/media.type.google_form.yml
@@ -1,0 +1,19 @@
+uuid: 3fa71289-2f90-4711-8759-7f5870260389
+langcode: en
+status: true
+dependencies:
+  module:
+    - crop
+    - stanford_media
+third_party_settings:
+  crop:
+    image_field: null
+id: google_form
+label: 'Google Form'
+description: 'Public shared <a href="http://forms.google.com">Google Form</a>'
+source: google_form
+queue_thumbnail_downloads: false
+new_revision: false
+source_configuration:
+  source_field: field_media_google_form
+field_map: {  }

--- a/config/sync/seckit.settings.yml
+++ b/config/sync/seckit.settings.yml
@@ -1,0 +1,55 @@
+seckit_xss:
+  csp:
+    checkbox: false
+    vendor-prefix:
+      x: false
+      webkit: false
+    report-only: false
+    default-src: ''
+    script-src: ''
+    object-src: ''
+    img-src: ''
+    media-src: ''
+    frame-src: ''
+    frame-ancestors: ''
+    child-src: ''
+    font-src: ''
+    connect-src: ''
+    report-uri: /report-csp-violation
+    upgrade-req: false
+    policy-uri: ''
+  x_xss:
+    seckit_x_xss_option_disable: Disabled
+    seckit_x_xss_option_0: '0'
+    seckit_x_xss_option_1: 1;
+    seckit_x_xss_option_1_block: '1; mode=block'
+    select: 0
+seckit_csrf:
+  origin: false
+  origin_whitelist: ''
+seckit_clickjacking:
+  js_css_noscript: false
+  noscript_message: 'Sorry, you need to enable JavaScript to visit this website.'
+  x_frame: '1'
+  x_frame_allow_from: ''
+seckit_ssl:
+  hsts: false
+  hsts_subdomains: false
+  hsts_max_age: 1000
+  hsts_preload: false
+seckit_ct:
+  expect_ct: false
+  max_age: 86400
+  report_uri: ''
+  enforce: false
+seckit_fp:
+  feature_policy: false
+  feature_policy_policy: ''
+seckit_various:
+  from_origin: false
+  from_origin_destination: same
+  referrer_policy: false
+  referrer_policy_policy: no-referrer-when-downgrade
+  disable_autocomplete: false
+_core:
+  default_config_hash: x6bhN6WZwfVUI_LLMvRJIUW_2c26VTaBozbfXmJWmro


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- this is dependent on https://github.com/SU-SWS/stanford_media/pull/49
- New media type for google forms

# Need Review By (Date)
- 4/15

# Urgency
- medium

# Steps to Test
1. checkout the branch in stanford_basic
1. checkout this branch
1. clear cache
1. `drush cim -y`
1. a page with a wysiwyg and add a google form.
1. validate it embeds.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)

