### PR TITLE
D8CORE-2220 Site managers can edit custom blocks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,7 @@
         "drupal/allowed_formats": "~1.1",
         "drupal/better_normalizers": "^1.0-beta3",
         "drupal/block_blacklist": "~1.0",
+        "drupal/block_content_permissions": "^1.8",
         "drupal/chosen": "~2.4",
         "drupal/ckeditor_fixed_toolbar": "dev-1.x#1e4a8191ab289b4c91d9a0f2ac6b40e82e294908",
         "drupal/components": "~1.0",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -8,6 +8,7 @@ module:
   auto_entitylabel: 0
   block: 0
   block_content: 0
+  block_content_permissions: 0
   breakpoint: 0
   chosen: 0
   chosen_lib: 0

--- a/config/sync/page_manager.page_variant.people-layout_builder-0.yml
+++ b/config/sync/page_manager.page_variant.people-layout_builder-0.yml
@@ -84,7 +84,7 @@ variant_settings:
             items_per_page: none
             context_mapping: {  }
           additional: {  }
-          weight: 3
+          weight: 5
         02b79daa-3558-4551-8313-5c6c65aa099c:
           uuid: 02b79daa-3558-4551-8313-5c6c65aa099c
           region: main
@@ -99,6 +99,19 @@ variant_settings:
             context_mapping: {  }
           additional: {  }
           weight: 2
+        8d451cfc-690e-43c1-95a5-e2f357c166a4:
+          uuid: 8d451cfc-690e-43c1-95a5-e2f357c166a4
+          region: main
+          configuration:
+            id: 'views_block:su_block_edit_links-people_intro'
+            label: ''
+            provider: views
+            label_display: '0'
+            views_label: ''
+            items_per_page: none
+            context_mapping: {  }
+          additional: {  }
+          weight: 4
       third_party_settings: {  }
 page: people
 weight: 0

--- a/config/sync/user.role.site_builder.yml
+++ b/config/sync/user.role.site_builder.yml
@@ -144,6 +144,7 @@ permissions:
   - 'select account cancellation method'
   - 'switch shortcut sets'
   - 'update any media'
+  - 'update any stanford_component_block block content'
   - 'update media'
   - 'use advanced search'
   - 'view all media revisions'

--- a/config/sync/user.role.site_developer.yml
+++ b/config/sync/user.role.site_developer.yml
@@ -180,6 +180,7 @@ permissions:
   - 'select account cancellation method'
   - 'switch shortcut sets'
   - 'update any media'
+  - 'update any stanford_component_block block content'
   - 'update media'
   - 'use advanced search'
   - 'view all media revisions'

--- a/config/sync/user.role.site_manager.yml
+++ b/config/sync/user.role.site_manager.yml
@@ -97,6 +97,7 @@ permissions:
   - 'revert stanford_page revisions'
   - 'revert stanford_person revisions'
   - 'update any media'
+  - 'update any stanford_component_block block content'
   - 'update media'
   - 'use advanced search'
   - 'view all media revisions'

--- a/config/sync/views.view.su_block_edit_links.yml
+++ b/config/sync/views.view.su_block_edit_links.yml
@@ -1,0 +1,243 @@
+uuid: 179fc468-4a96-472d-bf37-7f5c0a24c884
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - user
+id: su_block_edit_links
+label: 'Block Edit Links'
+module: views
+description: 'This view is for quick links to edit blocks.'
+tag: ''
+base_table: block_content_field_data
+base_field: id
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'update any stanford_component_block block content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+          contextual_filters_or: false
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: some
+        options:
+          items_per_page: 1
+          offset: 0
+      style:
+        type: default
+      row:
+        type: fields
+      fields:
+        edit_block_content:
+          id: edit_block_content
+          table: block_content
+          field: edit_block_content
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'Edit Block Content Above'
+          output_url_as_text: false
+          absolute: false
+          entity_type: block_content
+          plugin_id: entity_link_edit
+      filters:
+        status:
+          value: '1'
+          table: block_content_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: block_content
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+          group: 1
+        reusable:
+          id: reusable
+          plugin_id: boolean
+          table: block_content_field_data
+          field: reusable
+          value: '1'
+          entity_type: block_content
+          entity_field: reusable
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        uuid:
+          id: uuid
+          table: block_content
+          field: uuid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: fb905cf3-4bd3-4bcd-ad01-92d25e46ba32
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: block_content
+          entity_field: uuid
+          plugin_id: string
+      sorts: {  }
+      title: 'Block Edit Links'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments:
+        id:
+          id: id
+          table: block_content_field_data
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          entity_type: block_content
+          entity_field: id
+          plugin_id: numeric
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - user.permissions
+      tags: {  }
+  people_intro:
+    display_plugin: block
+    id: people_intro
+    display_title: 'People Intro Edit Link'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - user.permissions
+      tags: {  }

--- a/tests/codeception/acceptance/Content/CustomBlockCest.php
+++ b/tests/codeception/acceptance/Content/CustomBlockCest.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Test for custom block types.
+ *
+ * @group block
+ */
+class CustomBlockCest {
+
+  /**
+   * Site managers should be able to edit custom blocks.
+   */
+  public function testCustomBlockAccess(AcceptanceTester $I) {
+    $block = $I->createEntity([
+      'type' => 'stanford_component_block',
+      'info' => 'Custom Block Test',
+    ], 'block_content');
+    $I->logInWithRole('site_manager');
+    $I->amOnPage($block->toUrl()->toString());
+    $I->fillField('Block description', 'Foo Bar');
+    $I->click('Save');
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Allow site managers access to edit custom blocks.

# Need Review By (Date)
- asap

# Urgency
- high

# Steps to Test
1. `composer require su-sws/stanford_profile:dev-D8CORE-2220`
1. `drush cim -y & drush pmu simplesamlphp_auth & drush uli Morgan`
1. go to `/people` page and verify you can click the link and edit the intro block.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
