### PR TITLE
CAP-52 Import 3 more fields from the API

### DIFF
--- a/config/sync/core.entity_form_display.node.stanford_person.default.yml
+++ b/config/sync/core.entity_form_display.node.stanford_person.default.yml
@@ -348,4 +348,7 @@ hidden:
   layout_builder__layout: true
   promote: true
   sticky: true
+  su_person_academic_appt: true
+  su_person_admin_appts: true
   su_person_research_interests: true
+  su_person_scholarly_interests: true

--- a/config/sync/core.entity_view_display.node.stanford_person.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_person.default.yml
@@ -766,4 +766,7 @@ content:
     region: content
 hidden:
   layout_builder__layout: true
+  su_person_academic_appt: true
+  su_person_admin_appts: true
   su_person_research_interests: true
+  su_person_scholarly_interests: true

--- a/config/sync/core.entity_view_display.node.stanford_person.teaser.yml
+++ b/config/sync/core.entity_view_display.node.stanford_person.teaser.yml
@@ -51,6 +51,8 @@ content:
     region: content
 hidden:
   layout_builder__layout: true
+  su_person_academic_appt: true
+  su_person_admin_appts: true
   su_person_affiliations: true
   su_person_components: true
   su_person_education: true
@@ -69,6 +71,7 @@ hidden:
   su_person_profile_link: true
   su_person_research: true
   su_person_research_interests: true
+  su_person_scholarly_interests: true
   su_person_short_title: true
   su_person_telephone: true
   su_person_type_group: true

--- a/config/sync/field.field.node.stanford_person.su_person_academic_appt.yml
+++ b/config/sync/field.field.node.stanford_person.su_person_academic_appt.yml
@@ -1,0 +1,19 @@
+uuid: b7be9d37-ec35-4881-b964-e3f0f1d6aa3a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.su_person_academic_appt
+    - node.type.stanford_person
+id: node.stanford_person.su_person_academic_appt
+field_name: su_person_academic_appt
+entity_type: node
+bundle: stanford_person
+label: 'Academic Appointments'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.stanford_person.su_person_admin_appts.yml
+++ b/config/sync/field.field.node.stanford_person.su_person_admin_appts.yml
@@ -1,0 +1,19 @@
+uuid: e392a4cd-4997-4301-97f1-9de3ab607956
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.su_person_admin_appts
+    - node.type.stanford_person
+id: node.stanford_person.su_person_admin_appts
+field_name: su_person_admin_appts
+entity_type: node
+bundle: stanford_person
+label: 'Administrative Appointments'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.stanford_person.su_person_scholarly_interests.yml
+++ b/config/sync/field.field.node.stanford_person.su_person_scholarly_interests.yml
@@ -1,0 +1,27 @@
+uuid: edcebf44-29d0-4bfb-b8da-e72248bb07af
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.su_person_scholarly_interests
+    - node.type.stanford_person
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    stanford_minimal_html: stanford_minimal_html
+    stanford_html: '0'
+    plain_text: '0'
+id: node.stanford_person.su_person_scholarly_interests
+field_name: su_person_scholarly_interests
+entity_type: node
+bundle: stanford_person
+label: 'Scholarly and Research Interests'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/sync/field.storage.node.su_person_academic_appt.yml
+++ b/config/sync/field.storage.node.su_person_academic_appt.yml
@@ -5,9 +5,6 @@ dependencies:
   module:
     - field_permissions
     - node
-third_party_settings:
-  field_permissions:
-    permission_type: public
 id: node.su_person_academic_appt
 field_name: su_person_academic_appt
 entity_type: node

--- a/config/sync/field.storage.node.su_person_academic_appt.yml
+++ b/config/sync/field.storage.node.su_person_academic_appt.yml
@@ -1,0 +1,25 @@
+uuid: a58d55f7-fbd6-4cc3-b6ae-0bf92e45983b
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.su_person_academic_appt
+field_name: su_person_academic_appt
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.su_person_admin_appts.yml
+++ b/config/sync/field.storage.node.su_person_admin_appts.yml
@@ -5,9 +5,6 @@ dependencies:
   module:
     - field_permissions
     - node
-third_party_settings:
-  field_permissions:
-    permission_type: public
 id: node.su_person_admin_appts
 field_name: su_person_admin_appts
 entity_type: node

--- a/config/sync/field.storage.node.su_person_admin_appts.yml
+++ b/config/sync/field.storage.node.su_person_admin_appts.yml
@@ -1,0 +1,25 @@
+uuid: 64fdfbcf-c565-4315-be83-493e33ad5662
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.su_person_admin_appts
+field_name: su_person_admin_appts
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.su_person_scholarly_interests.yml
+++ b/config/sync/field.storage.node.su_person_scholarly_interests.yml
@@ -1,0 +1,23 @@
+uuid: da3e3403-129e-4c48-8414-626b5a02876f
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+    - text
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.su_person_scholarly_interests
+field_name: su_person_scholarly_interests
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.su_person_scholarly_interests.yml
+++ b/config/sync/field.storage.node.su_person_scholarly_interests.yml
@@ -6,9 +6,6 @@ dependencies:
     - field_permissions
     - node
     - text
-third_party_settings:
-  field_permissions:
-    permission_type: public
 id: node.su_person_scholarly_interests
 field_name: su_person_scholarly_interests
 entity_type: node

--- a/config/sync/migrate_plus.migration.su_stanford_person.yml
+++ b/config/sync/migrate_plus.migration.su_stanford_person.yml
@@ -126,7 +126,7 @@ process:
   revision_timestamp:
     -
       plugin: callback
-      callable: _stanford_profile_person_get_time
+      callable: _stanford_migrate_get_time
   revision_translation_affected:
     -
       plugin: default_value

--- a/config/sync/migrate_plus.migration.su_stanford_person.yml
+++ b/config/sync/migrate_plus.migration.su_stanford_person.yml
@@ -261,8 +261,6 @@ process:
         - scholarly_interests_fulltext
         - scholarly_interests_tersetext
 destination:
-  plugin: 'entity_reference_revisions:node'
-  new_revisions: true
-  force_revision: true
+  plugin: 'entity:node'
 migration_dependencies:
   required: {  }

--- a/config/sync/migrate_plus.migration.su_stanford_person.yml
+++ b/config/sync/migrate_plus.migration.su_stanford_person.yml
@@ -14,6 +14,7 @@ source:
     status: 1
     type: stanford_person
     basic_html: stanford_html
+    minimal_html: stanford_minimal_html
     link_domain: 'https://profiles.stanford.edu'
     link_text: 'View Full Stanford Profile'
     file_destination: 'public://media/person/'
@@ -97,6 +98,26 @@ source:
       name: etag
       label: 'CAP API Etag'
       selector: meta/etag
+    -
+      name: academic_appts
+      label: 'Academic Appointments'
+      selector: academicOffices/0/position
+    -
+      name: admin_appts
+      label: 'Administrative Appointments'
+      selector: administrativeAppointments
+    -
+      name: research_interest_topics
+      label: 'Research Interest Topics'
+      selector: researchInterestTopics
+    -
+      name: scholarly_interests_fulltext
+      label: 'Scholarly and Research Interests'
+      selector: currentResearchInterests/fullText/html
+    -
+      name: scholarly_interests_tersetext
+      label: 'Scholarly and Research Interests'
+      selector: currentResearchInterests/terseText/html
   ids:
     sunetid:
       type: string
@@ -219,6 +240,26 @@ process:
           regex: true
         title: label/text
   su_person_mail_code: mailcode
+  su_person_academic_appt: academic_appts
+  su_person_admin_appts:
+    -
+      source: admin_appts
+      plugin: sub_process
+      process:
+        value: label/text
+  su_person_research_interests:
+    -
+      source: research_interest_topics
+      plugin: sub_process
+      process:
+        value: label/text
+  su_person_scholarly_interests/format: constants/minimal_html
+  su_person_scholarly_interests/value:
+    -
+      plugin: null_coalesce
+      source:
+        - scholarly_interests_fulltext
+        - scholarly_interests_tersetext
 destination:
   plugin: 'entity_reference_revisions:node'
   new_revisions: true

--- a/tests/codeception/acceptance/Content/PersonCest.php
+++ b/tests/codeception/acceptance/Content/PersonCest.php
@@ -85,4 +85,21 @@ class PersonCest {
     $I->canSeeResponseCodeIs(200);
   }
 
+  /**
+   * CAP-52: Check for the new fields.
+   */
+  public function testCap52Fields(AcceptanceTester $I){
+    $I->logInWithRole('administrator');
+
+    $I->amOnPage('/admin/structure/types/manage/stanford_person/fields');
+    $I->canSee('Academic Appointments');
+    $I->canSee('Administrative Appointments');
+    $I->canSee('Scholarly and Research Interests');
+
+    $I->amOnPage('/admin/structure/types/manage/stanford_person/form-display');
+    $I->canSeeOptionIsSelected('fields[su_person_academic_appt][region]', 'Disabled');
+    $I->canSeeOptionIsSelected('fields[su_person_admin_appts][region]', 'Disabled');
+    $I->canSeeOptionIsSelected('fields[su_person_scholarly_interests][region]', 'Disabled');
+  }
+
 }

--- a/tests/codeception/acceptance/LocalFooter/LocalFooterCest.php
+++ b/tests/codeception/acceptance/LocalFooter/LocalFooterCest.php
@@ -6,6 +6,16 @@
  * @group local_footer
  */
 class LocalFooterCest {
+  
+  /**
+   * Tidy up after oneself.
+   */
+  public function _after(AcceptanceTester $I) {
+    $I->logInWithRole('administrator');
+    $I->amOnPage('/admin/config/system/local-footer');
+    $I->checkOption('Enabled');
+    $I->click('Save');
+  }
 
   /**
    * Only site manager and higher should have access.


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added 3 new fields (hidden on form and display until designs are available)
- Changed the importer to populate 4 fields
- Changed the importer to not create revisions. this appeared to be causing some issues and I hope that it will resolve some of them.

# Need Review By (Date)
- 9/21

# Urgency
- low

# Steps to Test
1. checkout this branch
1. import config
1. import profiles (i've been using org code `QYIS`)
1. load one of the profiles with devel and see the populated data.

# See Also
- https://github.com/SU-SWS/stanford_person/pull/110
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
