### PR TITLE
Add "include child orgs" checkbox for cap org importer

### DIFF
--- a/config/sync/core.entity_form_display.config_pages.stanford_person_importer.default.yml
+++ b/config/sync/core.entity_form_display.config_pages.stanford_person_importer.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - config_pages.type.stanford_person_importer
     - field.field.config_pages.stanford_person_importer.su_person_cap_password
     - field.field.config_pages.stanford_person_importer.su_person_cap_username
+    - field.field.config_pages.stanford_person_importer.su_person_child_orgs
     - field.field.config_pages.stanford_person_importer.su_person_orgs
     - field.field.config_pages.stanford_person_importer.su_person_sunetid
     - field.field.config_pages.stanford_person_importer.su_person_workgroup
@@ -49,8 +50,15 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
-  su_person_orgs:
+  su_person_child_orgs:
     weight: 3
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  su_person_orgs:
+    weight: 2
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -60,7 +68,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   su_person_sunetid:
-    weight: 5
+    weight: 4
     settings:
       size: 60
       placeholder: ''
@@ -68,7 +76,7 @@ content:
     type: string_textfield
     region: content
   su_person_workgroup:
-    weight: 4
+    weight: 1
     settings:
       size: 60
       placeholder: ''

--- a/config/sync/core.entity_view_display.config_pages.stanford_person_importer.default.yml
+++ b/config/sync/core.entity_view_display.config_pages.stanford_person_importer.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - config_pages.type.stanford_person_importer
     - field.field.config_pages.stanford_person_importer.su_person_cap_password
     - field.field.config_pages.stanford_person_importer.su_person_cap_username
+    - field.field.config_pages.stanford_person_importer.su_person_child_orgs
     - field.field.config_pages.stanford_person_importer.su_person_orgs
     - field.field.config_pages.stanford_person_importer.su_person_sunetid
     - field.field.config_pages.stanford_person_importer.su_person_workgroup
@@ -29,6 +30,16 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
+    region: content
+  su_person_child_orgs:
+    weight: 6
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
     region: content
   su_person_orgs:
     weight: 0

--- a/config/sync/field.field.config_pages.stanford_person_importer.su_person_child_orgs.yml
+++ b/config/sync/field.field.config_pages.stanford_person_importer.su_person_child_orgs.yml
@@ -1,0 +1,23 @@
+uuid: 3beeb0a8-dcbe-4853-83d8-182fe77a24ed
+langcode: en
+status: true
+dependencies:
+  config:
+    - config_pages.type.stanford_person_importer
+    - field.storage.config_pages.su_person_child_orgs
+id: config_pages.stanford_person_importer.su_person_child_orgs
+field_name: su_person_child_orgs
+entity_type: config_pages
+bundle: stanford_person_importer
+label: 'Include child organizations'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/field.storage.config_pages.su_person_child_orgs.yml
+++ b/config/sync/field.storage.config_pages.su_person_child_orgs.yml
@@ -1,0 +1,18 @@
+uuid: 0a08cbc7-eeb5-409c-aadb-677fb4e144e1
+langcode: en
+status: true
+dependencies:
+  module:
+    - config_pages
+id: config_pages.su_person_child_orgs
+field_name: su_person_child_orgs
+entity_type: config_pages
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added checkbox to include child organizations 

# Need Review By (Date)
- ASAP

# Urgency
- high

# Steps to Test
1. checkout this branch and the same branch in [stanford_profile](https://github.com/SU-SWS/stanford_person/pull/139)
2. `drush cim -y`
3. configure the importer with credentials on `/admin/config/importers/person-importer`
4. choose an organization but leave the "include child orgs" checkbox uncheck and save
5. run `drush cget migrate_plus.migration.su_stanford_person source.urls --include-overridden | grep includeChildren` and verify nothing is return
6. now check the box and resave.
7. run the drush command again and verify you see the urls.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
