### PR TITLE
D8CORE-3565: changing the more publication to not filter on taxonmy

### DIFF
--- a/config/sync/core.entity_view_display.node.stanford_publication.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_publication.default.yml
@@ -49,28 +49,20 @@ third_party_settings:
                 entity: layout_builder.entity
                 view_mode: view_mode
             additional: {  }
-            weight: 1
-          8d6c0e53-2154-4bbc-8015-4f90ada1b515:
-            uuid: 8d6c0e53-2154-4bbc-8015-4f90ada1b515
+            weight: 2
+          1444e926-3274-4a84-876f-8a51d12c2175:
+            uuid: 1444e926-3274-4a84-876f-8a51d12c2175
             region: main
             configuration:
-              id: 'field_block:node:stanford_publication:su_publication_topics'
-              label: Topics
-              provider: layout_builder
+              id: 'views_block:stanford_publications-pub_type'
+              label: ''
+              provider: views
               label_display: '0'
-              formatter:
-                label: hidden
-                type: entity_reference_label
-                settings:
-                  link: false
-                third_party_settings:
-                  field_formatter_class:
-                    class: ''
-              context_mapping:
-                entity: layout_builder.entity
-                view_mode: view_mode
+              views_label: ''
+              items_per_page: none
+              context_mapping: {  }
             additional: {  }
-            weight: 0
+            weight: 1
         third_party_settings: {  }
       -
         layout_id: jumpstart_ui_two_column

--- a/config/sync/field.field.node.stanford_publication.su_publication_citation.yml
+++ b/config/sync/field.field.node.stanford_publication.su_publication_citation.yml
@@ -14,7 +14,7 @@ field_name: su_publication_citation
 entity_type: node
 bundle: stanford_publication
 label: 'Citation information'
-description: 'Choose a type of publication item to display. You can preview display options in the user-guide.'
+description: 'Choose a type of publication item to display. You can preview display options in the <a href="https://userguide.sites.stanford.edu/tour/publications#publication-examples">user-guide</a>.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.stanford_publication.su_publication_topics.yml
+++ b/config/sync/field.field.node.stanford_publication.su_publication_topics.yml
@@ -11,7 +11,7 @@ field_name: su_publication_topics
 entity_type: node
 bundle: stanford_publication
 label: 'Publication Topic Terms'
-description: ''
+description: 'Add all topic terms for your publication here. Note, the top topic term in this list will be displayed at the top of the publication page. The complete list of terms will be displayed at the end of the publication page. You can rearrange the list using the drag-drop functionality. <a href="https://userguide.sites.stanford.edu/tour/publications#publication-taxonomy">How to add, edit and delete publication topics terms.</a>'
 required: false
 translatable: false
 default_value: {  }
@@ -24,6 +24,6 @@ settings:
     sort:
       field: name
       direction: asc
-    auto_create: true
+    auto_create: false
     auto_create_bundle: ''
 field_type: entity_reference

--- a/config/sync/views.view.stanford_publications.yml
+++ b/config/sync/views.view.stanford_publications.yml
@@ -408,6 +408,59 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
+        edit_node:
+          id: edit_node
+          table: node_field_revision
+          field: edit_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: su-button--secondary
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'Edit Publication'
+          output_url_as_text: false
+          absolute: true
+          entity_type: node
+          plugin_id: entity_link_edit
       defaults:
         fields: false
       block_category: 'Publication (Views)'
@@ -559,6 +612,59 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
+        edit_node:
+          id: edit_node
+          table: node_field_revision
+          field: edit_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: su-button--secondary
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'Edit Publication'
+          output_url_as_text: false
+          absolute: true
+          entity_type: node
+          plugin_id: entity_link_edit
       defaults:
         fields: false
       block_category: 'Publication (Views)'
@@ -1112,6 +1218,59 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
+        edit_node:
+          id: edit_node
+          table: node_field_revision
+          field: edit_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '<p><a class="su-button--secondary" href="{{ edit_node }}">Edit Publication</a></p>'
+            make_link: false
+            path: ''
+            absolute: true
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: 'Edit Publication'
+            rel: ''
+            link_class: su-button--secondary
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: su-button--secondary
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'Edit Publication'
+          output_url_as_text: true
+          absolute: true
+          entity_type: node
+          plugin_id: entity_link_edit
       style:
         type: default
         options:
@@ -1123,9 +1282,14 @@ display:
         options:
           default_field_elements: 0
           inline:
+            view_node: 0
+            su_publication_cta: 0
+            su_doi: 0
+            su_url: 0
             su_publication_topics: 0
             title: 0
             su_publication_topics_1: 0
+            edit_node: 0
           separator: ''
           hide_empty: 0
           pattern: card
@@ -1135,14 +1299,19 @@ display:
               weight: 0
               plugin: views_row
               source: su_publication_topics
+            'views_row:edit_node':
+              destination: card_body
+              weight: 1
+              plugin: views_row
+              source: edit_node
             'views_row:title':
               destination: card_headline
-              weight: 1
+              weight: 2
               plugin: views_row
               source: title
             'views_row:su_publication_topics_1':
               destination: card_body
-              weight: 2
+              weight: 3
               plugin: views_row
               source: su_publication_topics_1
           pattern_variant: default
@@ -1317,6 +1486,59 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
+        edit_node:
+          id: edit_node
+          table: node_field_revision
+          field: edit_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: su-button--secondary
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'Edit Publication'
+          output_url_as_text: false
+          absolute: true
+          entity_type: node
+          plugin_id: entity_link_edit
       defaults:
         fields: false
         pager: false

--- a/config/sync/views.view.stanford_publications.yml
+++ b/config/sync/views.view.stanford_publications.yml
@@ -3,10 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.citation.su_doi
     - field.storage.citation.su_url
     - field.storage.node.su_publication_citation
-    - field.storage.node.su_publication_cta
     - field.storage.node.su_publication_topics
     - node.type.stanford_publication
     - taxonomy.vocabulary.stanford_publication_topics
@@ -830,17 +828,17 @@ display:
           absolute: false
           entity_type: node
           plugin_id: entity_link
-        su_publication_cta:
-          id: su_publication_cta
-          table: node__su_publication_cta
-          field: su_publication_cta
-          relationship: none
+        su_url:
+          id: su_url
+          table: citation__su_url
+          field: su_url
+          relationship: su_publication_citation
           group_type: group
           admin_label: ''
           label: ''
           exclude: true
           alter:
-            alter_text: false
+            alter_text: true
             text: ''
             make_link: false
             path: ''
@@ -875,136 +873,6 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: '{{ view_node }}'
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: uri
-          type: link
-          settings:
-            trim_length: 80
-            url_only: true
-            url_plain: true
-            rel: '0'
-            target: '0'
-          group_column: ''
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
-        su_doi:
-          id: su_doi
-          table: citation__su_doi
-          field: su_doi
-          relationship: su_publication_citation
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: true
-          alter:
-            alter_text: true
-            text: 'http://doi.org/{{ su_doi }}'
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: '{{ su_publication_cta }}'
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          settings:
-            link_to_entity: false
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
-        su_url:
-          id: su_url
-          table: citation__su_url
-          field: su_url
-          relationship: su_publication_citation
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: '{{ su_doi }}'
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
@@ -1345,9 +1213,7 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
-        - 'config:field.storage.citation.su_doi'
         - 'config:field.storage.citation.su_url'
-        - 'config:field.storage.node.su_publication_cta'
         - 'config:field.storage.node.su_publication_topics'
   term_list_chicago:
     display_plugin: block

--- a/config/sync/views.view.stanford_publications.yml
+++ b/config/sync/views.view.stanford_publications.yml
@@ -462,6 +462,7 @@ display:
       defaults:
         fields: false
       block_category: 'Publication (Views)'
+      block_hide_empty: true
     cache_metadata:
       max-age: -1
       contexts:
@@ -666,6 +667,7 @@ display:
       defaults:
         fields: false
       block_category: 'Publication (Views)'
+      block_hide_empty: true
     cache_metadata:
       max-age: -1
       contexts:
@@ -677,6 +679,171 @@ display:
         - user.permissions
       tags:
         - 'config:field.storage.node.su_publication_citation'
+  pub_type:
+    display_plugin: block
+    id: pub_type
+    display_title: 'Publication Type'
+    position: 5
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'Publication Type'
+      defaults:
+        title: false
+        fields: false
+        filters: false
+        filter_groups: false
+        sorts: false
+        arguments: false
+        pager: false
+        style: false
+        row: false
+      fields:
+        type:
+          id: type
+          table: citation_field_data
+          field: type
+          relationship: su_publication_citation
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: citation
+          entity_field: type
+          plugin_id: field
+      filters:
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            stanford_publication: stanford_publication
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      sorts: {  }
+      arguments:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
+      block_category: 'Publication (Views)'
+      pager:
+        type: some
+        options:
+          items_per_page: 1
+          offset: 0
+      block_hide_empty: true
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+      row:
+        type: fields
+        options: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
   related:
     display_plugin: block
     id: related
@@ -1430,6 +1597,7 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
+      block_hide_empty: true
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/sync/views.view.stanford_publications.yml
+++ b/config/sync/views.view.stanford_publications.yml
@@ -7,12 +7,10 @@ dependencies:
     - field.storage.node.su_publication_citation
     - field.storage.node.su_publication_topics
     - node.type.stanford_publication
-    - taxonomy.vocabulary.stanford_publication_topics
   module:
     - link
     - node
     - stanford_publication
-    - taxonomy
     - ui_patterns_views
     - user
     - views_infinite_scroll
@@ -899,48 +897,6 @@ display:
           entity_type: node
           entity_field: nid
           plugin_id: node_nid
-        term_node_tid_depth:
-          id: term_node_tid_depth
-          table: node_field_data
-          field: term_node_tid_depth
-          relationship: none
-          group_type: group
-          admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: taxonomy_tid
-          default_argument_options:
-            node: true
-            limit: true
-            vids:
-              stanford_publication_topics: stanford_publication_topics
-            anyall: +
-            term_page: '0'
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          depth: 1
-          break_phrase: true
-          use_taxonomy_term_path: false
-          entity_type: node
-          plugin_id: taxonomy_index_tid_depth
       fields:
         view_node:
           id: view_node


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removed the extra filter on the More Publication cards on the Node page.

# Needed By (Date)
- 2/26

# Urgency
- Med

# Steps to Test

1. Pull in this change.
2. Verify that the node page has all the newest publications in the More Publications, rather than only the ones with the same taxonomy.

# Affected Projects or Products
- D8CORE-3565

# Associated Issues and/or People
- D8CORE-3565
- 
# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
