### PR TITLE
D8CORE-4068 Allow publication authors to have only one name part

### DIFF
--- a/config/sync/field.field.citation.su_article_journal.su_author.yml
+++ b/config/sync/field.field.citation.su_article_journal.su_author.yml
@@ -32,7 +32,7 @@ settings:
     middle: false
     generational: false
     credentials: false
-  allow_family_or_given: false
+  allow_family_or_given: true
   field_type:
     title: select
     given: text
@@ -94,7 +94,7 @@ settings:
     title: Title
     given: 'First Name'
     middle: 'Middle name'
-    family: 'Last Name'
+    family: 'Last Name/Company'
     generational: Generational
     credentials: Credentials
   title_display:

--- a/config/sync/field.field.citation.su_article_newspaper.su_author.yml
+++ b/config/sync/field.field.citation.su_article_newspaper.su_author.yml
@@ -32,7 +32,7 @@ settings:
     middle: false
     generational: false
     credentials: false
-  allow_family_or_given: false
+  allow_family_or_given: true
   field_type:
     title: select
     given: text
@@ -94,7 +94,7 @@ settings:
     title: Title
     given: 'First Name'
     middle: 'Middle name'
-    family: 'Last Name'
+    family: 'Last Name/Company'
     generational: Generational
     credentials: Credentials
   title_display:

--- a/config/sync/field.field.citation.su_book.su_author.yml
+++ b/config/sync/field.field.citation.su_book.su_author.yml
@@ -32,7 +32,7 @@ settings:
     middle: false
     generational: false
     credentials: false
-  allow_family_or_given: false
+  allow_family_or_given: true
   field_type:
     title: select
     given: text
@@ -94,7 +94,7 @@ settings:
     title: Title
     given: 'First Name'
     middle: 'Middle name'
-    family: 'Last Name'
+    family: 'Last Name/Company'
     generational: Generational
     credentials: Credentials
   title_display:

--- a/config/sync/field.field.citation.su_other.su_author.yml
+++ b/config/sync/field.field.citation.su_other.su_author.yml
@@ -32,7 +32,7 @@ settings:
     middle: false
     generational: false
     credentials: false
-  allow_family_or_given: false
+  allow_family_or_given: true
   field_type:
     title: select
     given: text
@@ -94,7 +94,7 @@ settings:
     title: Title
     given: 'First Name'
     middle: 'Middle Name'
-    family: 'Last Name'
+    family: 'Last Name/Company'
     generational: Generational
     credentials: Credentials
   title_display:

--- a/config/sync/field.field.citation.su_thesis.su_author.yml
+++ b/config/sync/field.field.citation.su_thesis.su_author.yml
@@ -32,7 +32,7 @@ settings:
     middle: false
     generational: false
     credentials: false
-  allow_family_or_given: false
+  allow_family_or_given: true
   field_type:
     title: select
     given: text
@@ -94,7 +94,7 @@ settings:
     title: Title
     given: 'First Name'
     middle: 'Middle name'
-    family: 'Last Name'
+    family: 'Last Name/Company'
     generational: Generational
     credentials: Credentials
   title_display:

--- a/tests/codeception/acceptance/Content/PublicationsCest.php
+++ b/tests/codeception/acceptance/Content/PublicationsCest.php
@@ -26,7 +26,7 @@ class PublicationsCest {
     $I->selectOption('su_publication_citation[actions][bundle]', 'Book');
     $I->click('Add Citation');
     $I->fillField('First Name', $faker->firstName);
-    $I->fillField('Last Name', $faker->lastName);
+    $I->fillField('Last Name/Company', $faker->lastName);
     $I->fillField('Subtitle', $faker->text);
     $I->fillField('Publication Place', $faker->text);
     $I->fillField('Publisher', $faker->text);
@@ -86,7 +86,7 @@ class PublicationsCest {
       $I->selectOption('su_publication_citation[actions][bundle]', 'Other');
       $I->click('Add Citation');
       $I->fillField('First Name', $faker->firstName);
-      $I->fillField('Last Name', $faker->lastName);
+      $I->fillField('Last Name/Company', $faker->lastName);
       $I->fillField('Subtitle', $faker->text);
       $I->fillField('Publisher', $faker->text);
       $I->fillField('su_publication_cta[0][uri]', $faker->url);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
-  Allow publication authors to have only one name part 

# Need Review By (Date)
- 4/22

# Urgency
- low

# Steps to Test
1. checkout this branch and `drush cim -y`
2. create a publication and in the citation information enter only the last name for an author
3. save and verify it does indeed save without errors.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
