### PR TITLE
D8CORE-3480 Disallow image gallery media in the wysiwyg.

### DIFF
--- a/config/sync/filter.format.stanford_html.yml
+++ b/config/sync/filter.format.stanford_html.yml
@@ -91,7 +91,12 @@ filters:
     weight: -47
     settings:
       default_view_mode: default
-      allowed_media_types: {  }
+      allowed_media_types:
+        embeddable: embeddable
+        file: file
+        google_form: google_form
+        image: image
+        video: video
       allowed_view_modes:
         default: default
         stanford_image_large: stanford_image_large


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Disallow image gallery media in the wysiwyg

# Need Review By (Date)
- 4/22

# Urgency
- low

# Steps to Test
1. checkout this branch and `drush cim -y`
2. go to any wysiwyg and click the embed button
3. verify you don't get the option on the left to upload an image gallery.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
