### PR TITLE
D8CORE-2155: Added configs for responsive 1:1 image styles

### DIFF
--- a/config/sync/image.style.square_1192.yml
+++ b/config/sync/image.style.square_1192.yml
@@ -1,0 +1,17 @@
+uuid: a89af49d-f182-4e85-9e93-aa2f48446b42
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: square_1192
+label: 'Square - 1192'
+effects:
+  e1b9c81d-c281-4e9d-b145-28144e978ac0:
+    uuid: e1b9c81d-c281-4e9d-b145-28144e978ac0
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 1192
+      height: 1192
+      crop_type: focal_point

--- a/config/sync/image.style.square_1900.yml
+++ b/config/sync/image.style.square_1900.yml
@@ -1,0 +1,17 @@
+uuid: 49586ca9-dc98-4743-88d2-6766a95b64a8
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: square_1900
+label: 'Square - 1900'
+effects:
+  578f3e25-6a90-4db7-a90c-91ce8bf4d99e:
+    uuid: 578f3e25-6a90-4db7-a90c-91ce8bf4d99e
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 1900
+      height: 1900
+      crop_type: focal_point

--- a/config/sync/image.style.square_478.yml
+++ b/config/sync/image.style.square_478.yml
@@ -1,0 +1,17 @@
+uuid: 07b69e97-1071-4e28-842c-f0d0f6234dcf
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: square_478
+label: 'Square - 478'
+effects:
+  1891a880-3259-4e36-a1e8-9d9f9de467d0:
+    uuid: 1891a880-3259-4e36-a1e8-9d9f9de467d0
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 478
+      height: 478
+      crop_type: focal_point

--- a/config/sync/image.style.square_956.yml
+++ b/config/sync/image.style.square_956.yml
@@ -1,0 +1,17 @@
+uuid: aef8656f-1161-4722-ae84-1c6f66489ce5
+langcode: en
+status: true
+dependencies:
+  module:
+    - focal_point
+name: square_956
+label: 'Square - 956'
+effects:
+  d383578e-88ff-41aa-830d-526c90d3df98:
+    uuid: d383578e-88ff-41aa-830d-526c90d3df98
+    id: focal_point_scale_and_crop
+    weight: 1
+    data:
+      width: 956
+      height: 956
+      crop_type: focal_point

--- a/config/sync/responsive_image.styles.responsive_1_1.yml
+++ b/config/sync/responsive_image.styles.responsive_1_1.yml
@@ -1,0 +1,56 @@
+uuid: 5ba1935d-e8ec-4a5e-ac02-8e2f9d68762c
+langcode: en
+status: true
+dependencies:
+  config:
+    - image.style.square_1192
+    - image.style.square_1900
+    - image.style.square_478
+    - image.style.square_956
+  module:
+    - stanford_image_styles
+id: responsive_1_1
+label: 'Responsive 1:1'
+image_style_mappings:
+  -
+    breakpoint_id: stanford_image_styles.lg
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: square_1192
+  -
+    breakpoint_id: stanford_image_styles.lg
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: square_1900
+  -
+    breakpoint_id: stanford_image_styles.md
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: square_956
+  -
+    breakpoint_id: stanford_image_styles.md
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: square_1900
+  -
+    breakpoint_id: stanford_image_styles.sm
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: square_956
+  -
+    breakpoint_id: stanford_image_styles.sm
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: square_1192
+  -
+    breakpoint_id: stanford_image_styles.xs
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: square_478
+  -
+    breakpoint_id: stanford_image_styles.xs
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: square_956
+breakpoint_group: stanford_image_styles
+fallback_image_style: square_1900


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- We want a responsive 1:1 image style. To accomplish that, I created 1:1 image styles following the patterns and dimensions specified in the Card 2:1 responsive image style.  These configs set up the styles and make them available..

# Needed By (Date)
- 7/24/2020

# Urgency
- Not critical.

# Steps to Test

1. Checkout this branch.
2. Do a `drush cim` to import the configs.
3. Create a page with 3 Card paragraphs.
4. Observe they use the `Card 2:1` images when saved.
5. Visit /admin/structure/paragraphs_type/stanford_card/display
6. Switch the Image or Video widget's Image Style to render as `Responsive 1:1`, and save your changes
7. Visit your page you created in step 3.  Observe the images in the paragraphs are now square.

# Affected Projects or Products
- n/a

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/D8CORE-2155

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
