### PR TITLE
D8CORE-3137 Hide the published checkbox on taxonomy terms

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.event_audience.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.event_audience.default.yml
@@ -1,12 +1,12 @@
-uuid: 53d6a841-b739-48c9-b772-d2f255e5aa3c
+uuid: 17560bac-e814-4536-bf2a-a63761d5af1b
 langcode: en
 status: true
 dependencies:
   config:
-    - taxonomy.vocabulary.stanford_person_types
-id: taxonomy_term.stanford_person_types.default
+    - taxonomy.vocabulary.event_audience
+id: taxonomy_term.event_audience.default
 targetEntityType: taxonomy_term
-bundle: stanford_person_types
+bundle: event_audience
 mode: default
 content:
   name:

--- a/config/sync/core.entity_form_display.taxonomy_term.stanford_event_types.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.stanford_event_types.default.yml
@@ -1,12 +1,12 @@
-uuid: 53d6a841-b739-48c9-b772-d2f255e5aa3c
+uuid: b26f2d22-1309-47a7-a944-fcd584ec49d5
 langcode: en
 status: true
 dependencies:
   config:
-    - taxonomy.vocabulary.stanford_person_types
-id: taxonomy_term.stanford_person_types.default
+    - taxonomy.vocabulary.stanford_event_types
+id: taxonomy_term.stanford_event_types.default
 targetEntityType: taxonomy_term
-bundle: stanford_person_types
+bundle: stanford_event_types
 mode: default
 content:
   name:

--- a/config/sync/core.entity_form_display.taxonomy_term.stanford_news_topics.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.stanford_news_topics.default.yml
@@ -1,12 +1,12 @@
-uuid: 53d6a841-b739-48c9-b772-d2f255e5aa3c
+uuid: f08848bc-43f1-45ed-8040-adbbc310ab8d
 langcode: en
 status: true
 dependencies:
   config:
-    - taxonomy.vocabulary.stanford_person_types
-id: taxonomy_term.stanford_person_types.default
+    - taxonomy.vocabulary.stanford_news_topics
+id: taxonomy_term.stanford_news_topics.default
 targetEntityType: taxonomy_term
-bundle: stanford_person_types
+bundle: stanford_news_topics
 mode: default
 content:
   name:

--- a/config/sync/core.entity_form_display.taxonomy_term.stanford_publication_topics.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.stanford_publication_topics.default.yml
@@ -1,12 +1,12 @@
-uuid: 53d6a841-b739-48c9-b772-d2f255e5aa3c
+uuid: e67b7e43-8ff9-40fe-970a-2cb3208069df
 langcode: en
 status: true
 dependencies:
   config:
-    - taxonomy.vocabulary.stanford_person_types
-id: taxonomy_term.stanford_person_types.default
+    - taxonomy.vocabulary.stanford_publication_topics
+id: taxonomy_term.stanford_publication_topics.default
 targetEntityType: taxonomy_term
-bundle: stanford_person_types
+bundle: stanford_publication_topics
 mode: default
 content:
   name:

--- a/tests/codeception/acceptance/Content/EventsCest.php
+++ b/tests/codeception/acceptance/Content/EventsCest.php
@@ -199,6 +199,26 @@ class EventsCest {
   }
 
   /**
+   * Published checkbox should be hidden on term edit pages.
+   */
+  public function testTermPublishing(AcceptanceTester $I) {
+    $I->logInWithRole('site_manager');
+    $term = $I->createEntity([
+      'vid' => 'event_audience',
+      'name' => 'Foo',
+    ], 'taxonomy_term');
+    $I->amOnPage($term->toUrl('edit')->toString());
+    $I->cantSee('Published');
+
+    $term = $I->createEntity([
+      'vid' => 'stanford_event_types',
+      'name' => 'Foo',
+    ], 'taxonomy_term');
+    $I->amOnPage($term->toUrl('edit')->toString());
+    $I->cantSee('Published');
+  }
+
+  /**
    * Create an Event Node.
    *
    * @param AcceptanceTester $I

--- a/tests/codeception/acceptance/Content/NewsCest.php
+++ b/tests/codeception/acceptance/Content/NewsCest.php
@@ -10,7 +10,7 @@ class NewsCest {
   /**
    * News list intro block is at the top of the page.
    */
-  public function testListIntro(AcceptanceTester $I){
+  public function testListIntro(AcceptanceTester $I) {
     $intro_text = Factory::create()->text();
     $I->logInWithRole('site_manager');
     $I->amOnPage('/news');
@@ -143,7 +143,7 @@ class NewsCest {
   /**
    * Special characters should stay.
    */
-  public function testSpecialCharacters(AcceptanceTester $I){
+  public function testSpecialCharacters(AcceptanceTester $I) {
     $faker = Factory::create();
     $I->logInWithRole('contributor');
     $I->amOnPage('/node/add/stanford_person');
@@ -152,6 +152,19 @@ class NewsCest {
     $I->fillField('Short Title', $faker->text);
     $I->click('Save');
     $I->canSee('Foo Bar-Baz & Foo', 'h1');
+  }
+
+  /**
+   * Published checkbox should be hidden on term edit pages.
+   */
+  public function testTermPublishing(AcceptanceTester $I) {
+    $I->logInWithRole('site_manager');
+    $term = $I->createEntity([
+      'vid' => 'stanford_news_topics',
+      'name' => 'Foo',
+    ], 'taxonomy_term');
+    $I->amOnPage($term->toUrl('edit')->toString());
+    $I->cantSee('Published');
   }
 
 }

--- a/tests/codeception/acceptance/Content/PersonCest.php
+++ b/tests/codeception/acceptance/Content/PersonCest.php
@@ -142,4 +142,17 @@ class PersonCest {
     $I->cantSeeLink('Baz');
   }
 
+  /**
+   * Published checkbox should be hidden on term edit pages.
+   */
+  public function testTermPublishing(AcceptanceTester $I) {
+    $I->logInWithRole('site_manager');
+    $term = $I->createEntity([
+      'vid' => 'stanford_person_types',
+      'name' => 'Foo',
+    ], 'taxonomy_term');
+    $I->amOnPage($term->toUrl('edit')->toString());
+    $I->cantSee('Published');
+  }
+
 }

--- a/tests/codeception/acceptance/Content/PublicationsCest.php
+++ b/tests/codeception/acceptance/Content/PublicationsCest.php
@@ -32,4 +32,18 @@ class PublicationsCest {
     $I->canSee('Test Publication', 'h1');
   }
 
+
+  /**
+   * Published checkbox should be hidden on term edit pages.
+   */
+  public function testTermPublishing(AcceptanceTester $I) {
+    $I->logInWithRole('site_manager');
+    $term = $I->createEntity([
+      'vid' => 'stanford_publication_topics',
+      'name' => 'Foo',
+    ], 'taxonomy_term');
+    $I->amOnPage($term->toUrl('edit')->toString());
+    $I->cantSee('Published');
+  }
+
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Hide the published checkbox on terms.

# Need Review By (Date)
- 3/3

# Urgency
- low

# Steps to Test
1. checkout this branch
2. drush cim -y
3. edit a taxonomy term
4. verify there isn't the "Published" checkbox. (The permissions to get that to function correctly aren't worth the benefit)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
