### PR TITLE
D8CORE-2759 Fix revisions table to show all revisions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -169,6 +169,9 @@
             "drupal/default_content": {
                 "https://www.drupal.org/project/default_content/issues/2698425": "https://www.drupal.org/files/issues/2020-02-05/2698425--accept-content-updates--122.patch"
             },
+            "drupal/diff": {
+                "https://www.drupal.org/project/diff/issues/2882334#comment-13913401": "https://www.drupal.org/files/issues/2020-09-11/2882334-diff-missing_some_revisions-11.patch"
+            },
             "drupal/fakeobjects": {
                 "https://www.drupal.org/project/fakeobjects/issues/3002953": "https://www.drupal.org/files/issues/2020-06-22/fakeobjects-missing_plugin-3002953-5.patch"
             },


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Patched the diff module to display all revisions of content.

# Need Review By (Date)
- 12/3

# Urgency
- medium

# Steps to Test
1. download the [patch](https://www.drupal.org/files/issues/2020-09-11/2882334-diff-missing_some_revisions-11.patch) and apply it to the `diff` module
1. create/edit a node and make some changes to the fields (don't change the node title)
1. view the revisions page for the node and validate you see your new revision.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
