### PR TITLE
D8CORE-4093: removing the margin top from the button on lists

### DIFF
--- a/config/sync/core.entity_view_display.paragraph.stanford_lists.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.stanford_lists.default.yml
@@ -31,7 +31,7 @@ content:
       target: '0'
     third_party_settings:
       field_formatter_class:
-        class: su-margin-top-5
+        class: ''
     type: link_class
     region: content
   su_list_description:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removing the margin top class for the CTA button all the lists. The list objects have padding bottom themselves and it was too much all added up.

# Needed By (Date)
- 4/23

# Urgency
- med

# Steps to Test

1. Pull in this change.
2. Clear the caches.
3. Create some lists with and without CTA buttons. Try the default lists and cards.
4. Review the button and see the margin top is removed. 

# Affected Projects or Products
- Lists module
- Sub themes

# Associated Issues and/or People
- D8CORE-4093
- SOE Subtheme - I tested
- SBT - I tested
- @rebeccahongsf , in case SAA Victoria theme is depending on the button for padding. 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
