### PR TITLE
D8CORE-3576: fixing spacing after the results for on the filtered page

### DIFF
--- a/config/sync/views.view.publication_terms.yml
+++ b/config/sync/views.view.publication_terms.yml
@@ -198,7 +198,7 @@ display:
           entity_field: tid
           plugin_id: taxonomy
       display_extenders: {  }
-      css_class: su-margin-bottom-3
+      css_class: ''
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removed the margin-bottom class on the "Results For" due to too much space.

# Needed By (Date)
- 3/3

# Urgency
- low

# Steps to Test

1. Pull in this change.
2. Clear caches.
3. Verify on a filtered Publication page that there is now only MS 3 of space between the first citation and the Results for.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- D8CORE-3576

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
