### PR TITLE
D8CORE-000 Patch simplesamlphp auth module to prevent unwanted redirect

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -178,8 +178,8 @@
             "drupal/paragraphs": {
                 "https://www.drupal.org/project/paragraphs/issues/2901390": "https://www.drupal.org/files/issues/2020-06-25/paragraphs-2901390-51.patch"
             },
-            "drupal/views_taxonomy_term_name_depth": {
-                "https://www.drupal.org/project/views_taxonomy_term_name_depth/issues/2877249": "https://www.drupal.org/files/issues/2020-05-01/2877249_21.patch"
+            "drupal/simplesamlphp_auth": {
+                "https://www.drupal.org/project/simplesamlphp_auth/issues/2936889": "https://www.drupal.org/files/issues/2020-07-31/simplesamlphp_auth-avoid_unexpected_redirect-2936889-12-d8.patch"
             },
             "drupal/token": {
                 "https://www.drupal.org/project/token/issues/3154183": "https://www.drupal.org/files/issues/2020-06-23/3154183-2.patch"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixes the redirect the next day.

# Need Review By (Date)
- 12/3

# Urgency
- medium

# Steps to Test
1. apply the patch manually or `composer require su-sws/stanford_profile:dev-D8CORE-000-saml-patch`
1. log into your local with saml.
1. navigate to a page like `/events`
1. see you are still logged in and on that url still.
1. edit the file `docroot/modules/contrib/simplesamlphp_auth/src/EventSubscriber/SimplesamlSubscriber.php` and comment out part of the code as in the screenshot below.
1. reload your `/events` page
1. verify you stayed on that page and are logged out.
![image](https://user-images.githubusercontent.com/7185045/100134154-9f45cf80-2e3c-11eb-81d3-853ea52059fd.png)



# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
