### PR TITLE
D8CORE-3951: fixing the pagination to the infinite scroll and a Load More button

### DIFF
--- a/config/sync/views.view.stanford_publications.yml
+++ b/config/sync/views.view.stanford_publications.yml
@@ -1554,7 +1554,7 @@ display:
         empty: false
       block_category: 'Publication (Views)'
       pager:
-        type: full
+        type: infinite_scroll
         options:
           items_per_page: 20
           offset: 0
@@ -1563,8 +1563,6 @@ display:
           tags:
             previous: '‹ Previous'
             next: 'Next ›'
-            first: '« First'
-            last: 'Last »'
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -1573,7 +1571,10 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          quantity: 9
+          views_infinite_scroll:
+            button_text: 'Load More'
+            automatically_load_content: false
+            initially_load_all_pages: false
       block_hide_empty: true
       arguments:
         term_node_tid_depth:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This adds the margin bottom to the filtered publications list.
- This fixes the narrow widths when there is little content in a publication.
- This fixes the pagination back to the infinite scroll and Load More button.

# Needed By (Date)
- 5/5

# Urgency
- high

# Steps to Test

1. Pull in this change and clear the caches.
2. Pull in [PR 41](https://github.com/SU-SWS/stanford_publication/pull/41) and clear caches.
2. Go to your publications page and generate 20 + pages.
3. Verify there is a margin bottom.
4. Note the pagination on the filtered pages is known by design. 

# Affected Projects or Products
- Publications

# Associated Issues and/or People
- [D8CORE-3951](https://stanfordits.atlassian.net/browse/D8CORE-3951)
- https://github.com/SU-SWS/stanford_publication/pull/41

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
