### PR TITLE
D8CORE-2864 Allow site managers access to contextual links

### DIFF
--- a/config/sync/user.role.site_manager.yml
+++ b/config/sync/user.role.site_manager.yml
@@ -9,6 +9,7 @@ is_admin: false
 permissions:
   - 'access administration pages'
   - 'access content overview'
+  - 'access contextual links'
   - 'access file_browser entity browser pages'
   - 'access image_browser entity browser pages'
   - 'access media overview'


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Allow site managers access to contextual links so they can configure and delete blocks in the layout builder.

# Need Review By (Date)
- asap

# Urgency
- high.

# Steps to Test
1. checkout this branch
1. `drush cim`
1. log in as a site manager
1. verify you can delete a block from layout builder on a basic page.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
