### PR TITLE
D8CORE-2867 Update image metadata tags

### DIFF
--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -5,6 +5,6 @@ ignored_config_entities:
   - '~block.block.stanford_basic_*'
   - 'block.block.*'
   - 'google_tag.container.*'
-enable_export_filtering: '0'
+enable_export_filtering: false
 _core:
   default_config_hash: v7E8C8wJWeAW2BGohMNY1tZSBc4bexM6O62tGxecTfE

--- a/config/sync/metatag.metatag_defaults.node__stanford_news.yml
+++ b/config/sync/metatag.metatag_defaults.node__stanford_news.yml
@@ -5,6 +5,6 @@ dependencies: {  }
 id: node__stanford_news
 label: 'Content: News'
 tags:
-  image_src: '[node:su_news_banner:entity:su_news_banner:0:entity:field_media_image:large]'
-  og_image: '[node:su_news_banner:entity:su_news_banner:0:entity:field_media_image:large]'
-  og_image_url: '[node:su_news_banner:entity:su_news_banner:0:entity:field_media_image:large:url]'
+  image_src: '[node:su_news_featured_media:entity:field_media_image:large]'
+  og_image_url: '[node:su_news_featured_media:entity:field_media_image:large]'
+  og_image: '[node:su_news_featured_media:entity:field_media_image:large]'

--- a/config/sync/metatag.metatag_defaults.node__stanford_person.yml
+++ b/config/sync/metatag.metatag_defaults.node__stanford_person.yml
@@ -5,8 +5,9 @@ dependencies: {  }
 id: node__stanford_person
 label: 'Content: Person'
 tags:
+  image_src: '[node:su_person_photo:entity:field_media_image:large]'
+  description: '[node:summary]'
   keywords: '[node:su_person_type]'
   title: '[node:title] | [site:name]'
-  description: '[node:summary]'
-  og_image: '[node:su_person_photo:entity:su_person_photo:0:entity:field_media_image:large]'
-  og_image_url: '[node:su_person_photo:entity:su_person_photo:0:entity:field_media_image:large]'
+  og_image_url: '[node:su_person_photo:entity:field_media_image:large]'
+  og_image: '[node:su_person_photo:entity:field_media_image:large]'

--- a/config/sync/rabbit_hole.behavior_settings.default.yml
+++ b/config/sync/rabbit_hole.behavior_settings.default.yml
@@ -5,7 +5,10 @@ dependencies: {  }
 _core:
   default_config_hash: V4kEJzI6kqZ9qVXKGyhOCUkL5K6ab7CL73QbvExeBkU
 id: default
+entity_type_id: null
+entity_id: null
 action: display_page
 allow_override: 1
 redirect: ''
 redirect_code: 0
+redirect_fallback_action: access_denied

--- a/config/sync/rabbit_hole.behavior_settings.default_bundle.yml
+++ b/config/sync/rabbit_hole.behavior_settings.default_bundle.yml
@@ -5,7 +5,10 @@ dependencies: {  }
 _core:
   default_config_hash: 9tPXnSvxaFBxdiQkvZZpU3OIFpU-AyFgeQSIPj2frXg
 id: default_bundle
+entity_type_id: null
+entity_id: null
 action: display_page
 allow_override: 1
 redirect: ''
 redirect_code: 0
+redirect_fallback_action: access_denied

--- a/config/sync/rabbit_hole.behavior_settings.node_type_stanford_event.yml
+++ b/config/sync/rabbit_hole.behavior_settings.node_type_stanford_event.yml
@@ -5,7 +5,10 @@ dependencies:
   config:
     - node.type.stanford_event
 id: node_type_stanford_event
+entity_type_id: node_type
+entity_id: stanford_event
 action: display_page
 allow_override: 1
 redirect: ''
 redirect_code: 301
+redirect_fallback_action: access_denied

--- a/config/sync/rabbit_hole.behavior_settings.node_type_stanford_news.yml
+++ b/config/sync/rabbit_hole.behavior_settings.node_type_stanford_news.yml
@@ -5,7 +5,10 @@ dependencies:
   config:
     - node.type.stanford_news
 id: node_type_stanford_news
+entity_type_id: node_type
+entity_id: stanford_news
 action: display_page
 allow_override: 1
 redirect: ''
 redirect_code: 301
+redirect_fallback_action: access_denied

--- a/config/sync/rabbit_hole.behavior_settings.node_type_stanford_person.yml
+++ b/config/sync/rabbit_hole.behavior_settings.node_type_stanford_person.yml
@@ -5,7 +5,10 @@ dependencies:
   config:
     - node.type.stanford_person
 id: node_type_stanford_person
+entity_type_id: node_type
+entity_id: stanford_person
 action: display_page
 allow_override: 0
 redirect: ''
 redirect_code: 301
+redirect_fallback_action: access_denied

--- a/config/sync/stanford_basic.settings.yml
+++ b/config/sync/stanford_basic.settings.yml
@@ -11,7 +11,6 @@ _core:
   default_config_hash: xlsR92AeFAiypan1iI5dNo3zdutIU3No20qwKwqiDag
 logo:
   use_default: true
-  path: ''
 brand_bar_variant: default
 lockup:
   option: a

--- a/tests/codeception/functional/Paragraphs/WYSIWYGCest.php
+++ b/tests/codeception/functional/Paragraphs/WYSIWYGCest.php
@@ -114,8 +114,20 @@ class WYSIWYGCest {
     $I->click('Video', '.media-library-menu-video');
     $I->waitForElementVisible('.media-library-add-form-oembed-url');
     $I->fillField('Add Video via URL', 'https://www.youtube.com/watch?v=ktCgVopf7D0');
-    $I->click('Add');
+
+    // If the youtube api fails, lets try again after a few seconds.
+    $bail = 0;
+    while (!empty($I->grabMultiple('input.media-library-add-form-oembed-submit[value="Add"]'))) {
+      $I->click('Add');
+      $I->wait(5);
+      $bail++;
+      if ($bail >= 10) {
+        break;
+      }
+    }
+
     $I->waitForText('The media item has been created but has not yet been saved');
+    $I->fillField('Name', 'Test Youtube Video');
     $I->clickWithLeftButton(".ui-dialog-buttonset button:nth-child(2)");
     $I->waitForAjaxToFinish();
     $I->click('Continue');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed the metadata tags for news and people
- exported config after a database update.

# Need Review By (Date)
- 12/3

# Urgency
- medium

# Steps to Test
1. Checkout this branch
1. `drush cim -y`
1. create a news item with a featured image
1. view the source and verify the `og:image` tag is visible with the path to the image
1. create a person with a photo
1. view the source and verify the `og:image` tag is visible with the path to the image

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
