### PR TITLE
D8CORE-3142: adding a class to the intro block

### DIFF
--- a/config/sync/core.entity_view_display.block_content.stanford_component_block.default.yml
+++ b/config/sync/core.entity_view_display.block_content.stanford_component_block.default.yml
@@ -6,7 +6,9 @@ dependencies:
     - block_content.type.stanford_component_block
     - field.field.block_content.stanford_component_block.su_component
   module:
+    - ds
     - entity_reference_revisions
+    - field_formatter_class
 id: block_content.stanford_component_block.default
 targetEntityType: block_content
 bundle: stanford_component_block
@@ -19,6 +21,10 @@ content:
     settings:
       view_mode: default
       link: ''
-    third_party_settings: {  }
+    third_party_settings:
+      field_formatter_class:
+        class: su-intro
+      ds:
+        ds_limit: ''
     region: content
 hidden: {  }

--- a/config/sync/field.field.block_content.stanford_component_block.su_component.yml
+++ b/config/sync/field.field.block_content.stanford_component_block.su_component.yml
@@ -5,6 +5,11 @@ dependencies:
   config:
     - block_content.type.stanford_component_block
     - field.storage.block_content.su_component
+    - paragraphs.paragraphs_type.stanford_banner
+    - paragraphs.paragraphs_type.stanford_card
+    - paragraphs.paragraphs_type.stanford_media_caption
+    - paragraphs.paragraphs_type.stanford_spacer
+    - paragraphs.paragraphs_type.stanford_wysiwyg
   module:
     - entity_reference_revisions
 id: block_content.stanford_component_block.su_component
@@ -19,5 +24,40 @@ default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:paragraph'
-  handler_settings: {  }
+  handler_settings:
+    negate: 0
+    target_bundles:
+      stanford_banner: stanford_banner
+      stanford_card: stanford_card
+      stanford_media_caption: stanford_media_caption
+      stanford_spacer: stanford_spacer
+      stanford_wysiwyg: stanford_wysiwyg
+    target_bundles_drag_drop:
+      stanford_banner:
+        enabled: true
+        weight: 10
+      stanford_card:
+        enabled: true
+        weight: 11
+      stanford_entity:
+        weight: 12
+        enabled: false
+      stanford_lists:
+        weight: 13
+        enabled: false
+      stanford_media_caption:
+        enabled: true
+        weight: 14
+      stanford_person_cta:
+        weight: 15
+        enabled: false
+      stanford_schedule:
+        weight: 16
+        enabled: false
+      stanford_spacer:
+        enabled: true
+        weight: 17
+      stanford_wysiwyg:
+        enabled: true
+        weight: 18
 field_type: entity_reference_revisions


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adding spacing at the bottom of the new info block on Events, News and People
- Limited the components available to this block after speaking with Ishi. That is covered in D8CORE-3188.

# Needed By (Date)
- 1/3/21

# Urgency
- Med

# Steps to Test

1. Pull in this and the other stanford_profile_helper change.
2. Clear caches
3. Checkout the padding on the new intro content on the New, People, Events List page. 
4. Try adding some content. We will be writing some documentation on best practices since it is currently an open slate. 
5. Try removing the content and see that there is not extra space above the list. 

# Affected Projects or Products
- Stanford Basic and  SOE

# Associated Issues and/or People
- D8CORE-3142
- D8CORE-3188
- https://github.com/SU-SWS/stanford_profile_helper/pull/60

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
