### PR TITLE
D8CORE-3947: adding classes to the filtered by for publications 

### DIFF
--- a/config/sync/views.view.publication_terms.yml
+++ b/config/sync/views.view.publication_terms.yml
@@ -68,7 +68,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: 'Publications | Results For: {{ name }}'
+            text: '<span class="results-for--publications">Publications</span> | <span class="results-for">Results For:</span> <span class="results-for--name">{{ name }}</span>'
             make_link: false
             path: ''
             absolute: false


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- adding classes to the Filter by in order to style it.

# Needed By (Date)
- 3/23

# Urgency
- Med

# Steps to Test

1. Pull in this change.
2. Verify there are classes on the publication filtered page.
3. The css is in the https://github.com/SU-SWS/stanford_publication/pull/32
     - As of writing, this isn't ready for merging and review.
     - This is the only config change I have related to the Publications.
4. If this [pull](https://github.com/SU-SWS/stanford_publication/pull/32) is added, then you will see the Publications as bold and the font size smaller.  

# Affected Projects or Products
- Publications

# Associated Issues and/or People
- D8CORE-3947
- D8CORE-3722
- https://github.com/SU-SWS/stanford_publication/pull/32
- @katrialesser 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
