### PR TITLE
D8CORE-3463 Adjust the list and cards displays

### DIFF
--- a/config/sync/core.entity_view_display.node.stanford_event.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event.stanford_card.yml
@@ -29,6 +29,7 @@ dependencies:
     - layout_builder
     - layout_builder_restrictions
     - layout_library
+    - link
     - smart_date
     - user
 third_party_settings:
@@ -120,8 +121,8 @@ third_party_settings:
         - node_title
       su_event_subheadline:
         - su_event_subheadline
-      su_event_dek:
-        - su_event_dek
+      su_event_url:
+        - su_event_source
       su_event_date_time:
         - su_event_date_time
       su_event_location:
@@ -129,6 +130,15 @@ third_party_settings:
       su_event_address:
         - su_event_location
     fields:
+      node_title:
+        plugin_id: node_title
+        weight: 5
+        label: hidden
+        formatter: default
+        settings:
+          link: true
+          wrapper: h2
+          class: ''
       'dynamic_token_field:node-date_end_day':
         plugin_id: 'dynamic_token_field:node-date_end_day'
         weight: 3
@@ -149,15 +159,6 @@ third_party_settings:
         weight: 0
         label: hidden
         formatter: default
-      node_title:
-        plugin_id: node_title
-        weight: 5
-        label: hidden
-        formatter: default
-        settings:
-          link: true
-          wrapper: h2
-          class: ''
 id: node.stanford_event.stanford_card
 targetEntityType: node
 bundle: stanford_event
@@ -184,14 +185,6 @@ content:
     third_party_settings:
       field_formatter_class:
         class: ''
-  su_event_dek:
-    type: string
-    weight: 7
-    region: su_event_dek
-    label: hidden
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
   su_event_location:
     type: address_default
     weight: 10
@@ -199,6 +192,20 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
+  su_event_source:
+    type: link
+    weight: 7
+    region: su_event_url
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: true
+      url_plain: true
+      rel: '0'
+      target: '0'
+    third_party_settings:
+      field_formatter_class:
+        class: ''
   su_event_subheadline:
     type: string
     weight: 6
@@ -222,9 +229,9 @@ hidden:
   su_event_audience: true
   su_event_components: true
   su_event_cta: true
+  su_event_dek: true
   su_event_email: true
   su_event_map_link: true
   su_event_schedule: true
-  su_event_source: true
   su_event_sponsor: true
   su_event_telephone: true

--- a/config/sync/views.view.stanford_events.yml
+++ b/config/sync/views.view.stanford_events.yml
@@ -650,20 +650,7 @@ display:
       title: Events
       header: {  }
       footer: {  }
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: '<h2>Sorry, no upcoming events.</h2>'
-            format: stanford_html
-          plugin_id: text
+      empty: {  }
       relationships: {  }
       arguments: {  }
       display_extenders: {  }

--- a/config/sync/views.view.stanford_events.yml
+++ b/config/sync/views.view.stanford_events.yml
@@ -2347,61 +2347,12 @@ display:
     display_plugin: block
     id: list_page_filtered
     display_title: 'List Page - Filtered'
-    position: 2
+    position: 1
     display_options:
       display_extenders: {  }
-      display_description: ''
-      block_description: 'List Page - Filtered'
-      css_class: stanford-events-list-page--filtered
-      defaults:
-        css_class: false
-        arguments: false
-        fields: false
-        style: false
-        row: false
-      arguments:
-        tid:
-          id: tid
-          table: taxonomy_index
-          field: tid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: taxonomy_tid
-          default_argument_options:
-            term_page: '1'
-            node: true
-            limit: true
-            vids:
-              stanford_event_types: stanford_event_types
-            anyall: ','
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: false
-          add_table: false
-          require_value: false
-          reduce_duplicates: false
-          plugin_id: taxonomy_index_tid
+      display_description: 'List - All Items'
+      block_description: 'List Page'
+      block_hide_empty: false
       block_category: 'Events Lists (Views)'
       fields:
         view_node:
@@ -2445,16 +2396,16 @@ display:
           element_label_type: ''
           element_label_class: ''
           element_label_colon: false
-          element_wrapper_type: div
-          element_wrapper_class: su-events-edit-article
-          element_default_classes: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
           empty: ''
-          hide_empty: true
+          hide_empty: false
           empty_zero: false
           hide_alter_empty: true
           text: view
           output_url_as_text: true
-          absolute: true
+          absolute: false
           entity_type: node
           plugin_id: entity_link
         su_event_source:
@@ -2537,7 +2488,7 @@ display:
             alter_text: true
             text: "<a class=\"su-link{% if su_event_source %} su-link--external{% endif %}\" href=\"{% if su_event_source %}{{ su_event_source }}{% else %}{{ view_node }}{% endif %}\">\r\n  {{ title }}\r\n</a>"
             make_link: false
-            path: '{{ su_event_source }}'
+            path: ''
             absolute: false
             external: false
             replace_spaces: false
@@ -2778,10 +2729,10 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
-        su_event_date_time:
-          id: su_event_date_time
+        su_event_date_time_value_1:
+          id: su_event_date_time_value_1
           table: node__su_event_date_time
-          field: su_event_date_time
+          field: su_event_date_time_value
           relationship: none
           group_type: group
           admin_label: ''
@@ -2819,34 +2770,21 @@ display:
           element_label_type: ''
           element_label_class: ''
           element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
+          element_wrapper_type: span
+          element_wrapper_class: su-start-month
+          element_default_classes: false
           empty: ''
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: smartdate_default
-          settings:
-            timezone_override: ''
-            format: stanford_event_long_no_time
-            force_chronological: false
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
-        su_event_date_time_1:
-          id: su_event_date_time_1
+          date_format: stanford_short_month
+          custom_date_format: ''
+          timezone: ''
+          plugin_id: date
+        su_event_date_time_value:
+          id: su_event_date_time_value
           table: node__su_event_date_time
-          field: su_event_date_time
+          field: su_event_date_time_value
           relationship: none
           group_type: group
           admin_label: ''
@@ -2884,30 +2822,121 @@ display:
           element_label_type: ''
           element_label_class: ''
           element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
+          element_wrapper_type: span
+          element_wrapper_class: su-start-date
           element_default_classes: true
           empty: ''
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: smartdate_default
-          settings:
-            timezone_override: ''
-            format: stanford_events_long
-            force_chronological: false
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
+          date_format: stanford_two_digit_day
+          custom_date_format: ''
+          timezone: ''
+          plugin_id: date
+        su_event_date_time_end_value:
+          id: su_event_date_time_end_value
+          table: node__su_event_date_time
+          field: su_event_date_time_end_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: '0'
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          date_format: stanford_short_month
+          custom_date_format: ''
+          timezone: ''
+          plugin_id: date
+        su_event_date_time_end_value_1:
+          id: su_event_date_time_end_value_1
+          table: node__su_event_date_time
+          field: su_event_date_time_end_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: '0'
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          date_format: stanford_two_digit_day
+          custom_date_format: ''
+          timezone: ''
+          plugin_id: date
         su_event_alt_loc:
           id: su_event_alt_loc
           table: node__su_event_alt_loc
@@ -2971,6 +3000,71 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
+        su_event_date_time:
+          id: su_event_date_time
+          table: node__su_event_date_time
+          field: su_event_date_time
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: smartdate_default
+          settings:
+            timezone_override: ''
+            format: stanford_events_long
+            force_chronological: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
         su_event_location:
           id: su_event_location
           table: node__su_event_location
@@ -3014,7 +3108,7 @@ display:
           element_label_colon: false
           element_wrapper_type: ''
           element_wrapper_class: ''
-          element_default_classes: true
+          element_default_classes: false
           empty: ''
           hide_empty: true
           empty_zero: false
@@ -3033,214 +3127,6 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
-        su_event_date_time_value:
-          id: su_event_date_time_value
-          table: node__su_event_date_time
-          field: su_event_date_time_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          date_format: stanford_short_month
-          custom_date_format: ''
-          timezone: ''
-          plugin_id: date
-        su_event_date_time_value_1:
-          id: su_event_date_time_value_1
-          table: node__su_event_date_time
-          field: su_event_date_time_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          date_format: stanford_two_digit_day
-          custom_date_format: ''
-          timezone: ''
-          plugin_id: date
-        su_event_date_time_end_value:
-          id: su_event_date_time_end_value
-          table: node__su_event_date_time
-          field: su_event_date_time_end_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          date_format: stanford_short_month
-          custom_date_format: ''
-          timezone: ''
-          plugin_id: date
-        su_event_date_time_end_value_1:
-          id: su_event_date_time_end_value_1
-          table: node__su_event_date_time
-          field: su_event_date_time_end_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          date_format: stanford_two_digit_day
-          custom_date_format: ''
-          timezone: ''
-          plugin_id: date
         edit_node:
           id: edit_node
           table: node
@@ -3277,13 +3163,13 @@ display:
             trim: false
             preserve_tags: ''
             html: false
-          element_type: ''
-          element_class: ''
+          element_type: div
+          element_class: su-events-edit-article
           element_label_type: ''
           element_label_class: ''
           element_label_colon: false
-          element_wrapper_type: div
-          element_wrapper_class: su-events-edit
+          element_wrapper_type: ''
+          element_wrapper_class: ''
           element_default_classes: true
           empty: ''
           hide_empty: true
@@ -3537,7 +3423,7 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
-          hide_empty: false
+          hide_empty: true
           empty_zero: false
           hide_alter_empty: true
           plugin_id: standard
@@ -3739,6 +3625,11 @@ display:
           empty_zero: false
           hide_alter_empty: true
           plugin_id: standard
+      defaults:
+        fields: false
+        style: false
+        row: false
+        arguments: false
       style:
         type: default
         options:
@@ -3756,14 +3647,13 @@ display:
             su_event_type: 0
             su_event_subheadline: 0
             su_event_dek: 0
-            su_event_date_time: 0
-            su_event_date_time_1: 0
-            su_event_alt_loc: 0
-            su_event_location: 0
-            su_event_date_time_value: 0
             su_event_date_time_value_1: 0
+            su_event_date_time_value: 0
             su_event_date_time_end_value: 0
             su_event_date_time_end_value_1: 0
+            su_event_alt_loc: 0
+            su_event_date_time: 0
+            su_event_location: 0
             edit_node: 0
             su_event_location_organization: 0
             su_event_location_locality: 0
@@ -3797,106 +3687,149 @@ display:
               weight: 0
               plugin: views_row
               source: title
-            'views_row:edit_node':
-              destination: su_event_edit
+            'views_row:su_event_date_time':
+              destination: su_event_date_time
               weight: 1
               plugin: views_row
-              source: edit_node
-            'views_row:su_event_type':
-              destination: su_event_type
+              source: su_event_date_time
+            'views_row:su_event_date_time_value_1':
+              destination: su_event_start_month
               weight: 2
               plugin: views_row
-              source: su_event_type
+              source: su_event_date_time_value_1
             'views_row:su_event_alt_loc':
               destination: su_event_location
               weight: 3
               plugin: views_row
               source: su_event_alt_loc
-            'views_row:su_event_date_time_end_value':
-              destination: su_event_end_month
+            'views_row:su_event_date_time_value':
+              destination: su_event_start_date
               weight: 4
               plugin: views_row
-              source: su_event_date_time_end_value
+              source: su_event_date_time_value
             'views_row:su_event_date_time_end_value_1':
               destination: su_event_end_date
               weight: 5
               plugin: views_row
               source: su_event_date_time_end_value_1
-            'views_row:su_event_date_time_value_1':
-              destination: su_event_start_date
+            'views_row:su_event_date_time_end_value':
+              destination: su_event_end_month
               weight: 6
               plugin: views_row
-              source: su_event_date_time_value_1
-            'views_row:su_event_date_time_value':
-              destination: su_event_start_month
+              source: su_event_date_time_end_value
+            'views_row:su_event_type':
+              destination: su_event_type
               weight: 7
               plugin: views_row
-              source: su_event_date_time_value
-            'views_row:su_event_date_time':
-              destination: su_event_date_time
-              weight: 8
-              plugin: views_row
-              source: su_event_date_time
+              source: su_event_type
             'views_row:su_event_subheadline':
               destination: su_event_subheadline
-              weight: 9
+              weight: 8
               plugin: views_row
               source: su_event_subheadline
             'views_row:su_event_dek':
               destination: su_event_dek
-              weight: 10
+              weight: 9
               plugin: views_row
               source: su_event_dek
             'views_row:su_event_location':
               destination: su_event_address
-              weight: 11
+              weight: 10
               plugin: views_row
               source: su_event_location
-            'views_row:su_event_location_locality':
-              destination: su_event_location_locality
-              weight: 12
+            'views_row:edit_node':
+              destination: su_event_edit
+              weight: 11
               plugin: views_row
-              source: su_event_location_locality
+              source: edit_node
             'views_row:su_event_location_organization':
               destination: su_event_location_organization
-              weight: 13
+              weight: 12
               plugin: views_row
               source: su_event_location_organization
-            'views_row:su_event_location_dependent_locality':
-              destination: su_event_location_dependent_locality
-              weight: 14
+            'views_row:su_event_location_locality':
+              destination: su_event_location_locality
+              weight: 13
               plugin: views_row
-              source: su_event_location_dependent_locality
+              source: su_event_location_locality
             'views_row:su_event_location_administrative_area':
               destination: su_event_location_administrative_area
-              weight: 15
+              weight: 14
               plugin: views_row
               source: su_event_location_administrative_area
             'views_row:su_event_location_address_line1':
               destination: su_event_location_address_line1
-              weight: 16
+              weight: 15
               plugin: views_row
               source: su_event_location_address_line1
             'views_row:su_event_location_address_line2':
               destination: su_event_location_address_line2
-              weight: 17
+              weight: 16
               plugin: views_row
               source: su_event_location_address_line2
             'views_row:su_event_location_postal_code':
               destination: su_event_location_postal_code
-              weight: 18
+              weight: 17
               plugin: views_row
               source: su_event_location_postal_code
             'views_row:su_event_location_sorting_code':
               destination: su_event_location_sorting_code
-              weight: 19
+              weight: 18
               plugin: views_row
               source: su_event_location_sorting_code
             'views_row:su_event_location_country_code':
               destination: su_event_location_country_code
-              weight: 20
+              weight: 19
               plugin: views_row
               source: su_event_location_country_code
+            'views_row:su_event_location_dependent_locality':
+              destination: su_event_location_dependent_locality
+              weight: 20
+              plugin: views_row
+              source: su_event_location_dependent_locality
+      arguments:
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: taxonomy_tid
+          default_argument_options:
+            term_page: '1'
+            node: true
+            limit: true
+            vids:
+              stanford_event_types: stanford_event_types
+            anyall: ','
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          add_table: false
+          require_value: false
+          reduce_duplicates: false
+          plugin_id: taxonomy_index_tid
     cache_metadata:
       max-age: -1
       contexts:
@@ -3990,76 +3923,10 @@ display:
           row_class_default: true
           row_class_custom: flex-container
       row:
-        type: ui_patterns
+        type: 'entity:node'
         options:
-          default_field_elements: 0
-          inline:
-            su_event_date_time_value: 0
-            su_event_date_time_value_1: 0
-            su_event_date_time_end_value: 0
-            su_event_date_time_end_value_1: 0
-            su_event_type: 0
-            title: 0
-            view_node: 0
-            su_event_source: 0
-            su_event_subheadline: 0
-            edit_node: 0
-            su_event_date_time: 0
-          separator: ''
-          hide_empty: 1
-          pattern: events-explore-more
-          variants:
-            alert: default
-            brandbar: default
-            button: default
-            card: default
-            cta: default
-            date-stacked: default
-            hero: default
-            link: default
-            lockup: a
-            media: default
-          pattern_mapping:
-            'views_row:su_event_date_time_value':
-              destination: su_event_start_month
-              weight: 0
-              plugin: views_row
-              source: su_event_date_time_value
-            'views_row:title':
-              destination: su_event_headline
-              weight: 1
-              plugin: views_row
-              source: title
-            'views_row:su_event_date_time':
-              destination: su_event_date_time
-              weight: 2
-              plugin: views_row
-              source: su_event_date_time
-            'views_row:su_event_date_time_value_1':
-              destination: su_event_start_date
-              weight: 3
-              plugin: views_row
-              source: su_event_date_time_value_1
-            'views_row:su_event_date_time_end_value':
-              destination: su_event_end_month
-              weight: 4
-              plugin: views_row
-              source: su_event_date_time_end_value
-            'views_row:su_event_date_time_end_value_1':
-              destination: su_event_end_date
-              weight: 5
-              plugin: views_row
-              source: su_event_date_time_end_value_1
-            'views_row:su_event_type':
-              destination: su_event_type
-              weight: 6
-              plugin: views_row
-              source: su_event_type
-            'views_row:su_event_subheadline':
-              destination: su_event_subheadline
-              weight: 7
-              plugin: views_row
-              source: su_event_subheadline
+          relationship: none
+          view_mode: stanford_card
       fields:
         su_event_date_time_value:
           id: su_event_date_time_value


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adjusted the events list and card views to display all the same content in the same way.
see https://github.com/SU-SWS/stanford_events/pull/54

# Need Review By (Date)
- 2/18

# Urgency
- medium

# Steps to Test
1. checkout this branch and the corresponding branch in [stanford_events](https://github.com/SU-SWS/stanford_events/pull/54)
2. `drush cim -y`
3. create some events and view the related events block at the bottom
4. ensure that related events displays the location


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
