### PR TITLE
D8CORE-3970: removed the extra h2

### DIFF
--- a/config/sync/core.entity_view_display.node.stanford_event_series.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event_series.stanford_card.yml
@@ -96,7 +96,7 @@ third_party_settings:
         formatter: default
         settings:
           link: true
-          wrapper: h2
+          wrapper: ''
           class: ''
 id: node.stanford_event_series.stanford_card
 targetEntityType: node


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- adding styles for the teaser of an Event Series

# Needed By (Date)
- 5/5

# Urgency
- Medium

# Steps to Test

1. Pull in this change
2. Clear caches.
3. Add or make sure you have an Event Series piece of content.
4. Add a teaser of the Series to a page. 
5. Verify the h2 is the right size when put next to another Event teaser.

# Affected Projects or Products
- SBT - Tested
- SOE - Testing
- SAA - @rebeccahongsf (I tested this too)
- https://github.com/SU-SWS/stanford_profile_helper/pull/106
- https://github.com/SU-SOE/soe_basic/pull/76
- https://github.com/SU-SWS/stanford_profile/pull/409

# Associated Issues and/or People
- D8CORE-3970

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
