### PR TITLE
D8CORE 2710 News lists contextual filters and tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,6 +125,7 @@
         "drupal/viewfield": "^3.0@beta",
         "drupal/views_block_filter_block": "^1.0@beta",
         "drupal/views_bulk_operations": "^3.6",
+        "drupal/views_taxonomy_term_name_depth": "^7.0",
         "drupal/xmlsitemap": "~1.0",
         "ext-imagick": "*",
         "su-sws/jumpstart_ui": "dev-8.x-1.x",
@@ -173,6 +174,9 @@
             },
             "drupal/paragraphs": {
                 "https://www.drupal.org/project/paragraphs/issues/2901390": "https://www.drupal.org/files/issues/2020-06-25/paragraphs-2901390-51.patch"
+            },
+            "drupal/views_taxonomy_term_name_depth": {
+                "https://www.drupal.org/project/views_taxonomy_term_name_depth/issues/2877249": "https://www.drupal.org/files/issues/2020-05-01/2877249_21.patch"
             }
         }
     }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -160,6 +160,7 @@ module:
   views_bulk_operations: 0
   views_contextual_filters_or: 0
   views_infinite_scroll: 0
+  views_taxonomy_term_name_depth: 0
   views_ui: 0
   xmlsitemap_engines: 0
   ds: 1

--- a/config/sync/views.view.stanford_news.yml
+++ b/config/sync/views.view.stanford_news.yml
@@ -20,6 +20,7 @@ dependencies:
     - ui_patterns_views
     - user
     - views_infinite_scroll
+    - views_taxonomy_term_name_depth
 id: stanford_news
 label: News
 module: views
@@ -699,7 +700,46 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       display_description: 'Term Block - All Results'
-      arguments: {  }
+      arguments:
+        term_node_taxonomy_name_depth:
+          id: term_node_taxonomy_name_depth
+          table: node_field_data
+          field: term_node_taxonomy_name_depth
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          depth: '0'
+          vocabularies:
+            stanford_news_topics: stanford_news_topics
+          break_phrase: true
+          use_taxonomy_term_path: false
+          entity_type: node
+          plugin_id: taxonomy_index_name_depth
       filters:
         status:
           value: '1'
@@ -857,6 +897,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
@@ -1274,6 +1315,45 @@ display:
       display_extenders: {  }
       display_description: 'Vertical Teaser Term'
       arguments:
+        term_node_taxonomy_name_depth:
+          id: term_node_taxonomy_name_depth
+          table: node_field_data
+          field: term_node_taxonomy_name_depth
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          depth: '0'
+          vocabularies:
+            stanford_news_topics: stanford_news_topics
+          break_phrase: true
+          use_taxonomy_term_path: false
+          entity_type: node
+          plugin_id: taxonomy_index_name_depth
         nid:
           id: nid
           table: node_field_data
@@ -1335,7 +1415,7 @@ display:
       row:
         type: ui_patterns
         options:
-          default_field_elements: 0
+          default_field_elements: 1
           inline:
             su_news_publishing_date: 0
             su_news_featured_media: 0
@@ -1346,19 +1426,19 @@ display:
             view_node: 0
             edit_node: 0
           separator: ''
-          hide_empty: 0
+          hide_empty: 1
           pattern: news-vertical-teaser
           variants:
-            media: default
-            lockup: a
-            hero: default
-            brandbar: default
-            link: default
-            button: default
-            date-stacked: default
-            cta: default
             alert: default
+            brandbar: default
+            button: default
             card: default
+            cta: default
+            date-stacked: default
+            hero: default
+            link: default
+            lockup: a
+            media: default
           pattern_mapping:
             'views_row:su_news_featured_media':
               destination: news_vertical_teaser_image

--- a/config/sync/views.view.stanford_news.yml
+++ b/config/sync/views.view.stanford_news.yml
@@ -1408,9 +1408,9 @@ display:
           columns: 3
           automatic_width: false
           alignment: horizontal
-          col_class_default: false
+          col_class_default: true
           col_class_custom: flex-4-of-12
-          row_class_default: false
+          row_class_default: true
           row_class_custom: 'flex-container more-news-view'
       row:
         type: ui_patterns


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added contextual filter arguments for the news topic terms

# Need Review By (Date)
- 10/30

# Urgency
- medium

# Steps to Test
1. Checkout this branch
1. drush cim
1. create some news with topic terms associated to them
1. create a basic page with a "Lists" paragraph using either of the news views.
1. Populate the "Arguments" with the taxonomy term names.
   - Note that if you populate it with a string that doesn't correlate to a taxonomy term name, the arguments will be empty and therefore it won't filter the content at all. It will be as if you didn't put any arguments in at all.
1. validate the view is filtered for your content.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
