### PR TITLE
D8CORE-1531 Removed "Remove formatting" ckeditor button that does nothing

### DIFF
--- a/config/sync/editor.editor.stanford_html.yml
+++ b/config/sync/editor.editor.stanford_html.yml
@@ -49,19 +49,18 @@ settings:
           items:
             - Superscript
             - Subscript
-            - RemoveFormat
             - Source
             - PasteFromWord
             - '-'
             - A11ychecker
   plugins:
-    drupallink:
-      linkit_enabled: true
-      linkit_profile: default
     stylescombo:
       styles: "a.su-button|Button\r\na.su-button--big|Big Button\r\na.su-button--secondary|Secondary Button\r\na.su-link--action|Action Link\r\np.plain-text|Normal\r\np.su-intro-text|Intro Text\r\np.su-font-splash|Splash Font\r\np.su-quote-text|Quote Text\r\np.su-drop-cap|Drop Cap First Letter\r\np.su-related-text|Card Text\r\np.su-callout-text|Callout Text\r\np.su-subheading|Sub Title"
     language:
       language_list: un
+    drupallink:
+      linkit_enabled: true
+      linkit_profile: default
 image_upload:
   status: false
   scheme: public


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removed "Remove formatting" ckeditor button that does nothing

# Need Review By (Date)
- 2/25

# Urgency
- low

# Steps to Test
1. checkout this branch
2. drush cim
3. create a basic page with a wysiwyg.
4. Verify the button doesn't exist. 
![image](https://user-images.githubusercontent.com/7185045/108282890-3c13c280-7137-11eb-83a0-31c3be1b7ea1.png)


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
