### PR TITLE
D8CORE-000: Set media with caption and wysiwyg to 3 in a row.

### DIFF
--- a/config/sync/core.entity_form_display.node.stanford_page.default.yml
+++ b/config/sync/core.entity_form_display.node.stanford_page.default.yml
@@ -78,7 +78,7 @@ content:
   su_page_components:
     weight: 9
     settings:
-      items_per_row: 4
+      items_per_row: 3
       resizable: false
     third_party_settings: {  }
     type: react_paragraphs

--- a/config/sync/field.field.node.stanford_page.su_page_components.yml
+++ b/config/sync/field.field.node.stanford_page.su_page_components.yml
@@ -44,7 +44,7 @@ settings:
       stanford_card:
         min: '4'
       stanford_media_caption:
-        min: '3'
+        min: '4'
       stanford_wysiwyg:
-        min: '3'
+        min: '4'
 field_type: react_paragraphs

--- a/stanford_profile.post_update.php
+++ b/stanford_profile.post_update.php
@@ -118,10 +118,17 @@ function stanford_profile_post_update_8013() {
     'contributor',
   ]);
 
-  $message = 'Update: All Paragraphs within a page will now support a maximum of 3 items per row where some allowed 4 items before. Any existing layouts with 4 items in a row will be grandfathered in but new content will be limited to 3 items per row.';
-  $notifications->addNotification($message, [
-    'site_manager',
-    'site_editor',
-    'contributor',
-  ]);
+  $database = \Drupal::database();
+  $query = $database->select('node_revision__su_page_components', 'nrspc');
+  $query->condition('nrspc.su_page_components_settings', '%"index":3%', 'LIKE');
+  $num_rows = $query->countQuery()->execute()->fetchField();
+  if ($num_rows >= 1) {
+    $message = 'Update: All Paragraphs within a page will now support a maximum of 3 items per row where some allowed 4 items before. Any existing layouts with 4 items in a row will be grandfathered in but new content will be limited to 3 items per row.';
+    $notifications->addNotification($message, [
+      'site_manager',
+      'site_editor',
+      'contributor',
+    ]);
+  }
+
 }

--- a/stanford_profile.post_update.php
+++ b/stanford_profile.post_update.php
@@ -105,11 +105,23 @@ function stanford_profile_post_update_8013() {
   $notifications = \Drupal::service('notification_service');
 
   $message = 'New: You can now create "News" content. See <a href="https://userguide.sites.stanford.edu/tour/news">the user guide</a> for more information';
-  $notifications->addNotification($message, ['site_manager', 'site_editor', 'contributor']);
+  $notifications->addNotification($message, [
+    'site_manager',
+    'site_editor',
+    'contributor',
+  ]);
 
   $message = 'New: You can now create "Person" content. See <a href="https://userguide.sites.stanford.edu/tour/person">the user guide</a> for more information';
-  $notifications->addNotification($message, ['site_manager', 'site_editor', 'contributor']);
+  $notifications->addNotification($message, [
+    'site_manager',
+    'site_editor',
+    'contributor',
+  ]);
 
   $message = 'Update: All Paragraphs within a page will now support a maximum of 3 items per row where some allowed 4 items before. Any existing layouts with 4 items in a row will be grandfathered in but new content will be limited to 3 items per row.';
-  $notifications->addNotification($message, ['site_manager', 'site_editor', 'contributor']);
+  $notifications->addNotification($message, [
+    'site_manager',
+    'site_editor',
+    'contributor',
+  ]);
 }

--- a/stanford_profile.post_update.php
+++ b/stanford_profile.post_update.php
@@ -104,9 +104,12 @@ function stanford_profile_post_update_8013() {
   /** @var \Drupal\stanford_notifications\NotificationServiceInterface $notifications */
   $notifications = \Drupal::service('notification_service');
 
-  $message = 'You can now create "News" content. See <a href="https://userguide.sites.stanford.edu/tour/news">the user guide</a> for more information';
-  $notifications->addNotification($message, ['site_manager', 'contributor']);
+  $message = 'New: You can now create "News" content. See <a href="https://userguide.sites.stanford.edu/tour/news">the user guide</a> for more information';
+  $notifications->addNotification($message, ['site_manager', 'site_editor', 'contributor']);
 
-  $message = 'You can now create "Person" content. See <a href="https://userguide.sites.stanford.edu/tour/person">the user guide</a> for more information';
-  $notifications->addNotification($message, ['site_manager', 'contributor']);
+  $message = 'New: You can now create "Person" content. See <a href="https://userguide.sites.stanford.edu/tour/person">the user guide</a> for more information';
+  $notifications->addNotification($message, ['site_manager', 'site_editor', 'contributor']);
+
+  $message = 'Update: All Paragraphs within a page will now support a maximum of 3 items per row where some allowed 4 items before. Any existing layouts with 4 items in a row will be grandfathered in but new content will be limited to 3 items per row.';
+  $notifications->addNotification($message, ['site_manager', 'site_editor', 'contributor']);
 }


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Sets all react paragraphs to max of 3 in a row.
- Adds notification to all user types for max-of-3

# Needed By (Date)
- ASAP

# Urgency
- Today

# Steps to Test

1.  Check out this branch
2. Import config
3. Try to place items more than 3.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
