### PR TITLE
D8CORE-3392 Changed the view blocks order and names

### DIFF
--- a/config/sync/views.view.stanford_events.yml
+++ b/config/sync/views.view.stanford_events.yml
@@ -688,11 +688,11 @@ display:
   cards:
     display_plugin: block
     id: cards
-    display_title: Cards
-    position: 1
+    display_title: 'Card Grid'
+    position: 2
     display_options:
       display_extenders: {  }
-      display_description: 'List - All Items'
+      display_description: 'Grid - All Items'
       block_description: 'List Page'
       block_hide_empty: false
       block_category: 'Events Lists (Views)'
@@ -844,7 +844,7 @@ display:
   list_page:
     display_plugin: block
     id: list_page
-    display_title: List
+    display_title: '- Default List -'
     position: 1
     display_options:
       display_extenders: {  }
@@ -2347,7 +2347,7 @@ display:
     display_plugin: block
     id: list_page_filtered
     display_title: 'List Page - Filtered'
-    position: 2
+    position: 3
     display_options:
       display_extenders: {  }
       display_description: ''
@@ -3918,7 +3918,7 @@ display:
     display_plugin: block
     id: more_events_block
     display_title: 'Explore More Events Block'
-    position: 3
+    position: 4
     display_options:
       display_extenders: {  }
       display_description: 'Explore More Events Block'

--- a/config/sync/views.view.stanford_news.yml
+++ b/config/sync/views.view.stanford_news.yml
@@ -673,7 +673,7 @@ display:
   block_1:
     display_plugin: block
     id: block_1
-    display_title: List
+    display_title: '- Default List -'
     position: 1
     display_options:
       display_extenders: {  }
@@ -700,7 +700,7 @@ display:
           expose_sort_order: true
           sort_asc_label: Asc
           sort_desc_label: Desc
-      display_description: 'Term Block - All Results'
+      display_description: 'List of all content'
       arguments:
         term_node_taxonomy_name_depth:
           id: term_node_taxonomy_name_depth
@@ -1310,7 +1310,7 @@ display:
   vertical_cards:
     display_plugin: block
     id: vertical_cards
-    display_title: Cards
+    display_title: 'Card Grid'
     position: 3
     display_options:
       display_extenders: {  }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changed the order and name of the view blocks so they are in the desired order in the field.
- https://github.com/SU-SWS/react_paragraphs/pull/89

# Need Review By (Date)
- 2/25

# Urgency
- medium

# Steps to Test
1. checkout the branch in https://github.com/SU-SWS/react_paragraphs/pull/89
2. checkout this branch
3. drush cim -y
4. create a basic page and add a list paragraph to a row
5. choose "Events" and verify the displays are "- Default List -" followed by "Card Grid"
6. Choose news and verify the same as the events.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
