### PR TITLE
remove 403 and 404 from xmlsitemap

### DIFF
--- a/stanford_profile.profile
+++ b/stanford_profile.profile
@@ -240,10 +240,10 @@ function stanford_profile_xmlsitemap_link_alter(array &$link, array $context) {
   // Get node/[:id] from loc.
   $node_id = $link['loc'];
 
-  // Get 403 page path
+  // Get 403 page path.
   $stanford_profile_403_page = \Drupal::config('system.site')->get('page.403');
 
-  // Get 404 page path
+  // Get 404 page path.
   $stanford_profile_404_page = \Drupal::config('system.site')->get('page.404');
 
   // If node id matches 403 or 404 pages, remove it from sitemap.

--- a/stanford_profile.profile
+++ b/stanford_profile.profile
@@ -226,3 +226,32 @@ function stanford_profile_config_pages_presave(ConfigPagesInterface $entity) {
     \Drupal::state()->set('xmlsitemap_base_url', $url_field[0]['uri']);
   }
 }
+
+/**
+ * Alter the data of a sitemap link before the link is saved.
+ *
+ * @param array $link
+ *   An array with the data of the sitemap link.
+ * @param array $context
+ *   An optional context array containing data related to the link.
+ */
+function stanford_profile_xmlsitemap_link_alter(array &$link, array $context) {
+
+  // Get node/[:id] from loc.
+  $node_id = $link['loc'];
+
+  // Get 403 page path
+  $stanford_profile_403_page = \Drupal::config('system.site')->get('page.403');
+
+  // Get 404 page path
+  $stanford_profile_404_page = \Drupal::config('system.site')->get('page.404');
+
+  // If node id matches 403 or 404 pages, remove it from sitemap.
+  switch ($node_id) {
+    case $stanford_profile_403_page:
+    case $stanford_profile_404_page:
+      // Status is set to zero to exclude the item in the sitemap.
+      $link['status'] = 0;
+
+  }
+}

--- a/tests/codeception/acceptance/Contrib/XmlsitemapCest.php
+++ b/tests/codeception/acceptance/Contrib/XmlsitemapCest.php
@@ -8,7 +8,7 @@ class XmlsitemapCest {
   /**
    * Test that xmlsitemap is having 403 and 404 pages removed.
    */
-  public function testSoeSitemapLinkAlter(AcceptanceTester $I) {
+  public function testStanfordProfileSitemapLinkAlter(AcceptanceTester $I) {
     $I->logInWithRole('administrator');
     $I->amOnPage("/admin/config/search/xmlsitemap/rebuild");
     $I->click('Save configuration');

--- a/tests/codeception/acceptance/Contrib/XmlsitemapCest.php
+++ b/tests/codeception/acceptance/Contrib/XmlsitemapCest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Test that stanford_profile_xmlsitemap_link_alter is working.
+ */
+class XmlsitemapCest {
+
+  /**
+   * Test that xmlsitemap is having 403 and 404 pages removed.
+   */
+  public function testSoeSitemapLinkAlter(AcceptanceTester $I) {
+    $I->logInWithRole('administrator');
+    $I->amOnPage("/admin/config/search/xmlsitemap/rebuild");
+    $I->click('Save configuration');
+    $I->runDrush('cr');
+    $I->amOnPage("/sitemap.xml");
+    $host = \Drupal::request()->getSchemeAndHttpHost();
+    $soe_profile_403_page = \Drupal::config('system.site')->get('page.403');
+    $alias_403 = \Drupal::service('path.alias_manager')->getAliasByPath($soe_profile_403_page);
+    $soe_profile_404_page = \Drupal::config('system.site')->get('page.404');
+    $alias_404 = \Drupal::service('path.alias_manager')->getAliasByPath($soe_profile_404_page);
+    $I->dontSeeLink($host . $alias_403);
+    $I->dontSeeLink($host . $alias_404);
+  }
+
+}


### PR DESCRIPTION
# NOT READY FOR REVIEW

# Summary
- Removing 403 and 404 pages from xmlsitemap

# Needed By (Date)
- ???

# Urgency
- low

# Steps to Test

1. on a build of lelelandd8 using soe_profile rebuild the xmlsitemap and verify the 403 and 404 pages are not in it.

# Affected Projects or Products
- soe_profile and associated sites

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/D8CORE-2153
- https://stanfordits.atlassian.net/browse/D8CORE-1989

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
