### PR TITLE
D8CORE-2325: fixed separator between event dates

### DIFF
--- a/config/sync/core.entity_view_display.node.stanford_event.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event.default.yml
@@ -189,7 +189,7 @@ third_party_settings:
                   date_format: 'l, F j, Y '
                   custom_date_format: ''
                   timezone: ''
-                  separator: ''
+                  separator: ' - '
                   join: ''
                   time_format: ''
                   time_hour_format: ''


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- A simple config change to add a separator for date strings.
- see related PR in stanford_events: https://github.com/SU-SWS/stanford_events/pull/44

# Needed By (Date)
- Dec. 3

# Urgency
- 1 of 10

# Steps to Test

1. Do this
1. Then this
2. Then this

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
