### PR TITLE
D8CORE-2780 Use square image style to make a circle

### DIFF
--- a/config/sync/core.entity_view_display.node.stanford_person.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_person.stanford_card.yml
@@ -84,7 +84,7 @@ third_party_settings:
         formatter: default
         settings:
           link: true
-          wrapper: h2
+          wrapper: ''
           class: ''
 id: node.stanford_person.stanford_card
 targetEntityType: node
@@ -105,7 +105,7 @@ content:
     label: hidden
     settings:
       view_mode: default
-      image_style: card_2_1
+      image_style: responsive_1_1
       link: false
     third_party_settings:
       field_formatter_class:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changed card display mode to prevent nested `<h2>` tags.
- Changed card display mode to use responsive square image style which will make a circle.

# Need Review By (Date)
- 10/30

# Urgency
- medium

# Steps to Test
1. Checkout this branch & same branch in https://github.com/SU-SWS/stanford_profile_helper/pull/40
1. create a person with an image
1. create a basic page and reference that person in the paragraph type
1. verify the image is a circle centered in the card.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
