### PR TITLE
D8CORE-1847 fix link text getting encoded

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -129,7 +129,7 @@
         "drupal/webform": "^5.4",
         "drupal/xmlsitemap": "~1.0@alpha",
         "ext-imagick": "*",
-        "su-sws/jumpstart_ui": "dev-D8CORE-1847",
+        "su-sws/jumpstart_ui": "dev-8.x-1.x",
         "su-sws/nobots": "dev-8.x-2.x",
         "su-sws/react_paragraphs": "dev-8.x-1.x",
         "su-sws/stanford_basic": "dev-8.x-4.x",

--- a/composer.json
+++ b/composer.json
@@ -129,7 +129,7 @@
         "drupal/webform": "^5.4",
         "drupal/xmlsitemap": "~1.0@alpha",
         "ext-imagick": "*",
-        "su-sws/jumpstart_ui": "dev-8.x-1.x",
+        "su-sws/jumpstart_ui": "dev-D8CORE-1847",
         "su-sws/nobots": "dev-8.x-2.x",
         "su-sws/react_paragraphs": "dev-8.x-1.x",
         "su-sws/stanford_basic": "dev-8.x-4.x",

--- a/modules/stanford_paragraph_card/stanford_paragraph_card.module
+++ b/modules/stanford_paragraph_card/stanford_paragraph_card.module
@@ -55,10 +55,28 @@ function stanford_paragraph_card_preprocess_ds_entity_view(array &$variables) {
     $variables['content']['#ds_configuration']['regions']['card_cta_label'] = $label;
 
     // Move the fields.
-    $variables['content']['#fields']['card_cta_label']['display_field_copy:paragraph-su_card_link_title'] = $variables['content']['display_field_copy:paragraph-su_card_link_title'];
+    $variables['content']['#fields']['card_cta_label'] = $variables['content']['#fields']['card_button_label'];
 
+    array_walk($variables['content']['#fields']['card_cta_label'], '_stanford_paragraph_card_decode_markup');
     // Unset the cruft.
     unset($variables['content']['#fields']['card_button_label']);
     unset($variables['content']['#ds_configuration']['regions']['card_button_label']);
   }
+}
+
+/**
+ * Decode markup strings in nested arrays.
+ *
+ * @param mixed $data
+ *   Array to decode.
+ */
+function _stanford_paragraph_card_decode_markup(&$data) {
+  if (!is_array($data)) {
+    return;
+  }
+  if (isset($data['#markup']) && is_string($data['#markup'])) {
+    $data['#markup'] = html_entity_decode($data['#markup'], ENT_QUOTES);
+    return;
+  }
+  array_walk($data, '_stanford_paragraph_card_decode_markup');
 }

--- a/modules/stanford_paragraph_card/stanford_paragraph_card.module
+++ b/modules/stanford_paragraph_card/stanford_paragraph_card.module
@@ -57,26 +57,8 @@ function stanford_paragraph_card_preprocess_ds_entity_view(array &$variables) {
     // Move the fields.
     $variables['content']['#fields']['card_cta_label'] = $variables['content']['#fields']['card_button_label'];
 
-    array_walk($variables['content']['#fields']['card_cta_label'], '_stanford_paragraph_card_decode_markup');
     // Unset the cruft.
     unset($variables['content']['#fields']['card_button_label']);
     unset($variables['content']['#ds_configuration']['regions']['card_button_label']);
   }
-}
-
-/**
- * Decode markup strings in nested arrays.
- *
- * @param mixed $data
- *   Array to decode.
- */
-function _stanford_paragraph_card_decode_markup(&$data) {
-  if (!is_array($data)) {
-    return;
-  }
-  if (isset($data['#markup']) && is_string($data['#markup'])) {
-    $data['#markup'] = html_entity_decode($data['#markup'], ENT_QUOTES);
-    return;
-  }
-  array_walk($data, '_stanford_paragraph_card_decode_markup');
 }

--- a/tests/codeception/acceptance/Paragraphs/StanfordCardCest.php
+++ b/tests/codeception/acceptance/Paragraphs/StanfordCardCest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Codeception tests on card paragraph type.
+ */
+class StanfordCardCest {
+
+  /**
+   * Test a card with a button link.
+   */
+  public function testCardButtonLinkText(\AcceptanceTester $I) {
+    $node = $this->createNodeWithLink($I);
+    $I->amOnPage($node->toUrl()->toString());
+    $I->canSeeLink('It\'s a "test" link & title', 'http://google.com');
+  }
+
+  /**
+   * Test a card with an action link.
+   */
+  public function testCardActionLinkText(\AcceptanceTester $I) {
+    $node = $this->createNodeWithLink($I, 'action');
+    $I->amOnPage($node->toUrl()->toString());
+    $I->canSeeLink('It\'s a "test" link & title', 'http://google.com');
+  }
+
+  /**
+   * Generate a node with a paragraph that contains a link.
+   */
+  protected function createNodeWithLink(\AcceptanceTester $I, $link_type = 'button') {
+    /** @var \Drupal\paragraphs\ParagraphInterface $paragraph */
+    $paragraph = $I->createEntity([
+      'type' => 'stanford_card',
+      'su_card_link' => [
+        'uri' => 'http://google.com',
+        'title' => 'It\'s a "test" link & title',
+      ],
+      'su_card_link_display' => $link_type,
+    ], 'paragraph');
+
+    $node = $I->createEntity([
+      'type' => 'stanford_page',
+      'title' => 'Test Card Links',
+      'su_page_components' => [
+        'target_id' => $paragraph->id(),
+        'entity' => $paragraph,
+        'settings' => json_encode([
+          'row' => 0,
+          'index' => 0,
+          'width' => 12,
+          'admin_title' => 'Card',
+        ]),
+      ],
+    ]);
+    // Clear router and menu cache so that the node urls work.
+    $I->runDrush('cache-clear router');
+    return $node;
+  }
+
+}


### PR DESCRIPTION
# NOT READY FOR REVIEW

# Summary
- Decode html entities and quotes when the Display Suite cloned field is used.
- I have a feeling this is going to happen often.
- first commit in this PR was the test alone. following commits resolved the test.

# Need Review By (Date)
- 4/22

# Urgency
- high

# Steps to Test
1. checkout this branch
1. create a card and for the link text put some quotes in.
1. choose "Button" for the link style
1. Save and verify the quotes look correct
1. change the button style to action
1. verify the quotes still look correct

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
