### PR TITLE
Revert a previous pull request

### DIFF
--- a/config/sync/views.view.publication_terms.yml
+++ b/config/sync/views.view.publication_terms.yml
@@ -198,7 +198,7 @@ display:
           entity_field: tid
           plugin_id: taxonomy
       display_extenders: {  }
-      css_class: ''
+      css_class: su-margin-bottom-3
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
This did not fix the problem. There was no problem. The extra space was not present when logged out.

Revert "D8CORE-3576: fixing spacing after the results for on the filtered page"

This reverts commit 6a0c5534aa606f4ef7964ab1ee5bc7c68cadc8cf.

# READY FOR REVIEW

# Summary
- This change didn't need to happen since the problem didn't exist on a logged out page.

# Needed By (Date)
- 3/3

# Urgency
- low

# Steps to Test

1. Pull in the change.
2. Verify on a logged out filter by page that the Filtered by text has space between content block.

# Affected Projects or Products
- Publications 

# Associated Issues and/or People
- D8CORE-3576

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
