### PR TITLE
D8CORE-2495 Changed the link button in minimal html format

### DIFF
--- a/config/sync/editor.editor.stanford_minimal_html.yml
+++ b/config/sync/editor.editor.stanford_minimal_html.yml
@@ -21,7 +21,7 @@ settings:
         -
           name: Links
           items:
-            - Link
+            - DrupalLink
             - Unlink
         -
           name: Tools


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changed the link button in minimal html to be the link button from core instead of the anchor link module.

# Need Review By (Date)
- 12/3

# Urgency
- low

# Steps to Test
1. Checkout this branch
1. `drush cim -y`
1. create a basic page and add a card
1. verify the link button in the ckeditor modal is the same as the other wysiwygs from other paragraph types.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
