### PR TITLE
D8CORE-3565: fixing up merge conflicts. Removes the more publication …

### DIFF
--- a/config/sync/views.view.stanford_publications.yml
+++ b/config/sync/views.view.stanford_publications.yml
@@ -7,10 +7,10 @@ dependencies:
     - field.storage.node.su_publication_citation
     - field.storage.node.su_publication_topics
     - node.type.stanford_publication
-    - taxonomy.vocabulary.stanford_publication_topics
   module:
     - link
     - node
+    - stanford_fields
     - stanford_publication
     - taxonomy
     - ui_patterns_views
@@ -904,48 +904,6 @@ display:
           entity_type: node
           entity_field: nid
           plugin_id: node_nid
-        term_node_tid_depth:
-          id: term_node_tid_depth
-          table: node_field_data
-          field: term_node_tid_depth
-          relationship: none
-          group_type: group
-          admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: taxonomy_tid
-          default_argument_options:
-            node: true
-            limit: true
-            vids:
-              stanford_publication_topics: stanford_publication_topics
-            anyall: +
-            term_page: '0'
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          depth: 1
-          break_phrase: true
-          use_taxonomy_term_path: false
-          entity_type: node
-          plugin_id: taxonomy_index_tid_depth
       fields:
         type:
           id: type


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removed the extra filter on the More Publication cards on the Node page.

# Needed By (Date)
- 3/3

# Urgency
- Med

# Steps to Test

1. Pull in this change.
2. Verify that the node page has all the newest publications in the More Publications, rather than only the ones with the same taxonomy.

# Affected Projects or Products
- D8CORE-3565

# Associated Issues and/or People
- D8CORE-3565
- https://github.com/SU-SWS/stanford_profile/pull/369 - the original PR had too many conflicts to easily resolve.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
