### PR TITLE
Adjusted the person importer to update the media item correctly

### DIFF
--- a/config/sync/migrate_plus.migration.su_stanford_person.yml
+++ b/config/sync/migrate_plus.migration.su_stanford_person.yml
@@ -213,20 +213,17 @@ process:
     -
       plugin: skip_on_empty
       method: process
-      source: profile_photo
-    -
-      plugin: skip_on_empty
-      method: process
       source: '@image_file'
     -
       plugin: entity_generate
-      source: display_name
-      value_key: name
+      source: '@image_file'
+      value_key: field_media_image
       bundle_key: bundle
       bundle: image
       entity_type: media
       ignore_case: true
       values:
+        name: '@title'
         field_media_image/target_id: '@image_file'
         field_media_image/alt: '@title'
   su_person_links:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
Before:
1. Importer runs and imports the image, lets say `pookmish123456.jpg` with file id `8` (123456 is the timestamp from the API)
1. a user changes the image and now its `pookmish654321.jpg` with file id `15`
1. the importer will run again and the file doesn't exist on the server so it downloads it
1. When getting to the `entity_generate` step, the key was targeting the name of the media item so it searches for the media entity before generating a new entity. Since the media item already exists, it doesn't create a new media item for the `pookmish654321.jpg`
1. The profile isn't updated with the new image

After:
In step 4 from above, now the entity_generate will search for a media item based on the file id of the imported file. Since no media item contains the file id `15` it will create a new media item and use that on the node.
The old image does become orphaned but i believe that's expected at this time.

Related PR: https://github.com/SU-SWS/stanford_person/pull/119

# Need Review By (Date)
- 10/20

# Urgency
- medium

# Steps to Test
1. run the above steps in the summary.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
