### PR TITLE
D8CORE-2002: config adjustment to hide required asterisk for field group

### DIFF
--- a/config/sync/core.entity_form_display.node.stanford_person.default.yml
+++ b/config/sync/core.entity_form_display.node.stanford_person.default.yml
@@ -104,7 +104,7 @@ third_party_settings:
         id: ''
         classes: ''
         description: ''
-        required_fields: true
+        required_fields: false
       label: 'Interests & Affiliations'
     group_taxonomy:
       children:

--- a/tests/codeception/acceptance/Content/PersonCest.php
+++ b/tests/codeception/acceptance/Content/PersonCest.php
@@ -107,7 +107,7 @@ class PersonCest {
    */
   public function testD8Core2613Terms(AcceptanceTester $I) {
     $I->logInWithRole('site_manager');
-    
+
     $foo = $I->createEntity([
       'name' => 'Foo',
       'vid' => 'stanford_person_types',
@@ -128,14 +128,14 @@ class PersonCest {
     $I->cantSeeLink('Baz');
 
     $I->amOnPage($baz->toUrl('edit-form')->toString());
-    $I->selectOption('Parent terms', '<root>');
+    $I->selectOption('Parent term', '<root>');
     $I->click('Save');
 
     $I->amOnPage('/people');
     $I->canSeeLink('Baz');
 
     $I->amOnPage($baz->toUrl('edit-form')->toString());
-    $I->selectOption('Parent terms', 'Bar');
+    $I->selectOption('Parent term', 'Bar');
     $I->click('Save');
 
     $I->amOnPage('/people');


### PR DESCRIPTION

# READY FOR REVIEW

# Summary
- Takes the config changes here: https://github.com/SU-SWS/stanford_person/pull/121
and applies them to the profile.

# Needed By (Date)
- soon.

# Urgency
- not critical

# Steps to Test

- Check out this branch
- `drush cim`
- Make a Person content type.
- in the "Interests & Affiliations" field group, add a link under Links or Stanford Affiliations.
- Notice that when you put in a URL, the Link Text gets marked as required.
- Notice that the "Interests & Affiliations" field group as a whole does not get marked as required.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/D8CORE-2002
- https://github.com/SU-SWS/stanford_person/pull/121

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
