### PR TITLE
D8CORE 000 display tweaks

### DIFF
--- a/config/sync/core.entity_view_display.node.stanford_person.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_person.stanford_card.yml
@@ -70,16 +70,14 @@ third_party_settings:
     regions:
       card_image:
         - su_person_photo
-      card_super_headline:
-        - su_person_short_title
       card_headline:
         - node_title
       card_body:
-        - su_person_full_title
+        - su_person_short_title
     fields:
       node_title:
         plugin_id: node_title
-        weight: 2
+        weight: 1
         label: hidden
         formatter: default
         settings:
@@ -91,13 +89,6 @@ targetEntityType: node
 bundle: stanford_person
 mode: stanford_card
 content:
-  su_person_full_title:
-    type: basic_string
-    weight: 3
-    region: card_body
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
   su_person_photo:
     type: media_responsive_image_formatter
     weight: 0
@@ -112,8 +103,8 @@ content:
         class: ''
   su_person_short_title:
     type: string
-    weight: 1
-    region: card_super_headline
+    weight: 2
+    region: card_body
     label: hidden
     settings:
       link_to_entity: false
@@ -130,6 +121,7 @@ hidden:
   su_person_email: true
   su_person_fax: true
   su_person_first_name: true
+  su_person_full_title: true
   su_person_last_name: true
   su_person_links: true
   su_person_location_address: true

--- a/config/sync/core.entity_view_display.paragraph.stanford_entity.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.stanford_entity.default.yml
@@ -38,7 +38,9 @@ content:
     weight: 1
     label: hidden
     settings: {  }
-    third_party_settings: {  }
+    third_party_settings:
+      field_formatter_class:
+        class: su-margin-bottom-3
     type: text_default
     region: content
   su_entity_headline:
@@ -47,7 +49,9 @@ content:
     settings:
       tag: h2
       linked: false
-    third_party_settings: {  }
+    third_party_settings:
+      field_formatter_class:
+        class: su-margin-bottom
     type: entity_title_heading
     region: content
   su_entity_item:
@@ -58,7 +62,7 @@ content:
       link: false
     third_party_settings:
       field_formatter_class:
-        class: ''
+        class: su-margin-bottom-5
       ds:
         ds_limit: ''
     type: entity_reference_entity_view

--- a/config/sync/core.entity_view_display.paragraph.stanford_lists.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.stanford_lists.default.yml
@@ -38,7 +38,9 @@ content:
     weight: 1
     label: hidden
     settings: {  }
-    third_party_settings: {  }
+    third_party_settings:
+      field_formatter_class:
+        class: su-margin-bottom-3
     type: text_default
     region: content
   su_list_headline:
@@ -47,7 +49,9 @@ content:
     settings:
       tag: h2
       linked: false
-    third_party_settings: {  }
+    third_party_settings:
+      field_formatter_class:
+        class: su-margin-bottom
     type: entity_title_heading
     region: content
   su_list_view:
@@ -55,9 +59,11 @@ content:
     label: hidden
     settings:
       view_title: hidden
-      always_build_output: false
       empty_view_title: hidden
-    third_party_settings: {  }
+      always_build_output: false
+    third_party_settings:
+      field_formatter_class:
+        class: su-margin-bottom-5
     type: viewfield_default
     region: content
 hidden: {  }

--- a/config/sync/views.view.stanford_events.yml
+++ b/config/sync/views.view.stanford_events.yml
@@ -761,6 +761,7 @@ display:
         row: false
         arguments: false
         css_class: false
+        pager: false
       style:
         type: grid
         options:
@@ -819,13 +820,17 @@ display:
           entity_type: node
           plugin_id: taxonomy_index_name_depth
       css_class: ''
+      pager:
+        type: some
+        options:
+          items_per_page: 3
+          offset: 0
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
-        - url.query_args
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/config/sync/views.view.stanford_news.yml
+++ b/config/sync/views.view.stanford_news.yml
@@ -1405,13 +1405,13 @@ display:
       style:
         type: grid
         options:
-          grouping: {  }
+          uses_fields: false
           columns: 3
           automatic_width: false
           alignment: horizontal
-          col_class_default: false
+          col_class_default: true
           col_class_custom: flex-4-of-12
-          row_class_default: false
+          row_class_default: true
           row_class_custom: 'flex-container more-news-view'
       row:
         type: 'entity:node'

--- a/config/sync/views.view.stanford_news.yml
+++ b/config/sync/views.view.stanford_news.yml
@@ -1307,10 +1307,149 @@ display:
         - user.permissions
       tags:
         - 'config:field.storage.node.su_news_topics'
+  vertical_cards:
+    display_plugin: block
+    id: vertical_cards
+    display_title: Cards
+    position: 3
+    display_options:
+      display_extenders: {  }
+      display_description: 'Vertical Cards'
+      arguments:
+        term_node_taxonomy_name_depth:
+          id: term_node_taxonomy_name_depth
+          table: node_field_data
+          field: term_node_taxonomy_name_depth
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          depth: '0'
+          vocabularies:
+            stanford_news_topics: stanford_news_topics
+          break_phrase: true
+          use_taxonomy_term_path: false
+          entity_type: node
+          plugin_id: taxonomy_index_name_depth
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: none
+            fail: ignore
+          validate_options: {  }
+          break_phrase: false
+          not: true
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
+      defaults:
+        arguments: false
+        style: false
+        row: false
+        pager: false
+        css_class: false
+        use_more: false
+        use_more_always: false
+        use_more_text: false
+        link_display: false
+        link_url: false
+      style:
+        type: grid
+        options:
+          uses_fields: false
+          columns: 3
+          automatic_width: false
+          alignment: horizontal
+          col_class_default: true
+          col_class_custom: flex-4-of-12
+          row_class_default: true
+          row_class_custom: 'flex-container more-news-view'
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: stanford_card
+      pager:
+        type: some
+        options:
+          items_per_page: 3
+          offset: 0
+      block_category: 'News Lists (Views)'
+      block_description: 'News Cards - All Items'
+      css_class: 'stanford-news--cards stanford-news--cards-any'
+      use_more: false
+      use_more_always: false
+      use_more_text: 'See All News'
+      link_display: custom_url
+      link_url: /news
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.su_news_dek'
+        - 'config:field.storage.node.su_news_featured_media'
+        - 'config:field.storage.node.su_news_headline'
+        - 'config:field.storage.node.su_news_publishing_date'
+        - 'config:field.storage.node.su_news_source'
+        - 'config:field.storage.node.su_news_topics'
   vertical_teaser_term:
     display_plugin: block
     id: vertical_teaser_term
-    display_title: Cards
+    display_title: 'Vertical Teaser Term'
     position: 3
     display_options:
       display_extenders: {  }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- some minor adjustments to the card display modes to make use of the utility classes in https://github.com/SU-SWS/stanford_profile_helper/pull/42
- Added a specific "Cards" view that only shows 3 items.
- see https://github.com/SU-SWS/stanford_profile_helper/pull/42

# Need Review By (Date)
- 11/4

# Urgency
- medium

# Steps to Test
1. checkout this branch and https://github.com/SU-SWS/stanford_profile_helper/pull/42
1. drush cim
1. create a basic page and use the list and content reference paragraphs.
1. populate all the fields on the paragraphs.
1. see some of the spacing is applied to the display.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
