### PR TITLE
D8CORE-2720 D8CORE-2787 News card display for entity reference

### DIFF
--- a/config/sync/core.entity_view_display.node.stanford_news.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_news.stanford_card.yml
@@ -18,10 +18,12 @@ dependencies:
     - node.type.stanford_news
   module:
     - ds
+    - element_class_formatter
     - field_formatter_class
     - layout_builder
     - layout_builder_restrictions
     - layout_library
+    - link
     - stanford_media
     - user
 third_party_settings:
@@ -53,63 +55,93 @@ third_party_settings:
     enable: false
   ds:
     layout:
-      id: pattern_card
+      id: pattern_news-vertical-teaser
       library: null
       disable_css: false
       entity_classes: all_classes
       settings:
         pattern:
-          field_templates: default
-          variant: default
+          field_templates: only_content
     regions:
-      card_image:
+      news_vertical_teaser_image:
         - su_news_featured_media
-      card_super_headline:
-        - su_news_dek
-      card_headline:
+      news_vertical_teaser_headline:
         - node_title
-      card_body:
-        - node_post_date
+      news_topics:
+        - su_news_topics
+      news_source:
+        - su_news_source
+      news_url:
+        - 'dynamic_token_field:node-news_content_url'
     fields:
+      'dynamic_token_field:node-news_content_url':
+        plugin_id: 'dynamic_token_field:node-news_content_url'
+        weight: 4
+        label: hidden
+        formatter: default
       node_title:
         plugin_id: node_title
-        weight: 2
+        weight: 1
         label: hidden
         formatter: default
         settings:
-          link: true
-          wrapper: h2
+          wrapper: ''
           class: ''
-      node_post_date:
-        plugin_id: node_post_date
-        weight: 3
-        label: hidden
-        formatter: ds_post_date_long
+          link: false
 id: node.stanford_news.stanford_card
 targetEntityType: node
 bundle: stanford_news
 mode: stanford_card
 content:
-  su_news_dek:
-    type: string
-    weight: 1
-    region: card_super_headline
-    label: hidden
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
   su_news_featured_media:
-    type: media_responsive_image_formatter
+    type: media_multimedia_formatter
     weight: 0
-    region: card_image
+    region: news_vertical_teaser_image
     label: hidden
     settings:
+      image:
+        image_formatter: image_style
+        image_formatter_image_style: su_news_list
+        image_formatter_responsive_image_style: full_responsive
+        image_formatter_view_mode: default
+      video:
+        video_formatter: entity
+        video_formatter_view_mode: default
+      other:
+        view_mode: default
       view_mode: default
-      image_style: card_2_1
-      link: true
+      link: false
     third_party_settings:
       field_formatter_class:
         class: ''
+  su_news_source:
+    type: link
+    weight: 3
+    region: news_source
+    label: hidden
+    settings:
+      trim_length: null
+      url_only: true
+      url_plain: true
+      rel: '0'
+      target: '0'
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+  su_news_topics:
+    type: entity_reference_list_label_class
+    weight: 2
+    region: news_topics
+    label: hidden
+    settings:
+      link: true
+      list_type: ul
+      class: ''
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+      ds:
+        ds_limit: ''
 hidden:
   layout_builder__layout: true
   layout_selection: true
@@ -118,7 +150,6 @@ hidden:
   su_news_banner_media_caption: true
   su_news_byline: true
   su_news_components: true
+  su_news_dek: true
   su_news_headline: true
   su_news_publishing_date: true
-  su_news_source: true
-  su_news_topics: true

--- a/config/sync/ds.field.news_content_url.yml
+++ b/config/sync/ds.field.news_content_url.yml
@@ -1,0 +1,11 @@
+id: news_content_url
+label: 'News Content URL'
+ui_limit: 'stanford_news|*'
+properties:
+  content:
+    value: "<p>[node:url]</p>\r\n"
+    format: stanford_minimal_html
+type: token
+type_label: 'Token field'
+entities:
+  node: node

--- a/config/sync/views.view.stanford_news.yml
+++ b/config/sync/views.view.stanford_news.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.node.stanford_card
     - field.storage.node.su_news_dek
     - field.storage.node.su_news_featured_media
     - field.storage.node.su_news_headline
@@ -1413,63 +1414,10 @@ display:
           row_class_default: true
           row_class_custom: 'flex-container more-news-view'
       row:
-        type: ui_patterns
+        type: 'entity:node'
         options:
-          default_field_elements: 1
-          inline:
-            su_news_publishing_date: 0
-            su_news_featured_media: 0
-            su_news_headline: 0
-            su_news_dek: 0
-            su_news_topics: 0
-            su_news_source: 0
-            view_node: 0
-            edit_node: 0
-          separator: ''
-          hide_empty: 1
-          pattern: news-vertical-teaser
-          variants:
-            alert: default
-            brandbar: default
-            button: default
-            card: default
-            cta: default
-            date-stacked: default
-            hero: default
-            link: default
-            lockup: a
-            media: default
-          pattern_mapping:
-            'views_row:su_news_featured_media':
-              destination: news_vertical_teaser_image
-              weight: 0
-              plugin: views_row
-              source: su_news_featured_media
-            'views_row:su_news_source':
-              destination: news_source
-              weight: 1
-              plugin: views_row
-              source: su_news_source
-            'views_row:view_node':
-              destination: news_url
-              weight: 2
-              plugin: views_row
-              source: view_node
-            'views_row:su_news_headline':
-              destination: news_vertical_teaser_headline
-              weight: 3
-              plugin: views_row
-              source: su_news_headline
-            'views_row:su_news_topics':
-              destination: news_topics
-              weight: 4
-              plugin: views_row
-              source: su_news_topics
-            'views_row:edit_node':
-              destination: news_footer
-              weight: 5
-              plugin: views_row
-              source: edit_node
+          relationship: none
+          view_mode: stanford_card
       pager:
         type: some
         options:
@@ -1584,63 +1532,10 @@ display:
           row_class_default: false
           row_class_custom: 'flex-container more-news-view'
       row:
-        type: ui_patterns
+        type: 'entity:node'
         options:
-          default_field_elements: 0
-          inline:
-            su_news_publishing_date: 0
-            su_news_featured_media: 0
-            su_news_headline: 0
-            su_news_dek: 0
-            su_news_topics: 0
-            su_news_source: 0
-            view_node: 0
-            edit_node: 0
-          separator: ''
-          hide_empty: 0
-          pattern: news-vertical-teaser
-          variants:
-            media: default
-            lockup: a
-            hero: default
-            brandbar: default
-            link: default
-            button: default
-            date-stacked: default
-            cta: default
-            alert: default
-            card: default
-          pattern_mapping:
-            'views_row:su_news_featured_media':
-              destination: news_vertical_teaser_image
-              weight: 0
-              plugin: views_row
-              source: su_news_featured_media
-            'views_row:view_node':
-              destination: news_url
-              weight: 1
-              plugin: views_row
-              source: view_node
-            'views_row:edit_node':
-              destination: news_footer
-              weight: 2
-              plugin: views_row
-              source: edit_node
-            'views_row:su_news_source':
-              destination: news_source
-              weight: 3
-              plugin: views_row
-              source: su_news_source
-            'views_row:su_news_headline':
-              destination: news_vertical_teaser_headline
-              weight: 4
-              plugin: views_row
-              source: su_news_headline
-            'views_row:su_news_topics':
-              destination: news_topics
-              weight: 5
-              plugin: views_row
-              source: su_news_topics
+          relationship: none
+          view_mode: stanford_card
       fields:
         su_news_publishing_date:
           id: su_news_publishing_date

--- a/tests/codeception/functional/Paragraphs/EntityReferenceCest.php
+++ b/tests/codeception/functional/Paragraphs/EntityReferenceCest.php
@@ -23,7 +23,7 @@ class EntityReferenceCest {
     $I->fillField('Headline', 'Foo Bar News');
     $I->click('Save');
 
-    $node = $this->getNodeWithList($I);
+    $node = $this->getNodeWithReferenceParagraph($I);
 
     $I->amOnPage($node->toUrl()->toString());
     $I->click('Edit', '.local-tasks-block');
@@ -39,7 +39,7 @@ class EntityReferenceCest {
     $I->waitForElementNotVisible('.MuiDialog-scrollPaper');
     $I->click('Save');
     $I->canSee('has been updated');
-    $I->canSee('Foo Bar News');
+    $I->canSee('Foo Bar News', '.su-card.su-news-vertical-teaser');
   }
 
   /**
@@ -50,7 +50,7 @@ class EntityReferenceCest {
    *
    * @return bool|\Drupal\node\NodeInterface
    */
-  protected function getNodeWithList(FunctionalTester $I) {
+  protected function getNodeWithReferenceParagraph(FunctionalTester $I) {
     $faker = Factory::create();
 
     $paragraph = $I->createEntity([


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Configure the card display mode on news to use the vertical teaser pattern
- Change the views to use the view mode instead of fields for consistency.

# Need Review By (Date)
- 10/30

# Urgency
- medium

# Steps to Test
1. checkout this branch & the matching branch in https://github.com/SU-SWS/stanford_news/pull/103
1. `drush cim`
1. Create a news item or publish existing news content.
1. create a basic page
1. add a "Content Reference" paragraph type
1. In the content reference field choose a news item
1. save the page and verify the news card looks like the vertical card pattern.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
