### PR TITLE
D8CORE-2292: Added in the More news button

### DIFF
--- a/config/sync/views.view.stanford_news.yml
+++ b/config/sync/views.view.stanford_news.yml
@@ -1303,6 +1303,11 @@ display:
         row: false
         pager: false
         css_class: false
+        use_more: false
+        use_more_always: false
+        use_more_text: false
+        link_display: false
+        link_url: false
       style:
         type: grid
         options:
@@ -1380,6 +1385,11 @@ display:
       block_category: 'News Lists (Views)'
       block_description: 'News Cards - All Items'
       css_class: 'stanford-news--cards stanford-news--cards-any'
+      use_more: true
+      use_more_always: false
+      use_more_text: 'See All News'
+      link_display: custom_url
+      link_url: /news
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- added the See More News to the vertical cards.

# Needed By (Date)
- Thursday

# Urgency
- Medium

# Steps to Test

1. Pull in this change
2. Get the configuration change from profile.
3. Refresh the css.
4. Verify on the sample news article at the bottom o

# Affected Projects or Products
- D8Core-2292 in News module and in the Profile module.

# Associated Issues and/or People
- D8Core-2292
- https://github.com/SU-SWS/stanford_news/pull/87
- https://github.com/SU-SWS/stanford_profile/pull/239

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
