### PR TITLE
D8CORE-4145: adding the margin bottom to the intro for events.

### DIFF
--- a/config/sync/core.entity_view_display.block_content.stanford_component_block.default.yml
+++ b/config/sync/core.entity_view_display.block_content.stanford_component_block.default.yml
@@ -23,7 +23,7 @@ content:
       link: ''
     third_party_settings:
       field_formatter_class:
-        class: su-intro
+        class: 'su-intro su-margin-bottom-3'
       ds:
         ds_limit: ''
     region: content


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adding margin bottom for the Events Intro paragraph.

# Needed By (Date)
- 5/5

# Urgency
- Medium

# Steps to Test

1. Pull in this change.
2. Clear caches.
3. Add an intro to the Events page. This is for the the types that aren't text only.  Such as Banners, Media, etc

# Affected Projects or Products
- Events for all sub themes. I've test SOE, SAA and SBT.

# Associated Issues and/or People
- [D8CORE-4145](https://stanfordits.atlassian.net/browse/D8CORE-4145)


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
