### PR TITLE
DEVGUIDE-000 Added html pre tag to allowed html tags.

### DIFF
--- a/config/sync/filter.format.stanford_html.yml
+++ b/config/sync/filter.format.stanford_html.yml
@@ -56,7 +56,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <em> <strong> <cite> <blockquote cite> <pre> <code> <ul type class> <ol start type class> <li class> <dl class> <dt> <dd class> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <a class href hreflang data-entity-substitution data-entity-type data-entity-uuid title name> <div class> <p class> <table> <caption> <tbody class> <thead> <tfoot> <th scope class> <td class colspan rowspan> <tr> <sup> <sub> <i class> <hr> <drupal-media data-entity-type data-entity-uuid data-align data-caption data-* alt>'
+      allowed_html: '<br> <em> <strong> <cite> <blockquote cite> <pre class> <code data-* class> <ul type class> <ol start type class> <li class> <dl class> <dt> <dd class> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <a class href hreflang data-entity-substitution data-entity-type data-entity-uuid title name> <div class> <p class> <table> <caption> <tbody class> <thead> <tfoot> <th scope class> <td class colspan rowspan> <tr> <sup> <sub> <i class> <hr> <drupal-media data-entity-type data-entity-uuid data-align data-caption data-* alt>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_htmlcorrector:

--- a/config/sync/filter.format.stanford_html.yml
+++ b/config/sync/filter.format.stanford_html.yml
@@ -56,7 +56,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <em> <strong> <cite> <blockquote cite> <code> <ul type class> <ol start type class> <li class> <dl class> <dt> <dd class> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <a class href hreflang data-entity-substitution data-entity-type data-entity-uuid title name> <div class> <p class> <table> <caption> <tbody class> <thead> <tfoot> <th scope class> <td class colspan rowspan> <tr> <sup> <sub> <i class> <hr> <drupal-media data-entity-type data-entity-uuid data-align data-caption data-* alt>'
+      allowed_html: '<br> <em> <strong> <cite> <blockquote cite> <pre> <code> <ul type class> <ol start type class> <li class> <dl class> <dt> <dd class> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <a class href hreflang data-entity-substitution data-entity-type data-entity-uuid title name> <div class> <p class> <table> <caption> <tbody class> <thead> <tfoot> <th scope class> <td class colspan rowspan> <tr> <sup> <sub> <i class> <hr> <drupal-media data-entity-type data-entity-uuid data-align data-caption data-* alt>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_htmlcorrector:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added html pre tag to allowed html tags.

# Needed By (Date)
- whenever 

# Urgency
- super low

# Steps to Test

1. Pull this branch
2. Clear cache
3. Create a basic page and add this snippet in the text area source and save:
```
<pre>
<code lang="css">
/* Stanford Web Services 
            :D */
body {
     display: block;
}
</code>
</pre>
```
The spacing/line breaks should stick and look something like this:
![image](https://user-images.githubusercontent.com/34019925/90574721-7db6b700-e16e-11ea-888d-4131197d5f42.png)


# Affected Projects or Products
- Dev Guide Sub Theming for Code Snippets

# Associated Issues
- https://github.com/SU-SWS/stanford_text_editor/pull/37

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
