### PR TITLE
D8CORE-2470: Add process plugin to check image dimensions

### DIFF
--- a/config/sync/migrate_plus.migration.su_stanford_person.yml
+++ b/config/sync/migrate_plus.migration.su_stanford_person.yml
@@ -200,6 +200,11 @@ process:
       method: process
       source: profile_photo
     -
+      plugin: image_dimension_skip
+      method: process
+      width: 10
+      height: 10
+    -
       plugin: file_import
       destination: '@image_path'
       id_only: true

--- a/tests/codeception/acceptance/Content/PersonCest.php
+++ b/tests/codeception/acceptance/Content/PersonCest.php
@@ -107,7 +107,7 @@ class PersonCest {
    */
   public function testD8Core2613Terms(AcceptanceTester $I) {
     $I->logInWithRole('site_manager');
-    
+
     $foo = $I->createEntity([
       'name' => 'Foo',
       'vid' => 'stanford_person_types',
@@ -128,14 +128,14 @@ class PersonCest {
     $I->cantSeeLink('Baz');
 
     $I->amOnPage($baz->toUrl('edit-form')->toString());
-    $I->selectOption('Parent terms', '<root>');
+    $I->selectOption('Parent term', '<root>');
     $I->click('Save');
 
     $I->amOnPage('/people');
     $I->canSeeLink('Baz');
 
     $I->amOnPage($baz->toUrl('edit-form')->toString());
-    $I->selectOption('Parent terms', 'Bar');
+    $I->selectOption('Parent term', 'Bar');
     $I->click('Save');
 
     $I->amOnPage('/people');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Use the new process plugin in https://github.com/SU-SWS/stanford_migrate/pull/15

# Need Review By (Date)
- 10/15

# Urgency
- medium

# Steps to Test
1. checkout this branch & related branch in https://github.com/SU-SWS/stanford_migrate/pull/15
1. using a profile that doesn't have a public image use the sunet and import that profile
1. validate the profile isn't imported with a black dot image.



# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
