### PR TITLE
Add a checkbox to the config pages for the drop down menu setting.

### DIFF
--- a/config/sync/config_pages.type.stanford_basic_site_settings.yml
+++ b/config/sync/config_pages.type.stanford_basic_site_settings.yml
@@ -36,6 +36,12 @@ third_party_settings:
       column: value
       config_name: google_analytics.settings
       config_item: account
+    6768a2b9-0c36-46de-aef2-7ca5a548c2a2:
+      field: su_site_dropdowns
+      delta: 0
+      column: value
+      config_name: stanford_basic.settings
+      config_item: nav_dropdown_enabled
 id: stanford_basic_site_settings
 label: 'Site Settings'
 context:

--- a/config/sync/core.entity_form_display.config_pages.stanford_basic_site_settings.default.yml
+++ b/config/sync/core.entity_form_display.config_pages.stanford_basic_site_settings.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - config_pages.type.stanford_basic_site_settings
     - field.field.config_pages.stanford_basic_site_settings.su_google_analytics
+    - field.field.config_pages.stanford_basic_site_settings.su_site_dropdowns
     - field.field.config_pages.stanford_basic_site_settings.su_site_email
     - field.field.config_pages.stanford_basic_site_settings.su_site_name
     - field.field.config_pages.stanford_basic_site_settings.su_site_url
@@ -22,6 +23,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
+    region: content
+  su_site_dropdowns:
+    weight: 4
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
     region: content
   su_site_email:
     weight: 1

--- a/config/sync/core.entity_view_display.config_pages.stanford_basic_site_settings.default.yml
+++ b/config/sync/core.entity_view_display.config_pages.stanford_basic_site_settings.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - config_pages.type.stanford_basic_site_settings
     - field.field.config_pages.stanford_basic_site_settings.su_google_analytics
+    - field.field.config_pages.stanford_basic_site_settings.su_site_dropdowns
     - field.field.config_pages.stanford_basic_site_settings.su_site_email
     - field.field.config_pages.stanford_basic_site_settings.su_site_name
     - field.field.config_pages.stanford_basic_site_settings.su_site_url
@@ -22,6 +23,16 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
+    region: content
+  su_site_dropdowns:
+    weight: 4
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
     region: content
   su_site_email:
     weight: 2

--- a/config/sync/field.field.config_pages.stanford_basic_site_settings.su_site_dropdowns.yml
+++ b/config/sync/field.field.config_pages.stanford_basic_site_settings.su_site_dropdowns.yml
@@ -1,0 +1,23 @@
+uuid: 6d248834-38c4-4d7d-9c0e-a29273da6b37
+langcode: en
+status: true
+dependencies:
+  config:
+    - config_pages.type.stanford_basic_site_settings
+    - field.storage.config_pages.su_site_dropdowns
+id: config_pages.stanford_basic_site_settings.su_site_dropdowns
+field_name: su_site_dropdowns
+entity_type: config_pages
+bundle: stanford_basic_site_settings
+label: 'Use drop down menus'
+description: 'Check this box to enable the split-button drop down menu feature.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.storage.config_pages.su_site_dropdowns.yml
+++ b/config/sync/field.storage.config_pages.su_site_dropdowns.yml
@@ -1,0 +1,18 @@
+uuid: 688b6301-7a15-4c8d-a86a-3c33cdb67b37
+langcode: en
+status: true
+dependencies:
+  module:
+    - config_pages
+id: config_pages.su_site_dropdowns
+field_name: su_site_dropdowns
+entity_type: config_pages
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/tests/codeception/functional/Navigation/NavigationDropDownsCest.php
+++ b/tests/codeception/functional/Navigation/NavigationDropDownsCest.php
@@ -8,33 +8,31 @@ use Faker\Factory;
 class NavigationDropDownsCest {
 
   /**
-   * Create some content and test the dropdown menu
+   * Create some content and test the dropdown menu.
    */
   public function testDropdownMenus(FunctionalTester $I) {
-
     $I->logInWithRole('Administrator');
-    $I->amOnPage('/admin/appearance/settings/stanford_basic');
-    $I->see('Enable dropdowns for navigation menu');
-    $I->checkOption('Enable dropdowns for navigation menu');
-    $I->click('Save configuration');
+    $I->amOnPage('/');
+    $I->cantSeeElement('button', ['class' => 'su-nav-toggle']);
+    $I->amOnPage('/admin/config/system/basic-site-settings');
+    $I->checkOption('Use drop down menus');
+    $I->click('Save');
 
-    $faker = Factory::create();
-    $node_title = $faker->text(20);
+    $node_title = Factory::create()->text(20);
 
     $I->amOnPage('/node/add/stanford_page');
-    $I->wait(3);
     $I->fillField('Title', $node_title);
     $I->click('Menu settings');
     $I->checkOption('Provide a menu link');
     $I->fillField('Menu link title', "$node_title");
     // The label on the menu parent changes in D9 vs D8
     $I->selectOption('Parent link', '-- Resources');
-    $I->wait(3);
+    $I->waitForText('Change the weight of the links within the Resources menu');
     $I->click('Save');
-    $I->canSeeLink("$node_title");
+    $I->canSeeLink($node_title);
 
     $I->amOnPage('/');
-    $I->resizeWindow(1000,800);
+    $I->resizeWindow(1000, 800);
     $I->seeElement('button', ['class' => 'su-nav-toggle']);
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added the drop downs menu setting to the site setting config page.

# Need Review By (Date)
- tomorrow

# Urgency
- high

# Steps to Test
1. checkout this branch
2. `drush cim -y`
3. create a child menu item
4. verify the main menu is not a drop down menu.
5. go to `/admin/config/system/basic-site-settings`
6. check the drop downs checkbox and save
7. go to the home page and verify the dropdown menu is used.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
