### PR TITLE
D8CORE-1852 Setup node revision delete on stanford_page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,6 +112,7 @@
         "drupal/menu_link_weight": "^1.0-beta3",
         "drupal/menu_position": "~1.0@alpha",
         "drupal/metatag": "~1.3",
+        "drupal/node_revision_delete": "^1.0@RC",
         "drupal/paragraph_blocks": "~2.1@beta",
         "drupal/paragraphs": "^1.11",
         "drupal/paragraphs_edit": "^2.0@alpha",

--- a/config/sync/core.entity_view_display.node.stanford_page.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_page.default.yml
@@ -27,6 +27,7 @@ third_party_settings:
         layout_settings:
           extra_classes: ''
           centered: null
+          columns: default
         components:
           da20ed40-0f0f-4103-bda1-29d84c24975f:
             uuid: da20ed40-0f0f-4103-bda1-29d84c24975f
@@ -53,6 +54,7 @@ third_party_settings:
         layout_settings:
           extra_classes: ''
           centered: centered-container
+          columns: default
         components:
           af0809fe-fe61-4e78-be4e-4837cd773c26:
             uuid: af0809fe-fe61-4e78-be4e-4837cd773c26
@@ -79,6 +81,7 @@ third_party_settings:
         layout_settings:
           extra_classes: ''
           centered: centered-container
+          orientation: right
         components:
           582a6898-7096-40c2-bb65-99a556ada919:
             uuid: 582a6898-7096-40c2-bb65-99a556ada919

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -80,6 +80,7 @@ module:
   metatag_verification: 0
   nobots: 0
   node: 0
+  node_revision_delete: 0
   options: 0
   page_cache: 0
   paragraphs_edit: 0

--- a/config/sync/node.type.stanford_page.yml
+++ b/config/sync/node.type.stanford_page.yml
@@ -4,11 +4,16 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - node_revision_delete
 third_party_settings:
   menu_ui:
     available_menus:
       - main
     parent: 'main:'
+  node_revision_delete:
+    minimum_revisions_to_keep: 5
+    minimum_age_to_delete: 0
+    when_to_delete: 0
 name: 'Basic Page'
 type: stanford_page
 description: ''

--- a/config/sync/node_revision_delete.settings.yml
+++ b/config/sync/node_revision_delete.settings.yml
@@ -1,0 +1,10 @@
+node_revision_delete_cron: 50
+node_revision_delete_time: 0
+node_revision_delete_minimum_age_to_delete_time:
+  max_number: 6
+  time: months
+node_revision_delete_when_to_delete_time:
+  max_number: 6
+  time: months
+_core:
+  default_config_hash: Pxmt-VsuXAuxxpRjBCrKQOxetjgmBAE2DfSD7s276UM

--- a/tests/codeception/acceptance/Contrib/NodeRevisionDeleteCest.php
+++ b/tests/codeception/acceptance/Contrib/NodeRevisionDeleteCest.php
@@ -3,10 +3,25 @@
 class NodeRevisionDeleteCest {
 
   public function testNodeRevisionDelete(AcceptanceTester $I) {
+    $I->logInWithRole('administrator');
+    /** @var \Drupal\node\NodeInterface $node */
     $node = $I->createEntity([
       'type' => 'stanford_page',
       'title' => 'revision test',
+      'revision' => TRUE,
     ]);
+    for ($j = 0; $j < 10; $j++) {
+      $node->setNewRevision();
+      $node->setRevisionLogMessage("Revision $j");
+      $node->setRevisionCreationTime(time() - ($j * 30));
+      $node->set('revision_translation_affected', TRUE);
+      $node->save();
+    }
+    $I->amOnPage("/node/{$node->id()}/revisions");
+    $I->canSeeNumberOfElements('.node-revision-table tbody tr', 11);
+    $I->runDrush('node-revision-delete stanford_page');
+    $I->amOnPage("/node/{$node->id()}/revisions");
+    $I->canSeeNumberOfElements('.node-revision-table tbody tr', 5);
   }
 
 }

--- a/tests/codeception/acceptance/Contrib/NodeRevisionDeleteCest.php
+++ b/tests/codeception/acceptance/Contrib/NodeRevisionDeleteCest.php
@@ -1,0 +1,12 @@
+<?php
+
+class NodeRevisionDeleteCest {
+
+  public function testNodeRevisionDelete(AcceptanceTester $I) {
+    $node = $I->createEntity([
+      'type' => 'stanford_page',
+      'title' => 'revision test',
+    ]);
+  }
+
+}

--- a/tests/codeception/acceptance/Contrib/NodeRevisionDeleteCest.php
+++ b/tests/codeception/acceptance/Contrib/NodeRevisionDeleteCest.php
@@ -1,7 +1,13 @@
 <?php
 
+/**
+ * Test the node revision delete module functionality.
+ */
 class NodeRevisionDeleteCest {
 
+  /**
+   * Test that revisions are trimmed after cron runs.
+   */
   public function testNodeRevisionDelete(AcceptanceTester $I) {
     $I->logInWithRole('administrator');
     /** @var \Drupal\node\NodeInterface $node */

--- a/tests/codeception/acceptance/Contrib/NodeRevisionDeleteCest.php
+++ b/tests/codeception/acceptance/Contrib/NodeRevisionDeleteCest.php
@@ -19,7 +19,7 @@ class NodeRevisionDeleteCest {
     }
     $I->amOnPage("/node/{$node->id()}/revisions");
     $I->canSeeNumberOfElements('.node-revision-table tbody tr', 11);
-    $I->runDrush('node-revision-delete stanford_page');
+    $I->runDrush('cron');
     $I->amOnPage("/node/{$node->id()}/revisions");
     $I->canSeeNumberOfElements('.node-revision-table tbody tr', 5);
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Setup node revision delete module and configuration

# Need Review By (Date)
- 4/29

# Urgency
- medium

# Steps to Test
1. `composer require su-sws/stanford_profile:dev-D8CORE-1852`
1. `drush cim -y`
1. create a node and edit it at least 5 times to generate the different revisions
1. `drush cron`
1. verify you are left with 5 revisions on the node

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
