### PR TITLE
CSD-227 Add configurable option to display breadcrumbs on basic pages.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -143,7 +143,7 @@
         "su-sws/stanford_news": "dev-8.x-2.x",
         "su-sws/stanford_notifications": "dev-8.x-1.x",
         "su-sws/stanford_person": "dev-8.x-1.x",
-        "su-sws/stanford_profile_helper": "dev-8.x-1.x",
+        "su-sws/stanford_profile_helper": "dev-CSD-227",
         "su-sws/stanford_ssp": "dev-8.x-1.x",
         "su-sws/stanford_text_editor": "dev-8.x-1.x"
     },

--- a/config/sync/core.entity_form_display.config_pages.stanford_basic_site_settings.default.yml
+++ b/config/sync/core.entity_form_display.config_pages.stanford_basic_site_settings.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - config_pages.type.stanford_basic_site_settings
     - field.field.config_pages.stanford_basic_site_settings.su_google_analytics
+    - field.field.config_pages.stanford_basic_site_settings.su_site_breadcrumbs
     - field.field.config_pages.stanford_basic_site_settings.su_site_email
     - field.field.config_pages.stanford_basic_site_settings.su_site_name
     - field.field.config_pages.stanford_basic_site_settings.su_site_url
@@ -22,6 +23,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
+    region: content
+  su_site_breadcrumbs:
+    weight: 4
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
     region: content
   su_site_email:
     weight: 1

--- a/config/sync/core.entity_view_display.config_pages.stanford_basic_site_settings.default.yml
+++ b/config/sync/core.entity_view_display.config_pages.stanford_basic_site_settings.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - config_pages.type.stanford_basic_site_settings
     - field.field.config_pages.stanford_basic_site_settings.su_google_analytics
+    - field.field.config_pages.stanford_basic_site_settings.su_site_breadcrumbs
     - field.field.config_pages.stanford_basic_site_settings.su_site_email
     - field.field.config_pages.stanford_basic_site_settings.su_site_name
     - field.field.config_pages.stanford_basic_site_settings.su_site_url
@@ -22,6 +23,16 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
+    region: content
+  su_site_breadcrumbs:
+    weight: 4
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
     region: content
   su_site_email:
     weight: 2

--- a/config/sync/core.entity_view_display.node.stanford_page.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_page.default.yml
@@ -16,6 +16,7 @@ dependencies:
     - layout_builder_restrictions
     - layout_library
     - menu_block
+    - system
     - user
 third_party_settings:
   layout_builder:
@@ -73,6 +74,17 @@ third_party_settings:
               context_mapping:
                 entity: layout_builder.entity
                 view_mode: view_mode
+            additional: {  }
+            weight: 1
+          71cdc4f7-083a-4e13-8950-22f31fec82f8:
+            uuid: 71cdc4f7-083a-4e13-8950-22f31fec82f8
+            region: main
+            configuration:
+              id: system_breadcrumb_block
+              label: Breadcrumbs
+              provider: system
+              label_display: '0'
+              context_mapping: {  }
             additional: {  }
             weight: 0
         third_party_settings: {  }

--- a/config/sync/field.field.config_pages.stanford_basic_site_settings.su_site_breadcrumbs.yml
+++ b/config/sync/field.field.config_pages.stanford_basic_site_settings.su_site_breadcrumbs.yml
@@ -1,0 +1,23 @@
+uuid: fdb20a35-10b0-486c-bd38-5be09ec450cb
+langcode: en
+status: true
+dependencies:
+  config:
+    - config_pages.type.stanford_basic_site_settings
+    - field.storage.config_pages.su_site_breadcrumbs
+id: config_pages.stanford_basic_site_settings.su_site_breadcrumbs
+field_name: su_site_breadcrumbs
+entity_type: config_pages
+bundle: stanford_basic_site_settings
+label: 'Display Breadcrumbs'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.storage.config_pages.su_site_breadcrumbs.yml
+++ b/config/sync/field.storage.config_pages.su_site_breadcrumbs.yml
@@ -1,0 +1,22 @@
+uuid: 5914dbf0-6966-4e05-b625-8c84ed11579d
+langcode: en
+status: true
+dependencies:
+  module:
+    - config_pages
+    - field_permissions
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: config_pages.su_site_breadcrumbs
+field_name: su_site_breadcrumbs
+entity_type: config_pages
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/codeception/acceptance/SystemSiteConfigCest.php
+++ b/tests/codeception/acceptance/SystemSiteConfigCest.php
@@ -57,4 +57,50 @@ class SystemSiteConfigCest {
     $I->cantSee('UA-12456-12');
   }
 
+  /**
+   * @group testme
+   */
+  public function testBreadcrumbs(AcceptanceTester $I) {
+    $I->logInWithRole('site_manager');
+    $I->amOnPage('/admin/config/system/basic-site-settings');
+    $I->uncheckOption('Display Breadcrumbs');
+    $I->click('Save');
+
+    $I->amOnPage('/node/add/stanford_page');
+    $I->fillField('Title', 'Foo');
+    $I->checkOption('Provide a menu link');
+    $I->fillField('Menu link title', 'Foo');
+    $I->click('Save');
+
+
+    $I->amOnPage('/node/add/stanford_page');
+    $I->fillField('Title', 'Bar');
+    $I->checkOption('Provide a menu link');
+    $I->fillField('Menu link title', 'Bar');
+    $I->selectOption('Parent item', '-- Foo');
+    $I->click('Change parent (update list of weights)');
+    $I->click('Save');
+    $I->canSee('Bar', 'h1');
+
+    $url = $I->grabFromCurrentUrl();
+    $I->cantSee('Foo', '.breadcrumb');
+    $I->cantSee('Bar', '.breadcrumb');
+
+    $I->amOnPage('/admin/config/system/basic-site-settings');
+    $I->checkOption('Display Breadcrumbs');
+    $I->click('Save');
+
+    $I->amOnPage($url);
+    $I->canSee('Foo', '.breadcrumb');
+    $I->canSee('Bar', '.breadcrumb');
+
+    $I->amOnPage('/admin/config/system/basic-site-settings');
+    $I->uncheckOption('Display Breadcrumbs');
+    $I->click('Save');
+
+    $I->amOnPage($url);
+    $I->cantSee('Foo', '.breadcrumb');
+    $I->cantSee('Bar', '.breadcrumb');
+  }
+
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adds breadcrumb block to the basic pages
- Add option in config pages to optionally display the breadcrumbs.

# Topics that might need discussion.
- Do we want breadcrumbs on other content types... even though they won't be placed in the menu?
- Do we want to breadcrumbs on full width pages? IMO no.

# Need Review By (Date)
- 7/22

# Urgency
- low

# Steps to Test
1. `composer require su-sws/stanford_profile:dev-CSD-227` or checkout this branch and the accompanying branch in `stanford_profile_helper`
1. `drush cim -y`
1. Create a basic page as a child of another menu item.
1. validate no breadcrumbs are displayed. 
1. go to the site settings config `/admin/config/system/basic-site-settings` and check the box to display breadcrumbs
1. go back to the page you created
1. See the breadcrumbs are displayed. You might need to clear render cache, but I didn't need to and neither do the tests it seems.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
