### PR TITLE
D8CORE-2885 People lists contextual filters and tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,6 +125,7 @@
         "drupal/viewfield": "^3.0@beta",
         "drupal/views_block_filter_block": "^1.0@beta",
         "drupal/views_bulk_operations": "^3.6",
+        "drupal/views_taxonomy_term_name_depth": "^7.0",
         "drupal/xmlsitemap": "~1.0",
         "ext-imagick": "*",
         "su-sws/jumpstart_ui": "dev-8.x-1.x",
@@ -173,6 +174,9 @@
             },
             "drupal/paragraphs": {
                 "https://www.drupal.org/project/paragraphs/issues/2901390": "https://www.drupal.org/files/issues/2020-06-25/paragraphs-2901390-51.patch"
+            },
+            "drupal/views_taxonomy_term_name_depth": {
+                "https://www.drupal.org/project/views_taxonomy_term_name_depth/issues/2877249": "https://www.drupal.org/files/issues/2020-05-01/2877249_21.patch"
             }
         }
     }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -160,6 +160,7 @@ module:
   views_bulk_operations: 0
   views_contextual_filters_or: 0
   views_infinite_scroll: 0
+  views_taxonomy_term_name_depth: 0
   views_ui: 0
   xmlsitemap_engines: 0
   ds: 1

--- a/config/sync/views.view.stanford_person.yml
+++ b/config/sync/views.view.stanford_person.yml
@@ -12,6 +12,7 @@ dependencies:
     - stanford_media
     - user
     - views_infinite_scroll
+    - views_taxonomy_term_name_depth
 id: stanford_person
 label: People
 module: views
@@ -589,7 +590,46 @@ display:
       display_description: 'A list of people on a grid page view'
       block_description: 'People Grid - All Results'
       block_category: 'People Lists (Views)'
-      arguments: {  }
+      arguments:
+        term_node_taxonomy_name_depth:
+          id: term_node_taxonomy_name_depth
+          table: node_field_data
+          field: term_node_taxonomy_name_depth
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          depth: '0'
+          vocabularies:
+            stanford_person_types: stanford_person_types
+          break_phrase: true
+          use_taxonomy_term_path: false
+          entity_type: node
+          plugin_id: taxonomy_index_name_depth
       defaults:
         arguments: false
         relationships: false
@@ -898,6 +938,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added contextual filter arguments for the People Type terms

# Need Review By (Date)
- 10/30

# Urgency
- medium

# Steps to Test
1. Checkout this branch
1. drush cim
1. create some profiles with "Type" terms associated to them
1. create a basic page with a "Lists" paragraph using the people views.
1. Populate the "Arguments" with the taxonomy term names.
   - Note that if you populate it with a string that doesn't correlate to a taxonomy term name, the arguments will be empty and therefore it won't filter the content at all. It will be as if you didn't put any arguments in at all.
1. validate the view is filtered for your content.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
