### PR TITLE
D8CORE-3050 Added path redirect import module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,6 +137,7 @@
         "drupal/paragraphs": "^1.11",
         "drupal/paragraphs_edit": "^2.0@alpha",
         "drupal/paranoia": "^1.0@alpha",
+        "drupal/path_redirect_import": "^1.0@beta",
         "drupal/pathauto": "^1.6",
         "drupal/redirect": "^1.0-beta1",
         "drupal/response_code_condition": "^1.0",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -102,6 +102,7 @@ module:
   paragraphs_edit: 0
   path: 0
   path_alias: 0
+  path_redirect_import: 0
   rabbit_hole: 0
   react_paragraphs: 0
   react_paragraphs_behaviors: 0

--- a/tests/codeception/acceptance/Content/PublicationsCest.php
+++ b/tests/codeception/acceptance/Content/PublicationsCest.php
@@ -10,7 +10,7 @@ use Faker\Factory;
 class PublicationsCest {
 
   /**
-   * @group testme
+   * Create a book citation
    */
   public function testBookCitation(AcceptanceTester $I) {
     $faker = Factory::create();

--- a/tests/codeception/functional/Contrib/RedirectImportCest.php
+++ b/tests/codeception/functional/Contrib/RedirectImportCest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Class RedirectImportCest.
+ *
+ * @group contrib
+ */
+class RedirectImportCest {
+
+  /**
+   * Cleanup.
+   */
+  public function __after() {
+    if (file_exists(rtrim(codecept_data_dir(), '/') . '/redirects.csv')) {
+      unlink(rtrim(codecept_data_dir(), '/') . '/redirects.csv');
+    }
+  }
+
+  /**
+   * An imported redirect csv will create the redirects we need.
+   */
+  public function testRedirectImports(FunctionalTester $I) {
+
+    $file = fopen(rtrim(codecept_data_dir(), '/') . '/redirects.csv', 'w+');
+    fputcsv($file, ['from', 'to']);
+    fputcsv($file, ['/foo', '/bar']);
+    fclose($file);
+
+    $I->logInWithRole('site_manager');
+    $I->amOnPage('/admin/config/search/redirect/import');
+    $I->attachFile('CSV File', 'redirects.csv');
+    $I->checkOption('Allow nonexistent paths to be imported');
+    $I->click('Import', '.redirect-import-form');
+    $I->waitForText('Redirects processed');
+    $I->amOnPage('/admin/config/search/redirect');
+    $I->canSee('/foo');
+    $I->amOnPage('/foo');
+    $current_url = $I->grabFromCurrentUrl();
+    $I->assertEquals('/bar', $current_url, 'URLS do not match');
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added path redirect import module for csv uploads.

# Need Review By (Date)
- 2/25

# Urgency
- medium

# Steps to Test
1. `composer require su-sws/stanford_profile:dev-D8CORE-3050 --no-update`
2. `composer update -n`
3. `drush cim -y`
4. test out the importer on `/admin/config/search/redirect/import`

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
