### PR TITLE
D8CORE-2878 Add coalesce support for small animated gif fix

### DIFF
--- a/config/sync/imagemagick.settings.yml
+++ b/config/sync/imagemagick.settings.yml
@@ -11,6 +11,7 @@ advanced:
   density: 72
   colorspace: '0'
   profile: ''
+  coalesce: true
 image_formats:
   PNG:
     mime_type: image/png


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added support for animated gif's resizing.

# Need Review By (Date)
- 12/3

# Urgency
- medium

# Steps to Test
1. Download [this gif ](https://students.alumni.stanford.edu/sites/g/files/sbiybj16871/files/media/image/stanfordstudents_0.gif?itok=dgY1dSfA)
1. create a basic page and use the gif you download. set it to display the `large` or smaller display
1. see the broken gif.
1. checkout this branch
1. `drush cim` & `drush if --all`
1. view the page again and verify the gif isn't broken anymore.

Broke:
![image](https://user-images.githubusercontent.com/7185045/100016960-0907a000-2d8f-11eb-8433-3a27aa05fbe3.png)


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
