### PR TITLE
D8CORE-4215: Undoing the change to the button margin

### DIFF
--- a/config/sync/core.entity_view_display.paragraph.stanford_lists.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.stanford_lists.default.yml
@@ -24,7 +24,7 @@ content:
     label: hidden
     settings:
       trim_length: 80
-      class: su-button
+      class: 'su-button su-margin-top-5'
       url_only: false
       url_plain: false
       rel: '0'

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -140,6 +140,7 @@ module:
   stanford_paragraph_card: 0
   stanford_person: 0
   stanford_person_importer: 0
+  stanford_profile_admin: 0
   stanford_profile_drush: 0
   stanford_profile_helper: 0
   stanford_profile_styles: 0

--- a/config/sync/views.view.user_admin_people.yml
+++ b/config/sync/views.view.user_admin_people.yml
@@ -6,9 +6,9 @@ dependencies:
     - role_delegation
     - user
 id: user_admin_people
-label: People
+label: Users
 module: user
-description: 'Find and manage people interacting with your site.'
+description: 'Find and manage users interacting with your site.'
 tag: default
 base_table: users_field_data
 base_field: uid
@@ -852,7 +852,7 @@ display:
           plugin_id: date
           entity_type: user
           entity_field: created
-      title: People
+      title: Users
       empty:
         area_text_custom:
           id: area_text_custom
@@ -896,7 +896,7 @@ display:
     display_title: Page
     position: 1
     display_options:
-      path: admin/people/list
+      path: admin/users/list
       show_admin_links: false
       menu:
         type: 'default tab'
@@ -907,9 +907,8 @@ display:
         context: ''
       tab_options:
         type: normal
-        title: People
+        title: Users
         description: 'Manage user accounts, roles, and permissions.'
-        menu_name: admin
         weight: 0
       defaults:
         show_admin_links: false

--- a/tests/codeception/acceptance/AuthenticatedPermissionsCest.php
+++ b/tests/codeception/acceptance/AuthenticatedPermissionsCest.php
@@ -48,7 +48,7 @@ class AuthenticatedPermissionsCest {
     $I->canSeeResponseCodeIs(403);
     $I->amOnPage('/admin/config');
     $I->canSeeResponseCodeIs(403);
-    $I->amOnPage('/admin/people');
+    $I->amOnPage('/admin/users');
     $I->canSeeResponseCodeIs(403);
     $I->amOnPage('/admin/reports');
     $I->canSeeResponseCodeIs(403);
@@ -71,7 +71,7 @@ class AuthenticatedPermissionsCest {
   public function testSiteManagerEscalationSelf(AcceptanceTester $I) {
     $site_manager = $I->logInWithRole('site_manager');
     $site_manager_id = $site_manager->id();
-    $I->amOnPage('/admin/people');
+    $I->amOnPage('/admin/users');
     $I->canSee($site_manager->getDisplayName());
     $I->click(['link' => $site_manager->getDisplayName()]);
     $I->click('.roles.tabs__tab a');
@@ -86,7 +86,7 @@ class AuthenticatedPermissionsCest {
    */
   public function testSiteManagerEscalationOthers(AcceptanceTester $I) {
     $I->logInWithRole('site_manager');
-    $I->amOnPage('/admin/people');
+    $I->amOnPage('/admin/users');
     $I->canSee('Morgan');
     $I->click('Morgan');
     $I->click('.roles.tabs__tab a');

--- a/tests/codeception/acceptance/Users/DefaultUsersCest.php
+++ b/tests/codeception/acceptance/Users/DefaultUsersCest.php
@@ -12,7 +12,7 @@ class DefaultUsersCest {
    */
   public function testDefaultUsers(AcceptanceTester $I) {
     $I->logInWithRole('administrator');
-    $I->amOnPage('/admin/people');
+    $I->amOnPage('/admin/users');
     $I->canSee('Alex');
     $I->canSee('Jamie');
     $I->canSee('Sam');

--- a/tests/codeception/acceptance/Users/RolesCest.php
+++ b/tests/codeception/acceptance/Users/RolesCest.php
@@ -12,7 +12,7 @@ class RolesCest {
    */
   public function testRolesExist(AcceptanceTester $I) {
     $I->logInWithRole('administrator');
-    $I->amOnPage('/admin/people/roles');
+    $I->amOnPage('/admin/users/roles');
     $I->canSee('Contributor');
     $I->canSee('Site Editor');
     $I->canSee('Site Manager');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adding the su-margin-top-5 back to the list button 
- Found an issue with removing it.
- This will undo the work in https://github.com/SU-SWS/stanford_profile/pull/405

# Needed By (Date)
- ASAP

# Urgency
- High
- 
# Steps to Test

1.  Create lists of events in the default view with a set number to display.
2. Notice the button is right up on the line.
3. Pull in this change.
4. Clear caches.
5. Notice the button now has top spacing.  

# Affected Projects or Products
- List paragraphs
- SAA
- SOE
- SBT

# Associated Issues and/or People
- D8CORE-4215
- D8CORE-4093 (undoing)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
