### PR TITLE
D8CORE-2205 Configure config ignore to allow for custom theme enabling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
         "drupal/ckeditor_fixed_toolbar": "dev-1.x#1e4a8191ab289b4c91d9a0f2ac6b40e82e294908",
         "drupal/components": "~1.0",
         "drupal/config_distro": "^1.0-alpha",
+        "drupal/config_ignore": "^2.2",
         "drupal/config_merge": "^1.0-rc",
         "drupal/config_pages": "^2.6",
         "drupal/config_pages_overrides": "^1.0",
@@ -158,6 +159,10 @@
             }
         },
         "patches": {
+            "drupal/config_ignore": {
+                "https://www.drupal.org/project/config_ignore/issues/2857247": "https://www.drupal.org/files/issues/2018-10-14/support-for-export-2857247-24.patch",
+                "https://www.drupal.org/project/config_ignore/issues/2865419": "https://www.drupal.org/files/issues/2020-06-21/config_ignore-wildcard_force-14.patch"
+            },
             "drupal/config_readonly": {
                 "https://www.drupal.org/project/config_readonly/issues/2892631": "https://www.drupal.org/files/issues/2018-04-01/config-readonly-2892631-18.patch"
             },

--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -1,0 +1,9 @@
+ignored_config_entities:
+  - 'core.extension:theme'
+  - 'system.theme:default'
+  - 'block.block.*'
+  - '~block.block.seven_*'
+  - '~block.block.stanford_basic_*'
+enable_export_filtering: '0'
+_core:
+  default_config_hash: v7E8C8wJWeAW2BGohMNY1tZSBc4bexM6O62tGxecTfE

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -20,6 +20,7 @@ module:
   components: 0
   config: 0
   config_filter: 0
+  config_ignore: 0
   config_merge: 0
   config_pages: 0
   config_readonly: 0

--- a/src/Config/ConfigOverrides.php
+++ b/src/Config/ConfigOverrides.php
@@ -37,9 +37,11 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   Config factory service.
    */
-  public function __construct(StateInterface $state, ConfigFactoryInterface $config_factory) {
+  public function __construct(StateInterface $state, ConfigFactoryInterface $config_factory = NULL) {
     $this->state = $state;
-    $this->configFactory = $config_factory;
+    if ($config_factory) {
+      $this->configFactory = $config_factory;
+    }
   }
 
   /**
@@ -57,7 +59,7 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
 
     // Add to the config ignore so that it will ignore the current theme's
     // settings config.
-    if (in_array('config_ignore.settings', $names)) {
+    if (in_array('config_ignore.settings', $names) && $this->configFactory) {
       // We have to get the original values to add to the array.
       $existing_ignored = $this->configFactory->getEditable('config_ignore.settings')
         ->getOriginal('ignored_config_entities', FALSE);

--- a/src/Config/ConfigOverrides.php
+++ b/src/Config/ConfigOverrides.php
@@ -3,6 +3,7 @@
 namespace Drupal\stanford_profile\Config;
 
 use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\State\StateInterface;
@@ -22,13 +23,23 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
   protected $state;
 
   /**
+   * Config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
    * ConfigOverrides constructor.
    *
    * @param \Drupal\Core\State\StateInterface $state
    *   State service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   Config factory service.
    */
-  public function __construct(StateInterface $state) {
+  public function __construct(StateInterface $state, ConfigFactoryInterface $config_factory) {
     $this->state = $state;
+    $this->configFactory = $config_factory;
   }
 
   /**
@@ -43,6 +54,21 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
         'front' => $this->state->get('stanford_profile.front_page'),
       ];
     }
+
+    // Add to the config ignore so that it will ignore the current theme's
+    // settings config.
+    if (in_array('config_ignore.settings', $names)) {
+      // We have to get the original values to add to the array.
+      $existing_ignored = $this->configFactory->getEditable('config_ignore.settings')
+        ->getOriginal('ignored_config_entities', FALSE);
+      $themes = $this->configFactory->getEditable('core.extension')
+        ->getOriginal('theme');
+      foreach(array_keys($themes) as $theme_name){
+        $existing_ignored[] = "$theme_name.settings";
+      }
+      $overrides['config_ignore.settings']['ignored_config_entities'] = $existing_ignored;
+    }
+
     return $overrides;
   }
 

--- a/src/Config/ConfigOverrides.php
+++ b/src/Config/ConfigOverrides.php
@@ -63,7 +63,7 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
         ->getOriginal('ignored_config_entities', FALSE);
       $themes = $this->configFactory->getEditable('core.extension')
         ->getOriginal('theme');
-      foreach(array_keys($themes) as $theme_name){
+      foreach (array_keys($themes) as $theme_name) {
         $existing_ignored[] = "$theme_name.settings";
       }
       $overrides['config_ignore.settings']['ignored_config_entities'] = $existing_ignored;

--- a/stanford_profile.profile
+++ b/stanford_profile.profile
@@ -256,3 +256,12 @@ function stanford_profile_xmlsitemap_link_alter(array &$link, array $context) {
 
   }
 }
+
+/**
+ * Implements hook_config_readonly_whitelist_patterns().
+ */
+function stanford_profile_config_readonly_whitelist_patterns() {
+  $default_theme = \Drupal::config('system.theme')->get('default');
+  // Allow the theme settings to be changed in the UI.
+  return ["$default_theme.settings"];
+}

--- a/stanford_profile.services.yml
+++ b/stanford_profile.services.yml
@@ -9,6 +9,6 @@ services:
       - { name: 'event_subscriber' }
   stanford_profile.config_overrider:
     class: Drupal\stanford_profile\Config\ConfigOverrides
-    arguments: ['@state']
+    arguments: ['@state', '@config.factory']
     tags:
       - {name: config.factory.override, priority: 5}

--- a/tests/codeception/acceptance/SubThemeCest.php
+++ b/tests/codeception/acceptance/SubThemeCest.php
@@ -1,0 +1,133 @@
+<?php
+
+use Drupal\Core\Serialization\Yaml;
+use Faker\Factory;
+
+/**
+ * Class SubThemeCest.
+ */
+class SubThemeCest {
+
+  /**
+   * Human readable name for the theme.
+   *
+   * @var string
+   */
+  protected $themeName;
+
+  /**
+   * Real path to the theme directory.
+   *
+   * @var string
+   */
+  protected $themePath;
+
+  /**
+   * SubThemeCest constructor.
+   */
+  public function __construct() {
+    $this->themeName = Factory::create()->firstName;
+    $this->themePath = realpath(dirname(drupal_get_path('theme', 'stanford_basic'))) . '/' . strtolower($this->themeName);
+  }
+
+  /**
+   * Before the tests, create a stubbed out subtheme.
+   *
+   * @param \AcceptanceTester $I
+   *   Tester.
+   */
+  public function _before(AcceptanceTester $I) {
+    $this->createTheme();
+  }
+
+  /**
+   * Always cleanup the config after testing.
+   *
+   * @param \AcceptanceTester $I
+   *   Tester.
+   */
+  public function _after(AcceptanceTester $I) {
+    $this->_failed($I);
+  }
+
+  /**
+   * Always cleanup the config after testing.
+   *
+   * @param \AcceptanceTester $I
+   *   Tester.
+   */
+  public function _failed(AcceptanceTester $I) {
+    $this->runConfigImport($I, TRUE);
+    unlink($this->themePath . '/' . strtolower($this->themeName) . '.info.yml');
+    rmdir($this->themePath);
+  }
+
+  /**
+   * Enable the subtheme and the config should reflect the changes done.
+   */
+  public function testSubTheme(AcceptanceTester $I) {
+    $I->runDrush('theme:enable -y ' . strtolower($this->themeName));
+    $I->logInWithRole('administrator');
+    $I->amOnPage('/admin/appearance');
+    $I->click('Set as default', sprintf('a[title="Set %s as default theme"]', $this->themeName));
+    $I->amOnPage('/');
+    $I->canSeeResponseCodeIs(200);
+
+    $this->runConfigImport($I);
+    $result = $I->runDrush('config-get system.theme default --format=json');
+    $result = json_decode($result, TRUE);
+    $I->assertEquals(strtolower($this->themeName), $result['system.theme:default']);
+
+    $I->amOnPage('/admin/appearance');
+    $I->click('Set as default', sprintf('a[title="Set %s as default theme"]', 'Stanford Basic'));
+    $this->runConfigImport($I);
+
+    $result = $I->runDrush('config-get system.theme default --format=json');
+    $result = json_decode($result, TRUE);
+    $I->assertEquals('stanford_basic', $result['system.theme:default']);
+
+    $I->amOnPage('/');
+    $I->canSeeResponseCodeIs(200);
+  }
+
+  /**
+   * Run config import and adjust saml module if necessary.
+   *
+   * @param \AcceptanceTester $I
+   *   Tester.
+   * @param bool $disable_config_ignore
+   *   If config ignore module should be disabled first.
+   */
+  protected function runConfigImport(AcceptanceTester $I, $disable_config_ignore = FALSE) {
+    $drush_response = $I->runDrush('pm-list --filter=name=stanford_ssp --format=json');
+    $drush_response = json_decode($drush_response, TRUE);
+    $saml_enabled = $drush_response['stanford_ssp']['status'] == 'Enabled';
+
+    if ($disable_config_ignore) {
+      $I->runDrush('pmu config_ignore');
+    }
+
+    $I->runDrush('config-import -y');
+    if (!$saml_enabled) {
+      $I->runDrush('pm-uninstall simplesamlphp_auth -y');
+    }
+  }
+
+  /**
+   * Create a stub of a subtheme based on stanford_basic.
+   */
+  protected function createTheme() {
+    if (!file_exists("{$this->themePath}/{$this->themeName}.info.yml")) {
+      mkdir($this->themePath, 0777, TRUE);
+      $info = file_get_contents(drupal_get_path('theme', 'stanford_basic') . '/stanford_basic.info.yml');
+      $info = Yaml::decode($info);
+      $info['name'] = $this->themeName;
+      $info['base theme'] = 'stanford_basic';
+      unset($info['component-libraries']);
+
+      $info_path = $this->themePath . '/' . strtolower($this->themeName) . '.info.yml';
+      file_put_contents($info_path, Yaml::encode($info));
+    }
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Configure config_ignore module to allow for custom themes

# Need Review By (Date)
- 6/25

# Urgency
- medium

# Steps to Test
1. use the branch in https://github.com/SU-SWS/acsf-cardinalsites/pull/162 and do a `composer install`
1. To test with config readonly enabled, comment out the Acquia environment conditions in the `global.settings.php`
1. install a fresh site or use an existing one and import config
1. create any stubbed out sub theme based on stanford_basic. you only need the `info.yml` file
1. enable the subtheme via drush `drush then [theme_name]`
1. go to the appearance page and enable the theme
1. edit the theme settings
1. run a config import and validate nothing moves with the new theme.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
