### PR TITLE
D8CORE-3169: Prepend mailto icon

### DIFF
--- a/config/sync/extlink.settings.yml
+++ b/config/sync/extlink.settings.yml
@@ -20,7 +20,7 @@ extlink_use_font_awesome: false
 extlink_font_awesome_classes:
   links: 'fa fa-external-link'
   mailto: 'fa fa-envelope-o'
-extlink_icon_placement: append
+extlink_icon_placement: prepend
 whitelisted_domains: {  }
 _core:
   default_config_hash: gp38_GoeI-5DmdfeFE0NfHi_mbT2SqdU0zsJIQv-ehc


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
Move mailto icon to prepend (Lead rather than trail)

# Needed By (Date)
sprint close

# Urgency
Not urgent

# Steps to Test

1. Checkout this branch
1. Import config
2. Rebuild cache
3. navigate to a page with a mailto link or create a mailto link
4. Verify the mail to link comes _before_ the mailto link and not after.
5. Verify it behaves as expected.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket https://stanfordits.atlassian.net/browse/D8CORE-3169
- Other PRs: https://github.com/SU-SWS/stanford_profile_helper/pull/92
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
