### PR TITLE
D8CORE-2185: matching the person edit to the news edit

### DIFF
--- a/config/sync/views.view.stanford_person.yml
+++ b/config/sync/views.view.stanford_person.yml
@@ -823,8 +823,8 @@ display:
             trim: false
             preserve_tags: ''
             html: false
-          element_type: ''
-          element_class: ''
+          element_type: div
+          element_class: su-people-edit-article
           element_label_type: ''
           element_label_class: ''
           element_label_colon: false
@@ -835,7 +835,7 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          text: edit
+          text: 'edit this item'
           output_url_as_text: false
           absolute: false
           entity_type: node


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Matching the person edit button to the news edit button

# Review By (Date)
- 9/25

# Criticality
- Low
- Effects all the sites with a people grid page. It is only on the authoring environment button.

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Navigate to the person grid page while logged in.
3. Review the edit button and verify it matches the news one.

## Front End Validation
- [ ] Is the markup using the appropriate semantic tags and passes HTML validation?
- [ ] Cross-browser testing has been performed?
- [ ] Automated accessibility scans performed?
- [ ] Manual accessibility tests performed?
- [ ] Design is approved by @ user?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Person pages in edit mode

# Associated Issues and/or People
- D8CORE-2185
- https://github.com/SU-SWS/stanford_person/pull/113

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
