### PR TITLE
D8CORE-3458 Dont display unpublished profiles in the lists

### DIFF
--- a/config/sync/views.view.stanford_person_list_terms_first.yml
+++ b/config/sync/views.view.stanford_person_list_terms_first.yml
@@ -488,15 +488,15 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
-        status_extra:
-          id: status_extra
+        status_1:
+          id: status_1
           table: node_field_data
-          field: status_extra
+          field: status
           relationship: reverse__node__su_person_type_group
           group_type: group
           admin_label: ''
           operator: '='
-          value: ''
+          value: '1'
           group: 1
           exposed: false
           expose:
@@ -526,7 +526,8 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           entity_type: node
-          plugin_id: view_unpublished_node_status
+          entity_field: status
+          plugin_id: boolean
       sorts:
         parent_target_id:
           id: parent_target_id
@@ -704,7 +705,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - user.permissions
       tags:
         - 'config:field.storage.node.su_person_photo'
@@ -726,7 +726,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - user.permissions
       tags:
         - 'config:field.storage.node.su_person_photo'

--- a/tests/codeception/acceptance/Content/PersonCest.php
+++ b/tests/codeception/acceptance/Content/PersonCest.php
@@ -155,4 +155,29 @@ class PersonCest {
     $I->cantSee('Published');
   }
 
+  /**
+   * Unpublished profiles should not display in the list.
+   */
+  public function testPublishedStatus(AcceptanceTester $I) {
+    $foo = $I->createEntity([
+      'name' => 'Foo',
+      'vid' => 'stanford_person_types',
+    ], 'taxonomy_term');
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $I->createEntity([
+      'type' => 'stanford_person',
+      'su_person_first_name' => "John",
+      'su_person_last_name' => "Wick",
+      'su_person_type_group' => $foo->id(),
+    ]);
+    $I->logInWithRole('administrator');
+    $I->amOnPage('/people/foo');
+    $I->canSee($node->label());
+    $node->setUnpublished()->save();
+
+    drupal_flush_all_caches();
+    $I->amOnPage('/people/foo');
+    $I->cantSee($node->label());
+  }
+
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changed the filter to only "Published status" instead of the "Published status or admin user" filter.

# Need Review By (Date)
- 4/7

# Urgency
- low

# Steps to Test
1. checkout this branch
2. drush cim -y
3. create an unpublished profile and tag it with a person type term
4. view that term list page and verify you don't see the profile you created.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
