### PR TITLE
Fix misspelled eduPersonEntitlement

### DIFF
--- a/config/sync/field.field.config_pages.stanford_saml.su_simplesaml_roles.yml
+++ b/config/sync/field.field.config_pages.stanford_saml.su_simplesaml_roles.yml
@@ -15,7 +15,7 @@ required: false
 translatable: false
 default_value:
   -
-    value: 'administrator:eduPersonEnttitlement,=,uit:sws'
+    value: 'administrator:eduPersonEntitlement,=,uit:sws'
 default_value_callback: ''
 settings: {  }
 field_type: string_long

--- a/config/sync/simplesamlphp_auth.settings.yml
+++ b/config/sync/simplesamlphp_auth.settings.yml
@@ -8,7 +8,7 @@ auth_source: default-sp
 login_link_display_name: 'SUNetID Login'
 header_no_cache: true
 role:
-  population: 'administrator:eduPersonEnttitlement,=,uit:sws'
+  population: 'administrator:eduPersonEntitlement,=,uit:sws'
   eval_every_time: 2
 register_users: true
 allow:

--- a/config/sync/stanford_ssp.settings.yml
+++ b/config/sync/stanford_ssp.settings.yml
@@ -1,4 +1,4 @@
-saml_attribute: eduPersonEnttitlement
+saml_attribute: eduPersonEntitlement
 workgroup_api_url: 'https://workgroupsvc.stanford.edu/v1/workgroups'
 use_workgroup_api: true
 hide_local_login: true


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fix misspelled eduPersonEntitlement

eduPersonEnttitlement => eduPersonEntitlement

Might also need to update user guide:
https://userguide.sites.stanford.edu/tour/site-organization-menus/managing-user-accounts/how-add-workgroup-role-mapping
