### PR TITLE
D8CORE-000: Custom theme blocks for custom sites with custom themes.

### DIFF
--- a/stanford_profile.post_update.php
+++ b/stanford_profile.post_update.php
@@ -93,6 +93,8 @@ function stanford_profile_post_update_8015() {
   $basic_super_config->set('id', $theme_name . '_config_pages_super_global_msg');
   $basic_global_config->set('theme', $theme_name);
   $basic_super_config->set('theme', $theme_name);
+  $basic_global_config->set('dependencies.theme', [$theme_name]);
+  $basic_super_config->set('dependencies.theme', [$theme_name]);
 
   // Remove the UUID.
   $basic_global_config->clear('uuid');

--- a/stanford_profile.post_update.php
+++ b/stanford_profile.post_update.php
@@ -72,7 +72,6 @@ function stanford_profile_post_update_8015() {
   // Resources.
   $config_path = Settings::get('config_sync_directory');
   $source = new FileStorage($config_path);
-  $config_storage = \Drupal::service('config.storage');
   $config_factory = \Drupal::service('config.factory');
 
   // Get the configuration out of the filesystem as it may not have been imported

--- a/stanford_profile.post_update.php
+++ b/stanford_profile.post_update.php
@@ -5,6 +5,9 @@
  * stanford_profile.install
  */
 
+use Drupal\Core\Site\Settings;
+use Drupal\Core\Config\FileStorage;
+
 /**
  * Implements hook_removed_post_updates().
  */
@@ -45,4 +48,57 @@ function stanford_profile_post_update_8014() {
     'contributor',
   ]);
 
+}
+
+/**
+ * Create blocks for sites with custom themes that were added to stanford_basic.
+ */
+function stanford_profile_post_update_8015() {
+  $theme_name = \Drupal::config('system.theme')->get('default');
+  // Default theme is good. Just end if so.
+  if ($theme_name == "stanford_basic") {
+    return;
+  }
+
+  // Not stanford_basic, we have to create two config page blocks.
+  // Copy the blocks from stanford_basic and rename them.
+  //
+  // Names of things.
+  $basic_global_name = 'block.block.stanford_basic_config_pages_stanford_global_msg';
+  $basic_super_name = 'block.block.stanford_basic_config_pages_stanford_super_footer';
+  $my_global_name = 'block.block.' . $theme_name . '_config_pages_stanford_global_msg';
+  $my_super_name = 'block.block.' . $theme_name . '_config_pages_stanford_super_footer';
+
+  // Resources.
+  $config_path = Settings::get('config_sync_directory');
+  $source = new FileStorage($config_path);
+  $config_storage = \Drupal::service('config.storage');
+  $config_factory = \Drupal::service('config.factory');
+
+  // Get the configuration out of the filesystem as it may not have been imported
+  // yet...
+  $basic_global_config = $config_factory
+    ->getEditable($my_global_name)
+    ->setData(
+      $source->read($basic_global_name)
+    );
+  $basic_super_config = $config_factory
+    ->getEditable($my_super_name)
+    ->setData(
+      $source->read($basic_super_name)
+    );
+
+  // Change a few ids.
+  $basic_global_config->set('id', $theme_name . '_config_pages_stanford_global_msg');
+  $basic_super_config->set('id', $theme_name . '_config_pages_super_global_msg');
+  $basic_global_config->set('theme', $theme_name);
+  $basic_super_config->set('theme', $theme_name);
+
+  // Remove the UUID.
+  $basic_global_config->clear('uuid');
+  $basic_super_config->clear('uuid');
+
+  // Add it to the DB.
+  $basic_global_config->save();
+  $basic_super_config->save();
 }


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Adds global message and super footer blocks to sites with custom themes.

# Needed By (Date)
- Friday Sept 11th

# Urgency
- Hight

# Steps to Test

1. On an existing build clone down a new theme (https://github.com/su-sws/saa_victoria_subtheme/) into /docroot/themes/custom
2. Enable the theme and set as default
3. Remove the global message and super footer blocks if they were placed in the block system
4. Check out this branch
5. Run database updates
6. Validate blocks were placed.

# Affected Projects or Products
- SAA sites only

# Associated Issues and/or People
- No Jira tickets
- @buttonwillowsix 
- @katrialesser 
- @alisonho 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
