### PR TITLE
Update extlink.settings.yml

### DIFF
--- a/config/sync/extlink.settings.yml
+++ b/config/sync/extlink.settings.yml
@@ -12,7 +12,7 @@ extlink_include: ''
 extlink_class: 'su-link su-link--external'
 extlink_label: '(link is external)'
 extlink_img_class: false
-extlink_css_exclude: ''
+extlink_css_exclude: '.news-social-media a'
 extlink_css_explicit: '#page-content, .su-local-footer'
 extlink_mailto_class: mailto
 extlink_mailto_label: '(link sends email)'


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Don't apply links to news social media sections

# Needed By (Date)
- Friday Sept 11th

# Urgency
- Hight

# Steps to Test

1. Check out this branch on an existing build
2. Import config (or just change the setting in your local site's config)
3. Clear all caches
4. Navigate to an internal news page
5. See no more ext links

# Affected Projects or Products
- D8CORE
- SOE
- SAA

# Associated Issues and/or People
- @ishahism 
- @jenbreese 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
