### PR TITLE
CSD-258 Reset selection when filtered

### DIFF
--- a/config/sync/views.view.content.yml
+++ b/config/sync/views.view.content.yml
@@ -192,16 +192,16 @@ display:
           batch_size: 10
           form_step: true
           buttons: false
-          clear_on_exposed: false
+          clear_on_exposed: true
           action_title: Action
           selected_actions:
-            -
-              action_id: node_unpublish_action
-            -
-              action_id: node_publish_action
-            -
+            3:
               action_id: node_assign_owner_action
-            -
+            5:
+              action_id: node_publish_action
+            6:
+              action_id: node_unpublish_action
+            9:
               action_id: views_bulk_operations_delete_entity
           plugin_id: views_bulk_operations_bulk_form
         title:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Reset selection when the user filters.

# Need Review By (Date)
- 7/29

# Urgency
- medium

# Steps to Test
1. checkout this branch
1. import config
1. view `/admin/content`
1. select some rows in the view
1. filter the results to another content type
1. validate the selection has been cleared.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
