### PR TITLE
D8CORE-000: Changed headline on news to 180 max from 70.

### DIFF
--- a/config/sync/field.field.node.stanford_news.su_news_headline.yml
+++ b/config/sync/field.field.node.stanford_news.su_news_headline.yml
@@ -10,7 +10,7 @@ field_name: su_news_headline
 entity_type: node
 bundle: stanford_news
 label: Headline
-description: 'Maximum 70 characters.'
+description: 'Maximum 255 characters.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.stanford_news.su_news_headline.yml
+++ b/config/sync/field.field.node.stanford_news.su_news_headline.yml
@@ -10,7 +10,7 @@ field_name: su_news_headline
 entity_type: node
 bundle: stanford_news
 label: Headline
-description: 'Maximum 255 characters.'
+description: 'Maximum 180 characters.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.storage.node.su_news_headline.yml
+++ b/config/sync/field.storage.node.su_news_headline.yml
@@ -9,7 +9,7 @@ field_name: su_news_headline
 entity_type: node
 type: string
 settings:
-  max_length: 255
+  max_length: 180
   is_ascii: false
   case_sensitive: false
 module: core

--- a/config/sync/field.storage.node.su_news_headline.yml
+++ b/config/sync/field.storage.node.su_news_headline.yml
@@ -9,7 +9,7 @@ field_name: su_news_headline
 entity_type: node
 type: string
 settings:
-  max_length: 70
+  max_length: 255
   is_ascii: false
   case_sensitive: false
 module: core


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Changed max chars on headline field

# Needed By (Date)
- Asap

# Urgency
- High

# Steps to Test

1. Check out this branch and do a `drush cim` or a full install
2. Validate that the headline field on news items is 180 chars and not 70.

# Affected Projects or Products
- D8CORE

# Associated Issues and/or People
- https://github.com/SU-SWS/stanford_news/pull/79

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
