### PR TITLE
D8CORE-2856 Add list and entity reference paragraph types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -138,7 +138,7 @@
         "su-sws/stanford_news": "dev-8.x-2.x",
         "su-sws/stanford_notifications": "dev-8.x-1.x",
         "su-sws/stanford_person": "dev-8.x-1.x",
-        "su-sws/stanford_profile_helper": "dev-8.x-1.x",
+        "su-sws/stanford_profile_helper": "dev-D8CORE-2856 as dev-8.x-1.x",
         "su-sws/stanford_ssp": "dev-8.x-1.x",
         "su-sws/stanford_text_editor": "dev-8.x-1.x"
     },

--- a/composer.json
+++ b/composer.json
@@ -122,6 +122,7 @@
         "drupal/role_delegation": "^1.0@beta",
         "drupal/seckit": "^1.0@alpha",
         "drupal/ui_patterns": "~1.0",
+        "drupal/viewfield": "^3.0@beta",
         "drupal/views_block_filter_block": "^1.0@beta",
         "drupal/views_bulk_operations": "^3.6",
         "drupal/xmlsitemap": "~1.0",

--- a/config/sync/core.entity_form_display.paragraph.stanford_entity.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.stanford_entity.default.yml
@@ -1,0 +1,25 @@
+uuid: 0e4ac1c8-76d0-4343-913f-f247f358e60a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.stanford_entity.su_entity_item
+    - paragraphs.paragraphs_type.stanford_entity
+id: paragraph.stanford_entity.default
+targetEntityType: paragraph
+bundle: stanford_entity
+mode: default
+content:
+  su_entity_item:
+    weight: 0
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+hidden:
+  created: true
+  status: true

--- a/config/sync/core.entity_form_display.paragraph.stanford_entity.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.stanford_entity.default.yml
@@ -3,13 +3,43 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.stanford_entity.su_entity_button
+    - field.field.paragraph.stanford_entity.su_entity_description
+    - field.field.paragraph.stanford_entity.su_entity_headline
     - field.field.paragraph.stanford_entity.su_entity_item
     - paragraphs.paragraphs_type.stanford_entity
+  module:
+    - link
+    - text
 id: paragraph.stanford_entity.default
 targetEntityType: paragraph
 bundle: stanford_entity
 mode: default
 content:
+  su_entity_button:
+    weight: 3
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  su_entity_description:
+    weight: 2
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  su_entity_headline:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   su_entity_item:
     weight: 0
     settings:

--- a/config/sync/core.entity_form_display.paragraph.stanford_lists.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.stanford_lists.default.yml
@@ -1,0 +1,23 @@
+uuid: 6120280f-7695-4492-b158-11d5697a6b9a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.stanford_lists.su_list_view
+    - paragraphs.paragraphs_type.stanford_lists
+  module:
+    - viewfield
+id: paragraph.stanford_lists.default
+targetEntityType: paragraph
+bundle: stanford_lists
+mode: default
+content:
+  su_list_view:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: viewfield_select
+    region: content
+hidden:
+  created: true
+  status: true

--- a/config/sync/core.entity_form_display.paragraph.stanford_lists.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.stanford_lists.default.yml
@@ -3,15 +3,44 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.stanford_lists.su_list_button
+    - field.field.paragraph.stanford_lists.su_list_description
+    - field.field.paragraph.stanford_lists.su_list_headline
     - field.field.paragraph.stanford_lists.su_list_view
     - paragraphs.paragraphs_type.stanford_lists
   module:
+    - link
+    - text
     - viewfield
 id: paragraph.stanford_lists.default
 targetEntityType: paragraph
 bundle: stanford_lists
 mode: default
 content:
+  su_list_button:
+    weight: 3
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  su_list_description:
+    weight: 2
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  su_list_headline:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   su_list_view:
     weight: 0
     settings: {  }

--- a/config/sync/core.entity_view_display.node.stanford_event.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event.stanford_card.yml
@@ -1,0 +1,155 @@
+uuid: 30bae438-e471-4dc7-9778-a324afa97357
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.stanford_card
+    - field.field.node.stanford_event.body
+    - field.field.node.stanford_event.layout_builder__layout
+    - field.field.node.stanford_event.su_event_alt_loc
+    - field.field.node.stanford_event.su_event_audience
+    - field.field.node.stanford_event.su_event_components
+    - field.field.node.stanford_event.su_event_cta
+    - field.field.node.stanford_event.su_event_date_time
+    - field.field.node.stanford_event.su_event_dek
+    - field.field.node.stanford_event.su_event_email
+    - field.field.node.stanford_event.su_event_location
+    - field.field.node.stanford_event.su_event_map_link
+    - field.field.node.stanford_event.su_event_schedule
+    - field.field.node.stanford_event.su_event_source
+    - field.field.node.stanford_event.su_event_sponsor
+    - field.field.node.stanford_event.su_event_subheadline
+    - field.field.node.stanford_event.su_event_telephone
+    - field.field.node.stanford_event.su_event_type
+    - node.type.stanford_event
+  module:
+    - ds
+    - layout_builder
+    - layout_builder_restrictions
+    - layout_library
+    - smart_date
+    - user
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+  layout_library:
+    enable: false
+  layout_builder_restrictions:
+    allowed_block_categories: {  }
+    entity_view_mode_restriction:
+      whitelisted_blocks:
+        'Chaos Tools': {  }
+        'Config Pages': {  }
+        'Content fields':
+          - 'field_block:node:stanford_event:su_event_audience'
+          - 'field_block:node:stanford_event:uid'
+          - 'field_block:node:stanford_event:created'
+          - 'field_block:node:stanford_event:body'
+          - 'field_block:node:stanford_event:su_event_cta'
+          - 'field_block:node:stanford_event:changed'
+          - 'field_block:node:stanford_event:su_event_components'
+          - 'field_block:node:stanford_event:su_event_email'
+          - 'field_block:node:stanford_event:su_event_telephone'
+          - 'field_block:node:stanford_event:su_event_date_time'
+          - 'field_block:node:stanford_event:su_event_dek'
+          - 'field_block:node:stanford_event:su_event_alt_loc'
+          - 'field_block:node:stanford_event:title'
+          - 'field_block:node:stanford_event:su_event_type'
+          - 'field_block:node:stanford_event:su_event_source'
+          - 'field_block:node:stanford_event:nid'
+          - 'extra_field_block:node:stanford_event:links'
+          - 'field_block:node:stanford_event:su_event_location'
+          - 'field_block:node:stanford_event:su_event_map_link'
+          - 'field_block:node:stanford_event:menu_link'
+          - 'field_block:node:stanford_event:status'
+          - 'field_block:node:stanford_event:su_event_schedule'
+          - 'field_block:node:stanford_event:su_event_sponsor'
+          - 'field_block:node:stanford_event:su_event_subheadline'
+        Devel: {  }
+        'Devel PHP': {  }
+        Forms: {  }
+        'Lists (Views)': {  }
+        Menus:
+          - 'menu_block:stanford-event-types'
+          - 'menu_block:main'
+        'News Lists (Views)':
+          - 'views_block:stanford_news-vertical_teaser_term'
+          - 'views_block:stanford_news-vertical_teaser_term_list'
+          - 'views_block:stanford_news-block_1'
+          - 'views_block:stanford_news-term_block'
+        'People Lists (Views)':
+          - 'views_block:stanford_person-grid_list_all'
+          - 'views_block:stanford_person_list_terms_first-person_list_grid'
+        'SimpleSAMLphp Authentication': {  }
+        'Stanford News': {  }
+        'Stanford SimpleSAML PHP': {  }
+        System:
+          - system_messages_block
+      blacklisted_blocks: {  }
+      allowed_layouts:
+        - jumpstart_ui_one_column
+        - jumpstart_ui_one_column_overlay
+        - jumpstart_ui_two_column
+        - jumpstart_ui_three_column
+        - stanford_events_editorial_content
+        - stanford_events_body
+  ds:
+    layout:
+      id: pattern_card
+      library: null
+      disable_css: false
+      entity_classes: all_classes
+      settings:
+        pattern:
+          field_templates: default
+          variant: default
+    regions:
+      card_super_headline:
+        - su_event_date_time
+      card_headline:
+        - node_title
+    fields:
+      node_title:
+        plugin_id: node_title
+        weight: 1
+        label: hidden
+        formatter: default
+        settings:
+          link: true
+          wrapper: h2
+          class: ''
+id: node.stanford_event.stanford_card
+targetEntityType: node
+bundle: stanford_event
+mode: stanford_card
+content:
+  su_event_date_time:
+    type: smartdate_default
+    weight: 0
+    region: card_super_headline
+    label: hidden
+    settings:
+      format: default
+      force_chronological: false
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+hidden:
+  body: true
+  layout_builder__layout: true
+  links: true
+  su_event_alt_loc: true
+  su_event_audience: true
+  su_event_components: true
+  su_event_cta: true
+  su_event_dek: true
+  su_event_email: true
+  su_event_location: true
+  su_event_map_link: true
+  su_event_schedule: true
+  su_event_source: true
+  su_event_sponsor: true
+  su_event_subheadline: true
+  su_event_telephone: true
+  su_event_type: true

--- a/config/sync/core.entity_view_display.node.stanford_event_series.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event_series.default.yml
@@ -179,20 +179,20 @@ third_party_settings:
         'Chaos Tools': {  }
         'Config Pages': {  }
         'Content fields':
+          - 'field_block:node:stanford_event_series:uid'
+          - 'field_block:node:stanford_event_series:created'
           - 'field_block:node:stanford_event_series:changed'
           - 'field_block:node:stanford_event_series:su_event_series_components'
           - 'field_block:node:stanford_event_series:su_event_series_dek'
           - 'field_block:node:stanford_event_series:su_event_series_event'
+          - 'field_block:node:stanford_event_series:nid'
+          - 'extra_field_block:node:stanford_event_series:links'
           - 'field_block:node:stanford_event_series:menu_link'
+          - 'field_block:node:stanford_event_series:status'
           - 'field_block:node:stanford_event_series:su_event_series_subheadline'
+          - 'field_block:node:stanford_event_series:title'
           - 'field_block:node:stanford_event_series:su_event_series_type'
           - 'field_block:node:stanford_event_series:su_event_series_weight'
-          - 'extra_field_block:node:stanford_event_series:links'
-          - 'field_block:node:stanford_event_series:uid'
-          - 'field_block:node:stanford_event_series:created'
-          - 'field_block:node:stanford_event_series:nid'
-          - 'field_block:node:stanford_event_series:status'
-          - 'field_block:node:stanford_event_series:title'
         'Devel PHP': {  }
         Menus:
           - 'menu_block:stanford-event-types'

--- a/config/sync/core.entity_view_display.node.stanford_event_series.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event_series.stanford_card.yml
@@ -1,0 +1,127 @@
+uuid: f79a5269-6233-462d-b458-d43b2d6f5d44
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.stanford_card
+    - field.field.node.stanford_event_series.layout_builder__layout
+    - field.field.node.stanford_event_series.su_event_series_components
+    - field.field.node.stanford_event_series.su_event_series_dek
+    - field.field.node.stanford_event_series.su_event_series_event
+    - field.field.node.stanford_event_series.su_event_series_subheadline
+    - field.field.node.stanford_event_series.su_event_series_type
+    - field.field.node.stanford_event_series.su_event_series_weight
+    - node.type.stanford_event_series
+  module:
+    - ds
+    - layout_builder
+    - layout_builder_restrictions
+    - layout_library
+    - user
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+  layout_library:
+    enable: false
+  layout_builder_restrictions:
+    allowed_block_categories: {  }
+    entity_view_mode_restriction:
+      whitelisted_blocks:
+        'Chaos Tools': {  }
+        'Config Pages': {  }
+        'Content fields':
+          - 'field_block:node:stanford_event_series:uid'
+          - 'field_block:node:stanford_event_series:created'
+          - 'field_block:node:stanford_event_series:changed'
+          - 'field_block:node:stanford_event_series:su_event_series_components'
+          - 'field_block:node:stanford_event_series:su_event_series_dek'
+          - 'field_block:node:stanford_event_series:su_event_series_event'
+          - 'field_block:node:stanford_event_series:nid'
+          - 'extra_field_block:node:stanford_event_series:links'
+          - 'field_block:node:stanford_event_series:menu_link'
+          - 'field_block:node:stanford_event_series:status'
+          - 'field_block:node:stanford_event_series:su_event_series_subheadline'
+          - 'field_block:node:stanford_event_series:title'
+          - 'field_block:node:stanford_event_series:su_event_series_type'
+          - 'field_block:node:stanford_event_series:su_event_series_weight'
+        'Devel PHP': {  }
+        Menus:
+          - 'menu_block:stanford-event-types'
+          - 'menu_block:main'
+        'News Lists (Views)':
+          - 'views_block:stanford_news-vertical_teaser_term'
+          - 'views_block:stanford_news-vertical_teaser_term_list'
+          - 'views_block:stanford_news-block_1'
+          - 'views_block:stanford_news-term_block'
+        'People Lists (Views)':
+          - 'views_block:stanford_person-grid_list_all'
+          - 'views_block:stanford_person_list_terms_first-person_list_grid'
+        'SimpleSAMLphp Authentication': {  }
+        'Stanford News': {  }
+        'Stanford SimpleSAML PHP': {  }
+        System:
+          - system_messages_block
+      blacklisted_blocks: {  }
+      allowed_layouts:
+        - jumpstart_ui_one_column
+        - jumpstart_ui_one_column_overlay
+        - jumpstart_ui_two_column
+        - jumpstart_ui_three_column
+        - stanford_events_editorial_content
+        - stanford_events_body
+  ds:
+    layout:
+      id: pattern_card
+      library: null
+      disable_css: false
+      entity_classes: all_classes
+      settings:
+        pattern:
+          field_templates: default
+          variant: default
+    regions:
+      card_super_headline:
+        - su_event_series_dek
+      card_headline:
+        - node_title
+      card_body:
+        - su_event_series_subheadline
+    fields:
+      node_title:
+        plugin_id: node_title
+        weight: 1
+        label: hidden
+        formatter: default
+        settings:
+          link: true
+          wrapper: h2
+          class: ''
+id: node.stanford_event_series.stanford_card
+targetEntityType: node
+bundle: stanford_event_series
+mode: stanford_card
+content:
+  su_event_series_dek:
+    type: string
+    weight: 0
+    region: card_super_headline
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  su_event_series_subheadline:
+    type: string
+    weight: 2
+    region: card_body
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden:
+  layout_builder__layout: true
+  links: true
+  su_event_series_components: true
+  su_event_series_event: true
+  su_event_series_type: true
+  su_event_series_weight: true

--- a/config/sync/core.entity_view_display.node.stanford_news.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_news.default.yml
@@ -5,11 +5,11 @@ dependencies:
   config:
     - field.field.node.stanford_news.layout_builder__layout
     - field.field.node.stanford_news.su_news_banner
+    - field.field.node.stanford_news.su_news_banner_media_caption
     - field.field.node.stanford_news.su_news_byline
     - field.field.node.stanford_news.su_news_components
     - field.field.node.stanford_news.su_news_dek
     - field.field.node.stanford_news.su_news_featured_media
-    - field.field.node.stanford_news.su_news_banner_media_caption
     - field.field.node.stanford_news.su_news_headline
     - field.field.node.stanford_news.su_news_publishing_date
     - field.field.node.stanford_news.su_news_source
@@ -23,6 +23,7 @@ dependencies:
     - jumpstart_ui
     - layout_builder
     - layout_builder_restrictions
+    - layout_library
     - stanford_news
     - user
     - views
@@ -345,6 +346,8 @@ third_party_settings:
         - jumpstart_ui_three_column
         - stanford_news_byline
         - ds_reset
+  layout_library:
+    enable: false
 id: node.stanford_news.default
 targetEntityType: node
 bundle: stanford_news

--- a/config/sync/core.entity_view_display.node.stanford_news.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_news.stanford_card.yml
@@ -1,0 +1,124 @@
+uuid: 7cbf2959-2047-4342-a9f2-36d1a6d8b346
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.stanford_card
+    - field.field.node.stanford_news.layout_builder__layout
+    - field.field.node.stanford_news.su_news_banner
+    - field.field.node.stanford_news.su_news_banner_media_caption
+    - field.field.node.stanford_news.su_news_byline
+    - field.field.node.stanford_news.su_news_components
+    - field.field.node.stanford_news.su_news_dek
+    - field.field.node.stanford_news.su_news_featured_media
+    - field.field.node.stanford_news.su_news_headline
+    - field.field.node.stanford_news.su_news_publishing_date
+    - field.field.node.stanford_news.su_news_source
+    - field.field.node.stanford_news.su_news_topics
+    - node.type.stanford_news
+  module:
+    - ds
+    - field_formatter_class
+    - layout_builder
+    - layout_builder_restrictions
+    - layout_library
+    - stanford_media
+    - user
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+  layout_builder_restrictions:
+    allowed_block_categories: {  }
+    entity_view_mode_restriction:
+      whitelisted_blocks:
+        'Chaos Tools': {  }
+        'Config Pages': {  }
+        Menus:
+          - 'menu_block:main'
+          - 'menu_block:news-topics'
+        'SimpleSAMLphp Authentication': {  }
+        System:
+          - system_messages_block
+        core:
+          - page_title_block
+      blacklisted_blocks: {  }
+      allowed_layouts:
+        - jumpstart_ui_one_column
+        - jumpstart_ui_two_column
+        - jumpstart_ui_three_column
+        - stanford_news_byline
+        - ds_reset
+  layout_library:
+    enable: false
+  ds:
+    layout:
+      id: pattern_card
+      library: null
+      disable_css: false
+      entity_classes: all_classes
+      settings:
+        pattern:
+          field_templates: default
+          variant: default
+    regions:
+      card_image:
+        - su_news_featured_media
+      card_super_headline:
+        - su_news_dek
+      card_headline:
+        - node_title
+      card_body:
+        - node_post_date
+    fields:
+      node_title:
+        plugin_id: node_title
+        weight: 2
+        label: hidden
+        formatter: default
+        settings:
+          link: true
+          wrapper: h2
+          class: ''
+      node_post_date:
+        plugin_id: node_post_date
+        weight: 3
+        label: hidden
+        formatter: ds_post_date_long
+id: node.stanford_news.stanford_card
+targetEntityType: node
+bundle: stanford_news
+mode: stanford_card
+content:
+  su_news_dek:
+    type: string
+    weight: 1
+    region: card_super_headline
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  su_news_featured_media:
+    type: media_responsive_image_formatter
+    weight: 0
+    region: card_image
+    label: hidden
+    settings:
+      view_mode: default
+      image_style: card_2_1
+      link: true
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+hidden:
+  layout_builder__layout: true
+  layout_selection: true
+  links: true
+  su_news_banner: true
+  su_news_banner_media_caption: true
+  su_news_byline: true
+  su_news_components: true
+  su_news_headline: true
+  su_news_publishing_date: true
+  su_news_source: true
+  su_news_topics: true

--- a/config/sync/core.entity_view_display.node.stanford_page.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_page.default.yml
@@ -160,6 +160,9 @@ third_party_settings:
         - jumpstart_ui_one_column
         - jumpstart_ui_two_column
         - jumpstart_ui_three_column
+      whitelisted_blocks: {  }
+      blacklisted_blocks: {  }
+    allowed_block_categories: {  }
 id: node.stanford_page.default
 targetEntityType: node
 bundle: stanford_page

--- a/config/sync/core.entity_view_display.node.stanford_page.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_page.stanford_card.yml
@@ -1,0 +1,91 @@
+uuid: c05a8d85-bad5-43aa-8e5c-511bc0038b89
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.stanford_card
+    - field.field.node.stanford_page.layout_builder__layout
+    - field.field.node.stanford_page.layout_selection
+    - field.field.node.stanford_page.su_page_banner
+    - field.field.node.stanford_page.su_page_components
+    - node.type.stanford_page
+  module:
+    - ds
+    - entity_reference_revisions
+    - layout_builder
+    - layout_builder_restrictions
+    - layout_library
+    - user
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+  layout_library:
+    enable: true
+  layout_builder_restrictions:
+    entity_view_mode_restriction:
+      allowed_blocks:
+        'Chaos Tools': {  }
+        'Content fields':
+          - 'field_block:node:stanford_page:su_page_banner'
+          - 'field_block:node:stanford_page:su_page_components'
+          - 'field_block:node:stanford_page:title'
+        Forms: {  }
+        Help: {  }
+        Menus:
+          - 'menu_block:footer'
+          - 'system_menu_block:footer'
+          - 'menu_block:main'
+          - 'system_menu_block:main'
+        'SimpleSAMLphp Authentication': {  }
+        'Stanford SimpleSAML PHP': {  }
+        System: {  }
+        'User fields': {  }
+        core: {  }
+      allowed_layouts:
+        - jumpstart_ui_one_column
+        - jumpstart_ui_two_column
+        - jumpstart_ui_three_column
+      whitelisted_blocks: {  }
+      blacklisted_blocks: {  }
+    allowed_block_categories: {  }
+  ds:
+    layout:
+      id: pattern_card
+      library: null
+      disable_css: false
+      entity_classes: all_classes
+      settings:
+        pattern:
+          field_templates: default
+          variant: default
+    regions:
+      card_image:
+        - su_page_banner
+      card_headline:
+        - node_title
+    fields:
+      node_title:
+        plugin_id: node_title
+        weight: 1
+        label: hidden
+        formatter: default
+id: node.stanford_page.stanford_card
+targetEntityType: node
+bundle: stanford_page
+mode: stanford_card
+content:
+  su_page_banner:
+    type: entity_reference_revisions_entity_view
+    weight: 0
+    region: card_image
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+hidden:
+  layout_builder__layout: true
+  layout_selection: true
+  links: true
+  su_page_components: true

--- a/config/sync/core.entity_view_display.node.stanford_person.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_person.default.yml
@@ -6,6 +6,8 @@ dependencies:
     - core.base_field_override.node.stanford_person.title
     - field.field.node.stanford_person.body
     - field.field.node.stanford_person.layout_builder__layout
+    - field.field.node.stanford_person.su_person_academic_appt
+    - field.field.node.stanford_person.su_person_admin_appts
     - field.field.node.stanford_person.su_person_affiliations
     - field.field.node.stanford_person.su_person_components
     - field.field.node.stanford_person.su_person_education
@@ -24,6 +26,7 @@ dependencies:
     - field.field.node.stanford_person.su_person_profile_link
     - field.field.node.stanford_person.su_person_research
     - field.field.node.stanford_person.su_person_research_interests
+    - field.field.node.stanford_person.su_person_scholarly_interests
     - field.field.node.stanford_person.su_person_short_title
     - field.field.node.stanford_person.su_person_telephone
     - field.field.node.stanford_person.su_person_type_group
@@ -33,6 +36,7 @@ dependencies:
     - jumpstart_ui
     - layout_builder
     - layout_builder_restrictions
+    - layout_library
     - link
     - stanford_person
     - text
@@ -573,6 +577,8 @@ third_party_settings:
         - stanford_person_header
         - stanford_person_body
         - ds_reset
+  layout_library:
+    enable: false
 id: node.stanford_person.default
 targetEntityType: node
 bundle: stanford_person

--- a/config/sync/core.entity_view_display.node.stanford_person.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_person.stanford_card.yml
@@ -1,9 +1,9 @@
-uuid: 5dd1ebc9-f284-4a5f-b64c-3ccae280d2ca
+uuid: 53368cbb-310e-4ea2-9dd0-e0f517cad40a
 langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.teaser
+    - core.entity_view_mode.node.stanford_card
     - field.field.node.stanford_person.body
     - field.field.node.stanford_person.layout_builder__layout
     - field.field.node.stanford_person.su_person_academic_appt
@@ -32,28 +32,96 @@ dependencies:
     - field.field.node.stanford_person.su_person_type_group
     - node.type.stanford_person
   module:
-    - text
+    - ds
+    - field_formatter_class
+    - layout_builder
+    - layout_builder_restrictions
+    - layout_library
+    - stanford_media
     - user
-id: node.stanford_person.teaser
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+  layout_builder_restrictions:
+    allowed_block_categories: {  }
+    entity_view_mode_restriction:
+      whitelisted_blocks: {  }
+      blacklisted_blocks: {  }
+      allowed_layouts:
+        - jumpstart_ui_one_column
+        - jumpstart_ui_two_column
+        - jumpstart_ui_three_column
+        - stanford_person_header
+        - stanford_person_body
+        - ds_reset
+  layout_library:
+    enable: false
+  ds:
+    layout:
+      id: pattern_card
+      library: null
+      disable_css: false
+      entity_classes: all_classes
+      settings:
+        pattern:
+          field_templates: default
+          variant: default
+    regions:
+      card_image:
+        - su_person_photo
+      card_super_headline:
+        - su_person_short_title
+      card_headline:
+        - node_title
+      card_body:
+        - su_person_full_title
+    fields:
+      node_title:
+        plugin_id: node_title
+        weight: 2
+        label: hidden
+        formatter: default
+        settings:
+          link: true
+          wrapper: h2
+          class: ''
+id: node.stanford_person.stanford_card
 targetEntityType: node
 bundle: stanford_person
-mode: teaser
+mode: stanford_card
 content:
-  body:
+  su_person_full_title:
+    type: basic_string
+    weight: 3
+    region: card_body
     label: hidden
-    type: text_summary_or_trimmed
-    weight: 101
-    settings:
-      trim_length: 600
-    third_party_settings: {  }
-    region: content
-  links:
-    weight: 100
     settings: {  }
     third_party_settings: {  }
-    region: content
+  su_person_photo:
+    type: media_responsive_image_formatter
+    weight: 0
+    region: card_image
+    label: hidden
+    settings:
+      view_mode: default
+      image_style: card_2_1
+      link: false
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+  su_person_short_title:
+    type: string
+    weight: 1
+    region: card_super_headline
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
 hidden:
+  body: true
   layout_builder__layout: true
+  links: true
   su_person_academic_appt: true
   su_person_admin_appts: true
   su_person_affiliations: true
@@ -62,7 +130,6 @@ hidden:
   su_person_email: true
   su_person_fax: true
   su_person_first_name: true
-  su_person_full_title: true
   su_person_last_name: true
   su_person_links: true
   su_person_location_address: true
@@ -70,11 +137,9 @@ hidden:
   su_person_mail_code: true
   su_person_map_url: true
   su_person_mobile_phone: true
-  su_person_photo: true
   su_person_profile_link: true
   su_person_research: true
   su_person_research_interests: true
   su_person_scholarly_interests: true
-  su_person_short_title: true
   su_person_telephone: true
   su_person_type_group: true

--- a/config/sync/core.entity_view_display.paragraph.stanford_entity.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.stanford_entity.default.yml
@@ -1,0 +1,26 @@
+uuid: f43e800f-32a2-4557-beb0-36002b7182b6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.stanford_entity.su_entity_item
+    - paragraphs.paragraphs_type.stanford_entity
+  module:
+    - field_formatter_class
+id: paragraph.stanford_entity.default
+targetEntityType: paragraph
+bundle: stanford_entity
+mode: default
+content:
+  su_entity_item:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: teaser
+      link: false
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+    type: entity_reference_entity_view
+    region: content
+hidden: {  }

--- a/config/sync/core.entity_view_display.paragraph.stanford_entity.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.stanford_entity.default.yml
@@ -3,17 +3,54 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.stanford_entity.su_entity_button
+    - field.field.paragraph.stanford_entity.su_entity_description
+    - field.field.paragraph.stanford_entity.su_entity_headline
     - field.field.paragraph.stanford_entity.su_entity_item
     - paragraphs.paragraphs_type.stanford_entity
   module:
+    - element_class_formatter
     - field_formatter_class
+    - stanford_fields
+    - text
 id: paragraph.stanford_entity.default
 targetEntityType: paragraph
 bundle: stanford_entity
 mode: default
 content:
-  su_entity_item:
+  su_entity_button:
+    weight: 3
+    label: hidden
+    settings:
+      trim_length: 80
+      class: su-button
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+    type: link_class
+    region: content
+  su_entity_description:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  su_entity_headline:
     weight: 0
+    label: hidden
+    settings:
+      tag: h2
+      linked: false
+    third_party_settings: {  }
+    type: entity_title_heading
+    region: content
+  su_entity_item:
+    weight: 2
     label: hidden
     settings:
       view_mode: teaser

--- a/config/sync/core.entity_view_display.paragraph.stanford_entity.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.stanford_entity.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.paragraph.stanford_entity.su_entity_item
     - paragraphs.paragraphs_type.stanford_entity
   module:
+    - ds
     - element_class_formatter
     - field_formatter_class
     - stanford_fields
@@ -53,11 +54,13 @@ content:
     weight: 2
     label: hidden
     settings:
-      view_mode: teaser
+      view_mode: stanford_card
       link: false
     third_party_settings:
       field_formatter_class:
         class: ''
+      ds:
+        ds_limit: ''
     type: entity_reference_entity_view
     region: content
 hidden: {  }

--- a/config/sync/core.entity_view_display.paragraph.stanford_lists.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.stanford_lists.default.yml
@@ -1,0 +1,25 @@
+uuid: 90bc4aaa-a4dc-418a-ae0e-295f66e679a9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.stanford_lists.su_list_view
+    - paragraphs.paragraphs_type.stanford_lists
+  module:
+    - viewfield
+id: paragraph.stanford_lists.default
+targetEntityType: paragraph
+bundle: stanford_lists
+mode: default
+content:
+  su_list_view:
+    weight: 0
+    label: hidden
+    settings:
+      view_title: hidden
+      always_build_output: false
+      empty_view_title: hidden
+    third_party_settings: {  }
+    type: viewfield_default
+    region: content
+hidden: {  }

--- a/config/sync/core.entity_view_display.paragraph.stanford_lists.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.stanford_lists.default.yml
@@ -3,17 +3,55 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.stanford_lists.su_list_button
+    - field.field.paragraph.stanford_lists.su_list_description
+    - field.field.paragraph.stanford_lists.su_list_headline
     - field.field.paragraph.stanford_lists.su_list_view
     - paragraphs.paragraphs_type.stanford_lists
   module:
+    - element_class_formatter
+    - field_formatter_class
+    - stanford_fields
+    - text
     - viewfield
 id: paragraph.stanford_lists.default
 targetEntityType: paragraph
 bundle: stanford_lists
 mode: default
 content:
-  su_list_view:
+  su_list_button:
+    weight: 3
+    label: hidden
+    settings:
+      trim_length: 80
+      class: su-button
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+    type: link_class
+    region: content
+  su_list_description:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  su_list_headline:
     weight: 0
+    label: hidden
+    settings:
+      tag: h2
+      linked: false
+    third_party_settings: {  }
+    type: entity_title_heading
+    region: content
+  su_list_view:
+    weight: 2
     label: hidden
     settings:
       view_title: hidden

--- a/config/sync/core.entity_view_mode.node.stanford_card.yml
+++ b/config/sync/core.entity_view_mode.node.stanford_card.yml
@@ -1,0 +1,10 @@
+uuid: 0437a24b-b939-4f82-a9cb-9529dceafaa5
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.stanford_card
+label: Card
+targetEntityType: node
+cache: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -154,6 +154,7 @@ module:
   ultimate_cron: 0
   user: 0
   view_unpublished: 0
+  viewfield: 0
   views: 0
   views_block_filter_block: 0
   views_bulk_operations: 0

--- a/config/sync/field.field.paragraph.stanford_entity.su_entity_button.yml
+++ b/config/sync/field.field.paragraph.stanford_entity.su_entity_button.yml
@@ -1,0 +1,23 @@
+uuid: de6e80e8-321c-4c2d-a786-af9853f7e88a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.su_entity_button
+    - paragraphs.paragraphs_type.stanford_entity
+  module:
+    - link
+id: paragraph.stanford_entity.su_entity_button
+field_name: su_entity_button
+entity_type: paragraph
+bundle: stanford_entity
+label: Button
+description: 'This button will appear below the content items.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/config/sync/field.field.paragraph.stanford_entity.su_entity_description.yml
+++ b/config/sync/field.field.paragraph.stanford_entity.su_entity_description.yml
@@ -1,0 +1,27 @@
+uuid: 8297f771-4c95-4c32-a4a3-3fcb0584a4dc
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.su_entity_description
+    - paragraphs.paragraphs_type.stanford_entity
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    stanford_minimal_html: stanford_minimal_html
+    stanford_html: '0'
+    plain_text: '0'
+id: paragraph.stanford_entity.su_entity_description
+field_name: su_entity_description
+entity_type: paragraph
+bundle: stanford_entity
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/sync/field.field.paragraph.stanford_entity.su_entity_headline.yml
+++ b/config/sync/field.field.paragraph.stanford_entity.su_entity_headline.yml
@@ -1,0 +1,19 @@
+uuid: 1ef6d7dc-bddc-4ca9-b527-26563f28d81d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.su_entity_headline
+    - paragraphs.paragraphs_type.stanford_entity
+id: paragraph.stanford_entity.su_entity_headline
+field_name: su_entity_headline
+entity_type: paragraph
+bundle: stanford_entity
+label: Headline
+description: 'This headline will appear above the content items in large font.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.paragraph.stanford_entity.su_entity_item.yml
+++ b/config/sync/field.field.paragraph.stanford_entity.su_entity_item.yml
@@ -1,0 +1,36 @@
+uuid: 79c18cee-aaea-413c-a062-68b0e26ab337
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.su_entity_item
+    - node.type.stanford_event
+    - node.type.stanford_event_series
+    - node.type.stanford_news
+    - node.type.stanford_page
+    - node.type.stanford_person
+    - paragraphs.paragraphs_type.stanford_entity
+id: paragraph.stanford_entity.su_entity_item
+field_name: su_entity_item
+entity_type: paragraph
+bundle: stanford_entity
+label: 'Content Item'
+description: 'Choose an existing piece of content to display.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      stanford_page: stanford_page
+      stanford_event: stanford_event
+      stanford_event_series: stanford_event_series
+      stanford_news: stanford_news
+      stanford_person: stanford_person
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: stanford_page
+field_type: entity_reference

--- a/config/sync/field.field.paragraph.stanford_entity.su_entity_item.yml
+++ b/config/sync/field.field.paragraph.stanford_entity.su_entity_item.yml
@@ -14,8 +14,8 @@ id: paragraph.stanford_entity.su_entity_item
 field_name: su_entity_item
 entity_type: paragraph
 bundle: stanford_entity
-label: 'Content Item'
-description: 'Choose an existing piece of content to display.'
+label: 'Content Items'
+description: 'Choose existing pieces of content to display.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.paragraph.stanford_lists.su_list_button.yml
+++ b/config/sync/field.field.paragraph.stanford_lists.su_list_button.yml
@@ -1,0 +1,23 @@
+uuid: 58918065-4d83-4057-89a5-917752630719
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.su_list_button
+    - paragraphs.paragraphs_type.stanford_lists
+  module:
+    - link
+id: paragraph.stanford_lists.su_list_button
+field_name: su_list_button
+entity_type: paragraph
+bundle: stanford_lists
+label: Button
+description: 'This button will appear at the end of the list view.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/config/sync/field.field.paragraph.stanford_lists.su_list_description.yml
+++ b/config/sync/field.field.paragraph.stanford_lists.su_list_description.yml
@@ -1,0 +1,27 @@
+uuid: 211fec7c-f060-455a-a993-a848ebd5457a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.su_list_description
+    - paragraphs.paragraphs_type.stanford_lists
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    stanford_minimal_html: stanford_minimal_html
+    stanford_html: '0'
+    plain_text: '0'
+id: paragraph.stanford_lists.su_list_description
+field_name: su_list_description
+entity_type: paragraph
+bundle: stanford_lists
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/sync/field.field.paragraph.stanford_lists.su_list_headline.yml
+++ b/config/sync/field.field.paragraph.stanford_lists.su_list_headline.yml
@@ -1,0 +1,19 @@
+uuid: 7c8cb349-3956-4558-bce7-db767fc5d021
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.su_list_headline
+    - paragraphs.paragraphs_type.stanford_lists
+id: paragraph.stanford_lists.su_list_headline
+field_name: su_list_headline
+entity_type: paragraph
+bundle: stanford_lists
+label: Headline
+description: 'This is the main headline for the list paragraph. The headline will appear above the list view in large font.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.paragraph.stanford_lists.su_list_view.yml
+++ b/config/sync/field.field.paragraph.stanford_lists.su_list_view.yml
@@ -1,0 +1,45 @@
+uuid: bd7c7df1-493e-4f23-aa24-5d981e6362c5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.su_list_view
+    - paragraphs.paragraphs_type.stanford_lists
+  module:
+    - viewfield
+id: paragraph.stanford_lists.su_list_view
+field_name: su_list_view
+entity_type: paragraph
+bundle: stanford_lists
+label: 'Content List'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  force_default: false
+  allowed_views:
+    stanford_events: stanford_events
+    stanford_news: stanford_news
+    stanford_person: stanford_person
+    su_block_edit_links: '0'
+    content: '0'
+    block_content: '0'
+    stanford_events_past: '0'
+    stanford_events_schedule: '0'
+    stanford_event_series: '0'
+    stanford_event_terms_utility: '0'
+    media: '0'
+    media_library: '0'
+    stanford_news_terms: '0'
+    stanford_person_list_terms_first: '0'
+    stanford_person_terms: '0'
+    redirect: '0'
+  allowed_display_types:
+    block: block
+    default: '0'
+    page: '0'
+  handler: 'default:view'
+  handler_settings: {  }
+field_type: viewfield

--- a/config/sync/field.storage.paragraph.su_entity_button.yml
+++ b/config/sync/field.storage.paragraph.su_entity_button.yml
@@ -1,0 +1,19 @@
+uuid: 6b2ca166-7a73-40f5-b8e1-2153462595c0
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.su_entity_button
+field_name: su_entity_button
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.su_entity_description.yml
+++ b/config/sync/field.storage.paragraph.su_entity_description.yml
@@ -1,0 +1,19 @@
+uuid: de42d572-5b09-4a90-8f02-80457b18c1f8
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.su_entity_description
+field_name: su_entity_description
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.su_entity_headline.yml
+++ b/config/sync/field.storage.paragraph.su_entity_headline.yml
@@ -1,19 +1,20 @@
-uuid: 5ae5094b-ea6a-466a-95b5-9843400ec417
+uuid: 62d9d9d4-e26f-423d-bcc6-d039856b2715
 langcode: en
 status: true
 dependencies:
   module:
-    - node
     - paragraphs
-id: paragraph.su_entity_item
-field_name: su_entity_item
+id: paragraph.su_entity_headline
+field_name: su_entity_headline
 entity_type: paragraph
-type: entity_reference
+type: string
 settings:
-  target_type: node
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
 module: core
 locked: false
-cardinality: -1
+cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/sync/field.storage.paragraph.su_entity_item.yml
+++ b/config/sync/field.storage.paragraph.su_entity_item.yml
@@ -1,0 +1,20 @@
+uuid: 5ae5094b-ea6a-466a-95b5-9843400ec417
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.su_entity_item
+field_name: su_entity_item
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.su_list_button.yml
+++ b/config/sync/field.storage.paragraph.su_list_button.yml
@@ -1,0 +1,19 @@
+uuid: 6eb0ee10-c4f2-4e61-b5d0-677364ed86e8
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.su_list_button
+field_name: su_list_button
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.su_list_description.yml
+++ b/config/sync/field.storage.paragraph.su_list_description.yml
@@ -1,0 +1,19 @@
+uuid: f40de0f7-51a6-4a7b-9c3a-8637e4a994c0
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.su_list_description
+field_name: su_list_description
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.su_list_headline.yml
+++ b/config/sync/field.storage.paragraph.su_list_headline.yml
@@ -1,19 +1,20 @@
-uuid: 5ae5094b-ea6a-466a-95b5-9843400ec417
+uuid: 9b56f4ec-7862-4fe3-a6f4-8152d3057808
 langcode: en
 status: true
 dependencies:
   module:
-    - node
     - paragraphs
-id: paragraph.su_entity_item
-field_name: su_entity_item
+id: paragraph.su_list_headline
+field_name: su_list_headline
 entity_type: paragraph
-type: entity_reference
+type: string
 settings:
-  target_type: node
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
 module: core
 locked: false
-cardinality: -1
+cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/sync/field.storage.paragraph.su_list_view.yml
+++ b/config/sync/field.storage.paragraph.su_list_view.yml
@@ -1,0 +1,21 @@
+uuid: d82e4bb3-a262-4642-b49e-8492517eebd1
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - viewfield
+    - views
+id: paragraph.su_list_view
+field_name: su_list_view
+entity_type: paragraph
+type: viewfield
+settings:
+  target_type: view
+module: viewfield
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/paragraphs.paragraphs_type.stanford_entity.yml
+++ b/config/sync/paragraphs.paragraphs_type.stanford_entity.yml
@@ -1,0 +1,10 @@
+uuid: 98599141-f758-4ea5-bec4-4119d7556a61
+langcode: en
+status: true
+dependencies: {  }
+id: stanford_entity
+label: 'Content Reference'
+icon_uuid: null
+icon_default: null
+description: 'Pick a specific piece of content to display.'
+behavior_plugins: {  }

--- a/config/sync/paragraphs.paragraphs_type.stanford_lists.yml
+++ b/config/sync/paragraphs.paragraphs_type.stanford_lists.yml
@@ -1,0 +1,10 @@
+uuid: 39ad7fe3-c7d5-44c7-baa4-9f3ded7a8db4
+langcode: en
+status: true
+dependencies: {  }
+id: stanford_lists
+label: Lists
+icon_uuid: null
+icon_default: null
+description: 'Choose a list to display various items dynamically.'
+behavior_plugins: {  }

--- a/config/sync/views.view.stanford_person.yml
+++ b/config/sync/views.view.stanford_person.yml
@@ -13,7 +13,7 @@ dependencies:
     - user
     - views_infinite_scroll
 id: stanford_person
-label: 'People Grid'
+label: People
 module: views
 description: 'A list of people in a grid with node as the base table'
 tag: ''
@@ -582,7 +582,7 @@ display:
   grid_list_all:
     display_plugin: block
     id: grid_list_all
-    display_title: 'People Grid - All Results'
+    display_title: 'Grid - All Results'
     position: 1
     display_options:
       display_extenders: {  }

--- a/tests/codeception/acceptance/Paragraphs/ListsCest.php
+++ b/tests/codeception/acceptance/Paragraphs/ListsCest.php
@@ -1,0 +1,126 @@
+<?php
+
+use Faker\Factory;
+
+/**
+ * Class ListsCest.
+ */
+class ListsCest {
+
+  /**
+   * News items should display in the list paragraph.
+   */
+  public function testListParagraphNews(AcceptanceTester $I) {
+    $I->logInWithRole('contributor');
+    $I->amOnPage('/node/add/stanford_news');
+    $I->fillField('Headline', 'Foo Bar News');
+    $I->click('Save');
+
+    $node = $this->getNodeWithList($I, [
+      'target_id' => 'stanford_news',
+      'display_id' => 'vertical_teaser_term',
+      'items_to_display' => 100,
+    ]);
+
+    $I->amOnPage($node->toUrl()->toString());
+    $I->canSee('Headliner');
+    $I->canSee('Lorem Ipsum');
+    $I->canSeeLink('Google', 'http://google.com');
+    $I->canSee('Foo Bar News');
+  }
+
+  /**
+   * Event items should display in the list paragraph.
+   */
+  public function testListParagraphEvents(AcceptanceTester $I) {
+    $I->logInWithRole('contributor');
+    $event = $I->createEntity([
+      'type' => 'stanford_event',
+      'title' => 'Foo Bar Event',
+      'su_event_date_time' => [
+        'value' => time(),
+        'end_value' => time() + 60,
+      ],
+    ]);
+    $I->amOnPage("/node/{$event->id()}/edit");
+    $I->click('Save');
+
+    $node = $this->getNodeWithList($I, [
+      'target_id' => 'stanford_events',
+      'display_id' => 'list_page',
+      'items_to_display' => 100,
+    ]);
+
+    $I->amOnPage($node->toUrl()->toString());
+    $I->canSee('Headliner');
+    $I->canSee('Lorem Ipsum');
+    $I->canSeeLink('Google', 'http://google.com');
+    $I->canSee('Foo Bar Event');
+  }
+
+  /**
+   * People items should display in the list paragraph.
+   */
+  public function testListParagraphPeople(AcceptanceTester $I) {
+    $I->logInWithRole('contributor');
+    $I->amOnPage('/node/add/stanford_person');
+    $I->fillField('First Name', 'Foo');
+    $I->fillField('Last Name', 'Bar Person');
+    $I->fillField('Short Title', 'Short title field');
+    $I->click('Save');
+
+    $node = $this->getNodeWithList($I, [
+      'target_id' => 'stanford_person',
+      'display_id' => 'grid_list_all',
+      'items_to_display' => 100,
+    ]);
+
+    $I->amOnPage($node->toUrl()->toString());
+    $I->canSee('Headliner');
+    $I->canSee('Lorem Ipsum');
+    $I->canSeeLink('Google', 'http://google.com');
+    $I->canSee('Foo Bar Person');
+  }
+
+  /**
+   * Get a node with a list paragraph in a row.
+   *
+   * @param \AcceptanceTester $I
+   *   Tester.
+   * @param array $view
+   *   Keyed field value.
+   *
+   * @return bool|\Drupal\node\NodeInterface
+   */
+  protected function getNodeWithList(AcceptanceTester $I, array $view) {
+    $faker = Factory::create();
+
+    $paragraph = $I->createEntity([
+      'type' => 'stanford_lists',
+      'su_list_view' => $view,
+      'su_list_headline' => 'Headliner',
+      'su_list_description' => [
+        'format' => 'stanford_basic_html',
+        'value' => '<p>Lorem Ipsum</p>',
+      ],
+      'su_list_button' => ['uri' => 'http://google.com', 'title' => 'Google'],
+    ], 'paragraph');
+    $row = $I->createEntity([
+      'type' => 'node_stanford_page_row',
+      'su_page_components' => [
+        'target_id' => $paragraph->id(),
+        'entity' => $paragraph,
+      ],
+    ], 'paragraph_row');
+
+    return $I->createEntity([
+      'type' => 'stanford_page',
+      'title' => $faker->text(30),
+      'su_page_components' => [
+        'target_id' => $row->id(),
+        'entity' => $row,
+      ],
+    ]);
+  }
+
+}

--- a/tests/codeception/functional/Paragraphs/EntityReferenceCest.php
+++ b/tests/codeception/functional/Paragraphs/EntityReferenceCest.php
@@ -1,0 +1,76 @@
+<?php
+
+use Faker\Factory;
+
+/**
+ * Class EntityReferenceCest.
+ */
+class EntityReferenceCest {
+
+  /**
+   * News items should display in the list paragraph.
+   */
+  public function testEntityReference(FunctionalTester $I) {
+    $I->logInWithRole('contributor');
+    $I->amOnPage('/node/add/stanford_news');
+    $I->fillField('Headline', 'Foo Bar News');
+    $I->click('Save');
+
+    $node = $this->getNodeWithList($I);
+
+    $I->amOnPage($node->toUrl()->toString());
+    $I->click('Edit', '.local-tasks-block');
+
+    $I->waitForElementVisible('#row-0');
+    $I->click('Edit', '.inner-row-wrapper');
+
+    $I->waitForText('Content Items');
+    $I->fillField('#su_entity_item', 'Foo Bar News');
+    $I->click('.MuiAutocomplete-option');
+
+    $I->click('Continue');
+    $I->waitForElementNotVisible('.MuiDialog-scrollPaper');
+    $I->click('Save');
+    $I->canSee('has been updated');
+    $I->canSee('Foo Bar News');
+  }
+
+  /**
+   * Get a node with a Entity Reference paragraph in a row.
+   *
+   * @param \FunctionalTester $I
+   *   Tester.
+   *
+   * @return bool|\Drupal\node\NodeInterface
+   */
+  protected function getNodeWithList(FunctionalTester $I) {
+    $faker = Factory::create();
+
+    $paragraph = $I->createEntity([
+      'type' => 'stanford_entity',
+      'su_list_headline' => 'Headliner',
+      'su_list_description' => [
+        'format' => 'stanford_basic_html',
+        'value' => '<p>Lorem Ipsum</p>',
+      ],
+      'su_list_button' => ['uri' => 'http://google.com', 'title' => 'Google'],
+    ], 'paragraph');
+    $row = $I->createEntity([
+      'type' => 'node_stanford_page_row',
+      'su_page_components' => [
+        'target_id' => $paragraph->id(),
+        'entity' => $paragraph,
+      ],
+    ], 'paragraph_row');
+
+    return $I->createEntity([
+      'type' => 'stanford_page',
+      'title' => $faker->text(30),
+      'su_page_components' => [
+        'target_id' => $row->id(),
+        'entity' => $row,
+      ],
+    ]);
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Created entity reference and view reference paragraph types
- Stubbed out starting point for a "Card" display for each paragraph type. These will be revised later
- Limited the views to only a few choices that I assume are the best at this time.

# Need Review By (Date)
- 10/19

# Urgency
- medium

# Steps to Test
1. checkout this branch and the same branch in https://github.com/SU-SWS/stanford_profile_helper/pull/34
1. `composer require drupal/viewfield` (it's easier this way than doing all the different requirements)
1. `blt drupal:update` or `blt drupal:install -n`
1. Create a basic page and use the "Lists" or "Content Reference" paragraph types.
1. verify they work close to what you'd expect.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)

see https://github.com/SU-SWS/stanford_profile_helper/pull/34