### PR TITLE
D8CORE-1458 Add media to linkit suggestions for inline links

### DIFF
--- a/config/sync/linkit.linkit_profile.default.yml
+++ b/config/sync/linkit.linkit_profile.default.yml
@@ -21,3 +21,14 @@ matchers:
       include_unpublished: false
       substitution_type: canonical
       limit: 100
+  4276c456-af46-418e-b628-4221c799416f:
+    uuid: 4276c456-af46-418e-b628-4221c799416f
+    id: 'entity:media'
+    weight: 0
+    settings:
+      metadata: '[media:field_media_file:entity:basename]: [media:field_media_file:entity:mime]'
+      bundles:
+        file: file
+      group_by_bundle: false
+      substitution_type: media
+      limit: 20

--- a/tests/codeception/acceptance/MediaCest.php
+++ b/tests/codeception/acceptance/MediaCest.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Tests for various media functionality.
+ */
+class MediaCest {
+
+  /**
+   * Documents can be embedded as links.
+   */
+  public function testFileLinks(AcceptanceTester $I) {
+    $I->logInWithRole('administrator');
+    $I->amOnPage('/admin/config/content/linkit/manage/default/matchers');
+    $I->canSee('Metadata: [media:field_media_file:entity:basename]: [media:field_media_file:entity:mime]');
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add file media bundles to linkit autocomplete

# Need Review By (Date)
- 4/29

# Urgency
- medium

# Steps to Test
1. checkout this branch
1. `drush cim -y`
1. go to a wysiwyg and upload a pdf or word doc or something via the media library
1. don't "insert" the media
1. highlight some text and click the link button
1. start typing the name of your file and click the suggestion
1. save the page and validate the path to the file is correct on the link.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
