### PR TITLE
D8CORE-2591: Allow lockup option M

### DIFF
--- a/config/sync/field.storage.config_pages.su_lockup_options.yml
+++ b/config/sync/field.storage.config_pages.su_lockup_options.yml
@@ -37,6 +37,9 @@ settings:
       value: i
       label: 'Option I: Lines 1, 3, 4'
     -
+      value: m
+      label: 'Option M: Lines 1, 2 Large'
+    -
       value: o
       label: 'Option O: Line 4'
     -

--- a/tests/codeception/acceptance/LockupSettings/LockupSettingsCest.php
+++ b/tests/codeception/acceptance/LockupSettings/LockupSettingsCest.php
@@ -197,7 +197,7 @@ class LockupSettingsCest {
    /**
    * Test the lockup settings overrides.
    */
-  public function testLockupSettingsO(AcceptanceTester $I) {
+  public function testLockupSettingsM(AcceptanceTester $I) {
     $I->logInWithRole('administrator');
     $I->amOnPage('/admin/config/system/lockup-settings');
     $I->canSeeResponseCodeIs(200);

--- a/tests/codeception/acceptance/LockupSettings/LockupSettingsCest.php
+++ b/tests/codeception/acceptance/LockupSettings/LockupSettingsCest.php
@@ -193,6 +193,27 @@ class LockupSettingsCest {
     $I->canSee("Organization name");
     $I->canSee("Tertiary title line");
   }
+  
+   /**
+   * Test the lockup settings overrides.
+   */
+  public function testLockupSettingsO(AcceptanceTester $I) {
+    $I->logInWithRole('administrator');
+    $I->amOnPage('/admin/config/system/lockup-settings');
+    $I->canSeeResponseCodeIs(200);
+    $I->uncheckOption('#edit-su-lockup-enabled-value');
+    $I->selectOption("#edit-su-lockup-options", "m");
+    $I->checkOption('#edit-su-use-theme-logo-value');
+    $I->fillField('Line 1', 'Site title line');
+    $I->fillField('Line 2', 'Secondary title line');
+    $I->fillField('Line 3', 'Tertiary title line');
+    $I->fillField('Line 4', 'Organization name');
+    $I->fillField('Line 5', 'Last line full width option');
+    $I->click('Save');
+    $I->amOnPage('/');
+    $I->canSee("Site title line");
+    $I->canSee("Secondary title line");
+  }
 
   /**
    * Test the lockup settings overrides.


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Allow for Decanter's M option.

# Needed By (Date)
- Sept 2nd

# Urgency
- Med/Low

# Steps to Test

1. Check out this branch
2. Clear cache
3. Go to lockup setting form
4. Select Option M
5. See only fields for line 1 & line 2
6. Fill in those fields and save
7. See rendered out fields on home page.

# Affected Projects or Products
- D8CORE 
- VPSA
- EARTH
- Others

# Associated Issues and/or People
- D8CORE-2591

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
