### PR TITLE
D8CORE-4215: Undoing the change to the button margin

### DIFF
--- a/config/sync/core.entity_view_display.paragraph.stanford_lists.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.stanford_lists.default.yml
@@ -24,7 +24,7 @@ content:
     label: hidden
     settings:
       trim_length: 80
-      class: su-button
+      class: 'su-button su-margin-top-5'
       url_only: false
       url_plain: false
       rel: '0'


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adding the su-margin-top-5 back to the list button 
- Found an issue with removing it.
- This will undo the work in https://github.com/SU-SWS/stanford_profile/pull/405

# Needed By (Date)
- ASAP

# Urgency
- High

# Steps to Test

1.  Create lists of events in the default view with a set number to display.
2. Notice the button is right up on the line.
3. Pull in this change.
4. Clear caches.
5. Notice the button now has top spacing.  

# Affected Projects or Products
- List paragraphs
- SAA
- SOE
- SBT

# Associated Issues and/or People
- D8CORE-4215
- D8CORE-4093 (undoing)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
