### PR TITLE
D8CORE-3445: tweaking the label names and hiding extra fields

### DIFF
--- a/config/sync/core.entity_view_display.citation.su_article_journal.default.yml
+++ b/config/sync/core.entity_view_display.citation.su_article_journal.default.yml
@@ -17,7 +17,6 @@ dependencies:
   module:
     - ds
     - field_formatter_class
-    - link
     - name
 id: citation.su_article_journal.default
 targetEntityType: citation
@@ -64,17 +63,6 @@ content:
         class: su-margin-bottom-2
     type: string
     region: content
-  su_issue:
-    weight: 6
-    label: above
-    settings:
-      thousand_separator: ''
-      prefix_suffix: true
-    third_party_settings:
-      field_formatter_class:
-        class: su-margin-bottom-2
-    type: number_integer
-    region: content
   su_month:
     weight: 2
     label: above
@@ -86,16 +74,6 @@ content:
         class: su-margin-bottom-2
     type: number_integer
     region: content
-  su_page:
-    weight: 7
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings:
-      field_formatter_class:
-        class: su-margin-bottom-2
-    type: string
-    region: content
   su_publisher:
     type: string
     weight: 4
@@ -106,28 +84,6 @@ content:
     third_party_settings:
       field_formatter_class:
         class: su-margin-bottom-2
-  su_url:
-    weight: 9
-    label: above
-    settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
-    third_party_settings: {  }
-    type: link
-    region: content
-  su_volume:
-    weight: 5
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings:
-      field_formatter_class:
-        class: su-margin-bottom-2
-    type: string
-    region: content
   su_year:
     weight: 1
     label: above
@@ -140,4 +96,8 @@ content:
     type: number_integer
     region: content
 hidden:
+  su_issue: true
+  su_page: true
+  su_url: true
+  su_volume: true
   title: true

--- a/config/sync/core.entity_view_display.citation.su_article_journal.default.yml
+++ b/config/sync/core.entity_view_display.citation.su_article_journal.default.yml
@@ -76,7 +76,7 @@ content:
     region: content
   su_publisher:
     type: string
-    weight: 4
+    weight: 1
     region: content
     label: above
     settings:

--- a/config/sync/core.entity_view_display.citation.su_article_newspaper.default.yml
+++ b/config/sync/core.entity_view_display.citation.su_article_newspaper.default.yml
@@ -13,7 +13,6 @@ dependencies:
   module:
     - ds
     - field_formatter_class
-    - link
     - name
 id: citation.su_article_newspaper.default
 targetEntityType: citation
@@ -71,20 +70,6 @@ content:
         class: su-margin-bottom-2
     type: string
     region: content
-  su_url:
-    weight: 5
-    label: above
-    settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: '0'
-      target: '0'
-    third_party_settings:
-      field_formatter_class:
-        class: su-margin-bottom-2
-    type: link
-    region: content
   su_year:
     weight: 4
     label: above
@@ -97,4 +82,5 @@ content:
     type: number_integer
     region: content
 hidden:
+  su_url: true
   title: true

--- a/config/sync/core.entity_view_display.citation.su_book.default.yml
+++ b/config/sync/core.entity_view_display.citation.su_book.default.yml
@@ -16,7 +16,6 @@ dependencies:
   module:
     - ds
     - field_formatter_class
-    - link
     - name
 id: citation.su_book.default
 targetEntityType: citation
@@ -60,69 +59,16 @@ content:
         class: su-margin-bottom-2
     type: string
     region: content
-  su_edition:
-    weight: 3
-    label: above
-    settings:
-      thousand_separator: ''
-      prefix_suffix: true
-    third_party_settings:
-      field_formatter_class:
-        class: su-margin-bottom-2
-    type: number_integer
-    region: content
-  su_page:
-    weight: 6
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings:
-      field_formatter_class:
-        class: su-margin-bottom-2
-    type: string
-    region: content
   su_publisher:
-    weight: 5
+    type: string
+    weight: 0
+    region: content
     label: above
     settings:
       link_to_entity: false
     third_party_settings:
       field_formatter_class:
         class: su-margin-bottom-2
-    type: string
-    region: content
-  su_publisher_place:
-    weight: 4
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings:
-      field_formatter_class:
-        class: su-margin-bottom-2
-    type: string
-    region: content
-  su_subtitle:
-    weight: 1
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings:
-      field_formatter_class:
-        class: su-margin-bottom-2
-    type: string
-    region: content
-  su_url:
-    weight: 8
-    label: above
-    settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
-    third_party_settings: {  }
-    type: link
-    region: content
   su_year:
     weight: 2
     label: above
@@ -135,4 +81,9 @@ content:
     type: number_integer
     region: content
 hidden:
+  su_edition: true
+  su_page: true
+  su_publisher_place: true
+  su_subtitle: true
+  su_url: true
   title: true

--- a/config/sync/core.entity_view_display.citation.su_thesis.default.yml
+++ b/config/sync/core.entity_view_display.citation.su_thesis.default.yml
@@ -73,7 +73,7 @@ content:
     type: number_integer
     region: content
   su_publisher:
-    weight: 5
+    weight: 1
     label: above
     settings:
       link_to_entity: false

--- a/config/sync/core.entity_view_display.citation.su_thesis.default.yml
+++ b/config/sync/core.entity_view_display.citation.su_thesis.default.yml
@@ -15,7 +15,6 @@ dependencies:
   module:
     - ds
     - field_formatter_class
-    - link
     - name
 id: citation.su_thesis.default
 targetEntityType: citation
@@ -62,16 +61,6 @@ content:
         class: su-margin-bottom-2
     type: string
     region: content
-  su_genre:
-    weight: 4
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings:
-      field_formatter_class:
-        class: su-margin-bottom-2
-    type: string
-    region: content
   su_month:
     weight: 1
     label: above
@@ -93,18 +82,6 @@ content:
         class: su-margin-bottom-2
     type: string
     region: content
-  su_url:
-    weight: 7
-    label: above
-    settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
-    third_party_settings: {  }
-    type: link
-    region: content
   su_year:
     weight: 3
     label: above
@@ -117,4 +94,6 @@ content:
     type: number_integer
     region: content
 hidden:
+  su_genre: true
+  su_url: true
   title: true

--- a/config/sync/field.field.citation.su_article_journal.su_publisher.yml
+++ b/config/sync/field.field.citation.su_article_journal.su_publisher.yml
@@ -9,7 +9,7 @@ id: citation.su_article_journal.su_publisher
 field_name: su_publisher
 entity_type: citation
 bundle: su_article_journal
-label: 'Journal Name'
+label: Publisher
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.citation.su_article_newspaper.su_publisher.yml
+++ b/config/sync/field.field.citation.su_article_newspaper.su_publisher.yml
@@ -9,7 +9,7 @@ id: citation.su_article_newspaper.su_publisher
 field_name: su_publisher
 entity_type: citation
 bundle: su_article_newspaper
-label: 'Newspaper Title'
+label: Publisher
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.citation.su_thesis.su_publisher.yml
+++ b/config/sync/field.field.citation.su_thesis.su_publisher.yml
@@ -9,7 +9,7 @@ id: citation.su_thesis.su_publisher
 field_name: su_publisher
 entity_type: citation
 bundle: su_thesis
-label: 'University Name'
+label: Publisher
 description: ''
 required: false
 translatable: true


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changed the su-publisher on all the types to be "Publisher"
- Hid some of the fields 

# Needed By (Date)
- 2/4

# Urgency
- high

# Steps to Test

1. Pull in this change.
2. import the profile configs.
3. Verify on the publication node that the publisher says "Publisher" for all the types. 
4. Verify the publisher always comes before the date 

# Affected Projects or Products
- Publication module

# Associated Issues and/or People
- D8CORE-3445
- https://github.com/SU-SWS/stanford_publication/compare/small-tweaks-jbk?expand=1

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
