### PR TITLE
changed label from body to description on card

### DIFF
--- a/config/sync/field.field.paragraph.stanford_card.su_card_body.yml
+++ b/config/sync/field.field.paragraph.stanford_card.su_card_body.yml
@@ -17,7 +17,7 @@ id: paragraph.stanford_card.su_card_body
 field_name: su_card_body
 entity_type: paragraph
 bundle: stanford_card
-label: Body
+label: Description
 description: 'The main text of the card.'
 required: false
 translatable: false


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changing the label on the card paragraph's wysiwyg field

# Needed By (Date)
- 5/21/2020

# Urgency
- low

# Steps to Test

1. Install stanford_profile using this branch and verify label is: "Description"

# Affected Projects or Products
- card authoring on stanford card

# Associated Issues and/or People
- D8CORE-2038: Card authoring: change "Body" label to "Description" for the markdown field

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)