### PR TITLE
D8CORE-2570 Add intro block above event and news lists

### DIFF
--- a/config/sync/page_manager.page_variant.stanford_events_upcoming-layout_builder-0.yml
+++ b/config/sync/page_manager.page_variant.stanford_events_upcoming-layout_builder-0.yml
@@ -74,7 +74,34 @@ variant_settings:
             items_per_page: none
             context_mapping: {  }
           additional: {  }
+          weight: 2
+        535c57e1-3c85-4315-bd32-3f8277b218d4:
+          uuid: 535c57e1-3c85-4315-bd32-3f8277b218d4
+          region: main
+          configuration:
+            id: 'block_content:f7125c85-197d-4ba2-9f6f-1126bbda0466'
+            label: 'Events Intro'
+            provider: block_content
+            label_display: '0'
+            status: true
+            info: ''
+            view_mode: full
+            context_mapping: {  }
+          additional: {  }
           weight: 0
+        343a76ca-856e-461b-b36c-021c34293235:
+          uuid: 343a76ca-856e-461b-b36c-021c34293235
+          region: main
+          configuration:
+            id: 'views_block:su_block_edit_links-events_intro'
+            label: ''
+            provider: views
+            label_display: '0'
+            views_label: ''
+            items_per_page: none
+            context_mapping: {  }
+          additional: {  }
+          weight: 1
       third_party_settings: {  }
 page: stanford_events_upcoming
 weight: 0

--- a/config/sync/page_manager.page_variant.stanford_news_list-layout_builder-0.yml
+++ b/config/sync/page_manager.page_variant.stanford_news_list-layout_builder-0.yml
@@ -84,7 +84,34 @@ variant_settings:
             items_per_page: '20'
             context_mapping: {  }
           additional: {  }
+          weight: 5
+        92d34c88-16dd-4ffc-994e-ffa358a88002:
+          uuid: 92d34c88-16dd-4ffc-994e-ffa358a88002
+          region: main
+          configuration:
+            id: 'block_content:5168834f-3271-4951-bd95-e75340ca5522'
+            label: 'News Intro'
+            provider: block_content
+            label_display: '0'
+            status: true
+            info: ''
+            view_mode: full
+            context_mapping: {  }
+          additional: {  }
           weight: 3
+        7a2c8639-c149-459e-af92-29b9e48b582d:
+          uuid: 7a2c8639-c149-459e-af92-29b9e48b582d
+          region: main
+          configuration:
+            id: 'views_block:su_block_edit_links-news_intro'
+            label: ''
+            provider: views
+            label_display: '0'
+            views_label: ''
+            items_per_page: none
+            context_mapping: {  }
+          additional: {  }
+          weight: 4
       third_party_settings: {  }
     -
       layout_id: jumpstart_ui_one_column

--- a/config/sync/views.view.su_block_edit_links.yml
+++ b/config/sync/views.view.su_block_edit_links.yml
@@ -226,6 +226,182 @@ display:
         - url
         - user.permissions
       tags: {  }
+  events_intro:
+    display_plugin: block
+    id: events_intro
+    display_title: 'Events Intro Edit Link'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      filters:
+        status:
+          value: '1'
+          table: block_content_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: block_content
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+          group: 1
+        reusable:
+          id: reusable
+          plugin_id: boolean
+          table: block_content_field_data
+          field: reusable
+          value: '1'
+          entity_type: block_content
+          entity_field: reusable
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        uuid:
+          id: uuid
+          table: block_content
+          field: uuid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: f7125c85-197d-4ba2-9f6f-1126bbda0466
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: block_content
+          entity_field: uuid
+          plugin_id: string
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - user.permissions
+      tags: {  }
+  news_intro:
+    display_plugin: block
+    id: news_intro
+    display_title: 'News Intro Edit Link'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      filters:
+        status:
+          value: '1'
+          table: block_content_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: block_content
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+          group: 1
+        reusable:
+          id: reusable
+          plugin_id: boolean
+          table: block_content_field_data
+          field: reusable
+          value: '1'
+          entity_type: block_content
+          entity_field: reusable
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        uuid:
+          id: uuid
+          table: block_content
+          field: uuid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: 5168834f-3271-4951-bd95-e75340ca5522
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: block_content
+          entity_field: uuid
+          plugin_id: string
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - user.permissions
+      tags: {  }
   people_intro:
     display_plugin: block
     id: people_intro
@@ -234,6 +410,79 @@ display:
     display_options:
       display_extenders: {  }
       display_description: ''
+      filters:
+        status:
+          value: '1'
+          table: block_content_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: block_content
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+          group: 1
+        reusable:
+          id: reusable
+          plugin_id: boolean
+          table: block_content_field_data
+          field: reusable
+          value: '1'
+          entity_type: block_content
+          entity_field: reusable
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        uuid:
+          id: uuid
+          table: block_content
+          field: uuid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: fb905cf3-4bd3-4bcd-ad01-92d25e46ba32
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: block_content
+          entity_field: uuid
+          plugin_id: string
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
     cache_metadata:
       max-age: -1
       contexts:

--- a/content/block_content/5168834f-3271-4951-bd95-e75340ca5522.json
+++ b/content/block_content/5168834f-3271-4951-bd95-e75340ca5522.json
@@ -7,19 +7,9 @@
       "href": "http:\/\/drupal.org\/rest\/type\/block_content\/stanford_component_block"
     }
   },
-  "id": [
-    {
-      "value": 3
-    }
-  ],
   "uuid": [
     {
       "value": "5168834f-3271-4951-bd95-e75340ca5522"
-    }
-  ],
-  "revision_id": [
-    {
-      "value": 3
     }
   ],
   "langcode": [
@@ -31,12 +21,6 @@
   "type": [
     {
       "target_id": "stanford_component_block"
-    }
-  ],
-  "revision_created": [
-    {
-      "value": "2020-11-04T19:09:51+00:00",
-      "format": "Y-m-d\\TH:i:sP"
     }
   ],
   "status": [

--- a/content/block_content/5168834f-3271-4951-bd95-e75340ca5522.json
+++ b/content/block_content/5168834f-3271-4951-bd95-e75340ca5522.json
@@ -1,0 +1,88 @@
+{
+  "_links": {
+    "self": {
+      "href": "http:\/\/default\/block\/3?_format=hal_json"
+    },
+    "type": {
+      "href": "http:\/\/drupal.org\/rest\/type\/block_content\/stanford_component_block"
+    }
+  },
+  "id": [
+    {
+      "value": 3
+    }
+  ],
+  "uuid": [
+    {
+      "value": "5168834f-3271-4951-bd95-e75340ca5522"
+    }
+  ],
+  "revision_id": [
+    {
+      "value": 3
+    }
+  ],
+  "langcode": [
+    {
+      "value": "en",
+      "lang": "en"
+    }
+  ],
+  "type": [
+    {
+      "target_id": "stanford_component_block"
+    }
+  ],
+  "revision_created": [
+    {
+      "value": "2020-11-04T19:09:51+00:00",
+      "format": "Y-m-d\\TH:i:sP"
+    }
+  ],
+  "status": [
+    {
+      "value": true,
+      "lang": "en"
+    }
+  ],
+  "info": [
+    {
+      "value": "News Intro",
+      "lang": "en"
+    }
+  ],
+  "changed": [
+    {
+      "value": "2020-11-04T19:09:51+00:00",
+      "lang": "en",
+      "format": "Y-m-d\\TH:i:sP"
+    }
+  ],
+  "reusable": [
+    {
+      "value": true
+    }
+  ],
+  "default_langcode": [
+    {
+      "value": true,
+      "lang": "en"
+    }
+  ],
+  "revision_translation_affected": [
+    {
+      "value": true,
+      "lang": "en"
+    }
+  ],
+  "metatag": [
+    {
+      "value": {
+        "title": "| University",
+        "og_site_name": "University",
+        "canonical_url": "http:\/\/default\/home",
+        "og_url": "http:\/\/default\/home"
+      }
+    }
+  ]
+}

--- a/content/block_content/f7125c85-197d-4ba2-9f6f-1126bbda0466.json
+++ b/content/block_content/f7125c85-197d-4ba2-9f6f-1126bbda0466.json
@@ -7,19 +7,9 @@
       "href": "http:\/\/drupal.org\/rest\/type\/block_content\/stanford_component_block"
     }
   },
-  "id": [
-    {
-      "value": 2
-    }
-  ],
   "uuid": [
     {
       "value": "f7125c85-197d-4ba2-9f6f-1126bbda0466"
-    }
-  ],
-  "revision_id": [
-    {
-      "value": 2
     }
   ],
   "langcode": [
@@ -31,12 +21,6 @@
   "type": [
     {
       "target_id": "stanford_component_block"
-    }
-  ],
-  "revision_created": [
-    {
-      "value": "2020-11-04T19:09:51+00:00",
-      "format": "Y-m-d\\TH:i:sP"
     }
   ],
   "status": [

--- a/content/block_content/f7125c85-197d-4ba2-9f6f-1126bbda0466.json
+++ b/content/block_content/f7125c85-197d-4ba2-9f6f-1126bbda0466.json
@@ -1,0 +1,88 @@
+{
+  "_links": {
+    "self": {
+      "href": "http:\/\/default\/block\/2?_format=hal_json"
+    },
+    "type": {
+      "href": "http:\/\/drupal.org\/rest\/type\/block_content\/stanford_component_block"
+    }
+  },
+  "id": [
+    {
+      "value": 2
+    }
+  ],
+  "uuid": [
+    {
+      "value": "f7125c85-197d-4ba2-9f6f-1126bbda0466"
+    }
+  ],
+  "revision_id": [
+    {
+      "value": 2
+    }
+  ],
+  "langcode": [
+    {
+      "value": "en",
+      "lang": "en"
+    }
+  ],
+  "type": [
+    {
+      "target_id": "stanford_component_block"
+    }
+  ],
+  "revision_created": [
+    {
+      "value": "2020-11-04T19:09:51+00:00",
+      "format": "Y-m-d\\TH:i:sP"
+    }
+  ],
+  "status": [
+    {
+      "value": true,
+      "lang": "en"
+    }
+  ],
+  "info": [
+    {
+      "value": "Events Intro",
+      "lang": "en"
+    }
+  ],
+  "changed": [
+    {
+      "value": "2020-11-04T19:09:51+00:00",
+      "lang": "en",
+      "format": "Y-m-d\\TH:i:sP"
+    }
+  ],
+  "reusable": [
+    {
+      "value": true
+    }
+  ],
+  "default_langcode": [
+    {
+      "value": true,
+      "lang": "en"
+    }
+  ],
+  "revision_translation_affected": [
+    {
+      "value": true,
+      "lang": "en"
+    }
+  ],
+  "metatag": [
+    {
+      "value": {
+        "title": "| University",
+        "og_site_name": "University",
+        "canonical_url": "http:\/\/default\/home",
+        "og_url": "http:\/\/default\/home"
+      }
+    }
+  ]
+}

--- a/tests/codeception/acceptance/Content/EventsCest.php
+++ b/tests/codeception/acceptance/Content/EventsCest.php
@@ -1,9 +1,25 @@
 <?php
 
+use Faker\Factory;
+
 /**
  * Test the events + importer functionality.
  */
 class EventsCest {
+
+  /**
+   * Events list intro block is at the top of the page.
+   */
+  public function testListIntro(AcceptanceTester $I){
+    $intro_text = Factory::create()->text();
+    $I->logInWithRole('site_manager');
+    $I->amOnPage('/events');
+    $I->click('Edit Block Content Above');
+    $I->click('Add Text Area');
+    $I->fillField('Body', $intro_text);
+    $I->click('Save');
+    $I->canSee($intro_text);
+  }
 
   /**
    * Ensure events are in the sitemap.

--- a/tests/codeception/acceptance/Content/NewsCest.php
+++ b/tests/codeception/acceptance/Content/NewsCest.php
@@ -1,9 +1,25 @@
 <?php
 
+use Faker\Factory;
+
 /**
  * Test the news functionality.
  */
 class NewsCest {
+
+  /**
+   * News list intro block is at the top of the page.
+   */
+  public function testListIntro(AcceptanceTester $I){
+    $intro_text = Factory::create()->text();
+    $I->logInWithRole('site_manager');
+    $I->amOnPage('/news');
+    $I->click('Edit Block Content Above');
+    $I->click('Add Text Area');
+    $I->fillField('Body', $intro_text);
+    $I->click('Save');
+    $I->canSee($intro_text);
+  }
 
   /**
    * Test that the default content has installed and is unpublished.

--- a/tests/codeception/acceptance/Paragraphs/ListsCest.php
+++ b/tests/codeception/acceptance/Paragraphs/ListsCest.php
@@ -267,8 +267,6 @@ class ListsCest {
 
   /**
    * When using the list paragraph and view arguments, it should filter results.
-   *
-   * @group testme
    */
   public function testListParagraphEventFiltersAudienceFilter(AcceptanceTester $I) {
     $I->logInWithRole('site_manager');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add intro blocks at the top of events and news list pages.
- Update hook: https://github.com/SU-SWS/stanford_profile_helper/pull/45

# Need Review By (Date)
- 11/5

# Urgency
- medium

# Steps to Test
1. checkout this branch.
1. either do a fresh install, or checkout the same branch in [stanford_profile_helper](https://github.com/SU-SWS/stanford_profile_helper/pull/45) and do a `blt drupal:update`
1. Go to the news and the events pages
1. click on the link to edit the intro block
1. populate it with stuff
1. validate it displays at the top of the page.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
