### PR TITLE
D8CORE-3536 Display publications as a teaser in the paragraph

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -163,7 +163,7 @@
         "su-sws/stanford_notifications": "dev-8.x-1.x",
         "su-sws/stanford_person": "dev-8.x-1.x",
         "su-sws/stanford_profile_helper": "dev-8.x-1.x",
-        "su-sws/stanford_publication": "dev-8.x-1.x",
+        "su-sws/stanford_publication": "dev-D8CORE-3536",
         "su-sws/stanford_ssp": "dev-8.x-1.x",
         "su-sws/stanford_text_editor": "dev-8.x-1.x"
     },

--- a/config/sync/core.entity_view_display.node.stanford_publication.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_publication.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.stanford_publication.layout_builder__layout
+    - field.field.node.stanford_publication.stanford_intranet__access
     - field.field.node.stanford_publication.su_publication_citation
     - field.field.node.stanford_publication.su_publication_components
     - field.field.node.stanford_publication.su_publication_cta
@@ -13,6 +14,7 @@ dependencies:
   module:
     - jumpstart_ui
     - layout_builder
+    - layout_builder_restrictions
     - layout_library
     - user
     - views
@@ -29,6 +31,21 @@ third_party_settings:
           columns: default
           label: ''
         components:
+          4df7625d-a934-4076-a6ff-d70bf5aa9f2e:
+            uuid: 4df7625d-a934-4076-a6ff-d70bf5aa9f2e
+            region: main
+            configuration:
+              id: 'extra_field_block:node:stanford_publication:citation_type'
+              label: 'Publication Type'
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                settings: {  }
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+            additional: {  }
+            weight: 2
           1a0c44d4-f6a2-457f-9d43-0bfb7f32c58f:
             uuid: 1a0c44d4-f6a2-457f-9d43-0bfb7f32c58f
             region: main
@@ -49,20 +66,7 @@ third_party_settings:
                 entity: layout_builder.entity
                 view_mode: view_mode
             additional: {  }
-            weight: 2
-          1444e926-3274-4a84-876f-8a51d12c2175:
-            uuid: 1444e926-3274-4a84-876f-8a51d12c2175
-            region: main
-            configuration:
-              id: 'views_block:stanford_publications-pub_type'
-              label: ''
-              provider: views
-              label_display: '0'
-              views_label: ''
-              items_per_page: none
-              context_mapping: {  }
-            additional: {  }
-            weight: 1
+            weight: 3
         third_party_settings: {  }
       -
         layout_id: jumpstart_ui_two_column
@@ -188,12 +192,19 @@ third_party_settings:
         third_party_settings: {  }
   layout_library:
     enable: false
+  layout_builder_restrictions:
+    allowed_block_categories: {  }
+    entity_view_mode_restriction:
+      whitelisted_blocks: {  }
+      blacklisted_blocks: {  }
+      allowed_layouts: {  }
 id: node.stanford_publication.default
 targetEntityType: node
 bundle: stanford_publication
 mode: default
 content: {  }
 hidden:
+  citation_type: true
   layout_builder__layout: true
   links: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.stanford_publication.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_publication.stanford_card.yml
@@ -1,0 +1,92 @@
+uuid: 8fcc2198-636c-4d86-b700-5a78e89d01ff
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.stanford_card
+    - field.field.node.stanford_publication.layout_builder__layout
+    - field.field.node.stanford_publication.stanford_intranet__access
+    - field.field.node.stanford_publication.su_publication_citation
+    - field.field.node.stanford_publication.su_publication_components
+    - field.field.node.stanford_publication.su_publication_cta
+    - field.field.node.stanford_publication.su_publication_topics
+    - node.type.stanford_publication
+  module:
+    - ds
+    - element_class_formatter
+    - field_formatter_class
+    - layout_builder
+    - layout_builder_restrictions
+    - layout_library
+    - user
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+  layout_library:
+    enable: false
+  layout_builder_restrictions:
+    allowed_block_categories: {  }
+    entity_view_mode_restriction:
+      whitelisted_blocks: {  }
+      blacklisted_blocks: {  }
+      allowed_layouts: {  }
+  ds:
+    layout:
+      id: pattern_card
+      library: null
+      disable_css: false
+      entity_classes: all_classes
+      settings:
+        pattern:
+          field_templates: default
+          variant: default
+    regions:
+      card_super_headline:
+        - citation_type
+      card_headline:
+        - node_title
+      card_body:
+        - su_publication_topics
+    fields:
+      node_title:
+        plugin_id: node_title
+        weight: 1
+        label: hidden
+        formatter: default
+        settings:
+          link: true
+          wrapper: h2
+          class: ''
+id: node.stanford_publication.stanford_card
+targetEntityType: node
+bundle: stanford_publication
+mode: stanford_card
+content:
+  citation_type:
+    weight: 0
+    region: card_super_headline
+    settings: {  }
+    third_party_settings: {  }
+  su_publication_topics:
+    type: entity_reference_list_label_class
+    weight: 2
+    region: card_body
+    label: hidden
+    settings:
+      link: true
+      list_type: ul
+      class: ''
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+      ds:
+        ds_limit: ''
+hidden:
+  layout_builder__layout: true
+  links: true
+  search_api_excerpt: true
+  stanford_intranet__access: true
+  su_publication_citation: true
+  su_publication_components: true
+  su_publication_cta: true

--- a/config/sync/field.field.paragraph.stanford_entity.su_entity_item.yml
+++ b/config/sync/field.field.paragraph.stanford_entity.su_entity_item.yml
@@ -8,6 +8,7 @@ dependencies:
     - node.type.stanford_event_series
     - node.type.stanford_news
     - node.type.stanford_person
+    - node.type.stanford_publication
     - paragraphs.paragraphs_type.stanford_entity
 id: paragraph.stanford_entity.su_entity_item
 field_name: su_entity_item
@@ -27,8 +28,10 @@ settings:
       stanford_event_series: stanford_event_series
       stanford_news: stanford_news
       stanford_person: stanford_person
+      stanford_publication: stanford_publication
     sort:
       field: _none
+      direction: ASC
     auto_create: false
     auto_create_bundle: stanford_event
 field_type: entity_reference

--- a/tests/codeception/functional/Paragraphs/EntityReferenceCest.php
+++ b/tests/codeception/functional/Paragraphs/EntityReferenceCest.php
@@ -10,7 +10,7 @@ class EntityReferenceCest {
   /**
    * Allow all paragraph types by using state.
    */
-  public function _before(){
+  public function _before() {
     \Drupal::state()->set('stanford_profile_allow_all_paragraphs', TRUE);
   }
 
@@ -40,6 +40,39 @@ class EntityReferenceCest {
     $I->click('Save');
     $I->canSee('has been updated');
     $I->canSee('Foo Bar News', '.su-card.su-news-vertical-teaser');
+  }
+
+  /**
+   * Publications can be referenced in teaser paragraph.
+   */
+  public function testPublicationTeasers(FunctionalTester $I) {
+    $faker = Factory::create();
+    $publication_title = $faker->text(20);
+    $I->logInWithRole('site_manager');
+    $I->amOnPage('node/add/stanford_publication');
+    $I->fillField('Title', $publication_title);
+    $I->selectOption('su_publication_citation[actions][bundle]', 'Journal Article');
+    $I->click('Add Citation');
+    $I->waitForText('First Name');
+    $I->click('Save');
+    $I->canSee($publication_title, 'h1');
+
+    $node = $this->getNodeWithReferenceParagraph($I);
+    $I->amOnPage("/node/{$node->id()}/edit");
+
+    $I->waitForElementVisible('#row-0');
+    $I->click('Edit', '.inner-row-wrapper');
+
+    $I->waitForText('Content Item(s)');
+    $I->fillField('#su_entity_item', $publication_title);
+    $I->click('.MuiAutocomplete-option');
+
+    $I->click('Continue');
+    $I->waitForElementNotVisible('.MuiDialog-scrollPaper');
+    $I->click('Save');
+    $I->canSee('has been updated');
+    $I->canSee($publication_title, 'h2');
+    $I->canSee('Journal Article');
   }
 
   /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Set up the publications to display as a card in the teasers.

# Related
- https://github.com/SU-SWS/stanford_publication/pull/33

# Need Review By (Date)
- 3/24

# Urgency
- medium

# Steps to Test
1. `composer require su-sws/stanford_profile:dev-D8CORE-3536 --no-update`
2. `composer update -n`
3. `blt drupal:update` or `blt drupal:install`
4. create a publication and fill out a bunch of fields including at least some citation information and save
5. create a basic page and use the "teaser" paragraph and choose the publication you created
6. save and verify the publication is displayed in a card.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
