### PR TITLE
D8CORE-4033: updated view config to allow filtering past events lists

### DIFF
--- a/config/sync/views.view.stanford_events.yml
+++ b/config/sync/views.view.stanford_events.yml
@@ -6135,7 +6135,46 @@ display:
               weight: 22
               plugin: views_row
               source: past_event_location
-      arguments: {  }
+      arguments:
+        term_node_taxonomy_name_depth:
+          id: term_node_taxonomy_name_depth
+          table: node_field_data
+          field: term_node_taxonomy_name_depth
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: 0
+            title: All
+          title_enable: 0
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: 0
+          summary_options:
+            base_path: ''
+            count: '1'
+            items_per_page: '25'
+            override: 0
+          summary:
+            sort_order: asc
+            number_of_records: '0'
+            format: default_summary
+          specify_validation: 0
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          depth: '1'
+          vocabularies:
+            stanford_event_types: stanford_event_types
+          break_phrase: 1
+          use_taxonomy_term_path: false
+          entity_type: node
+          plugin_id: taxonomy_index_name_depth
       title: 'Past Events'
       filters:
         status:
@@ -6262,6 +6301,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added a contextual filter to the past events view.  This will allow filtering by event category in the past events list.
- see also the changes pulled in to the stanford_events module for posterity: https://github.com/SU-SWS/stanford_events/pull/64/files

# Needed By (Date)
- 4/7

# Urgency
- medium

# Steps to Test

1. Checkout this branch
2. `drush cim`
3. Create a bunch of past events, with different event types.
4. Create a list paragraph.  Choose the Past Events list.  Under `Advanced`, filter by an event category.  Remember to use dashes to replace spaces.  
5. Verify your list paragraph only shows the past events in the category you specified.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
