### PR TITLE
Removed views_taxonomy_term_name_depth not in use.

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -157,7 +157,6 @@ module:
   views_bulk_operations: 0
   views_contextual_filters_or: 0
   views_infinite_scroll: 0
-  views_taxonomy_term_name_depth: 0
   views_ui: 0
   xmlsitemap_engines: 0
   ds: 1


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removed module from that isn't being used and is no longer part of dependencies.

# Need Review By (Date)
- asap

# Urgency
- high

# Steps to Test

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
