### PR TITLE
Added stanford notifications module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,7 +137,7 @@
         "su-sws/stanford_date_formats": "dev-8.x-1.x",
         "su-sws/stanford_fields": "dev-8.x-1.x",
         "su-sws/stanford_image_styles": "dev-8.x-1.x",
-        "su-sws/stanford_notifications": "dev-use-decanter-alerts",
+        "su-sws/stanford_notifications": "dev-8.x-1.x",
         "su-sws/stanford_ssp": "dev-8.x-1.x",
         "su-sws/stanford_text_editor": "dev-8.x-1.x"
     },

--- a/composer.json
+++ b/composer.json
@@ -137,6 +137,7 @@
         "su-sws/stanford_date_formats": "dev-8.x-1.x",
         "su-sws/stanford_fields": "dev-8.x-1.x",
         "su-sws/stanford_image_styles": "dev-8.x-1.x",
+        "su-sws/stanford_notifications": "dev-8.x-1.x",
         "su-sws/stanford_ssp": "dev-8.x-1.x",
         "su-sws/stanford_text_editor": "dev-8.x-1.x"
     },

--- a/composer.json
+++ b/composer.json
@@ -137,7 +137,7 @@
         "su-sws/stanford_date_formats": "dev-8.x-1.x",
         "su-sws/stanford_fields": "dev-8.x-1.x",
         "su-sws/stanford_image_styles": "dev-8.x-1.x",
-        "su-sws/stanford_notifications": "dev-8.x-1.x",
+        "su-sws/stanford_notifications": "dev-use-decanter-alerts",
         "su-sws/stanford_ssp": "dev-8.x-1.x",
         "su-sws/stanford_text_editor": "dev-8.x-1.x"
     },

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -101,6 +101,7 @@ module:
   stanford_fields: 0
   stanford_image_styles: 0
   stanford_media: 0
+  stanford_notifications: 0
   stanford_paragraph_card: 0
   stanford_profile_drush: 0
   stanford_profile_styles: 0

--- a/config/sync/layout_library.layout.stanford_basic_page_full.yml
+++ b/config/sync/layout_library.layout.stanford_basic_page_full.yml
@@ -12,6 +12,7 @@ layout:
     layout_settings:
       extra_classes: ''
       centered: null
+      columns: default
     components:
       4fba82f7-8808-4c93-95d9-7ecdde2fb0b1:
         uuid: 4fba82f7-8808-4c93-95d9-7ecdde2fb0b1
@@ -37,6 +38,7 @@ layout:
     layout_settings:
       extra_classes: ''
       centered: centered-container
+      columns: default
     components:
       6ce9c0ce-a019-44f4-9225-4c2a1a9fbc6d:
         uuid: 6ce9c0ce-a019-44f4-9225-4c2a1a9fbc6d
@@ -62,6 +64,7 @@ layout:
     layout_settings:
       extra_classes: ''
       centered: null
+      columns: default
     components:
       d23da6c4-a596-41c2-8185-cd712c160306:
         uuid: d23da6c4-a596-41c2-8185-cd712c160306

--- a/stanford_profile.post_update.php
+++ b/stanford_profile.post_update.php
@@ -95,3 +95,18 @@ function stanford_profile_post_update_8003() {
   }
   $view_display->save();
 }
+
+/**
+ * Send out notification message about news and person content types.
+ */
+function stanford_profile_post_update_8013() {
+  \Drupal::service('module_installer')->install(['stanford_notifications']);
+  /** @var \Drupal\stanford_notifications\NotificationServiceInterface $notifications */
+  $notifications = \Drupal::service('notification_service');
+
+  $message = 'You can now create "News" content. See <a href="https://userguide.sites.stanford.edu/tour/news">the user guide</a> for more information';
+  $notifications->addNotification($message, ['site_manager', 'contributor']);
+
+  $message = 'You can now create "Person" content. See <a href="https://userguide.sites.stanford.edu/tour/person">the user guide</a> for more information';
+  $notifications->addNotification($message, ['site_manager', 'contributor']);
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added stanford_notification module and add notification for news and person

# Need Review By (Date)
- tomorrow

# Urgency
- high

# Steps to Test
1. checkout `8.x-1.x` branch and install a site and create/edit a site manager or contributor 
1. then `composer require su-sws/stanford_profile:dev-notification-module`
1. `blt drupal:update`
1. disable saml so you can log in as a site manager or contributor
1. view the site as an existing site manager or contributor
1. verify there are 2 new notifications for the user.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
