### PR TITLE
D8CORE-3973: added shared tags vocabulary.

### DIFF
--- a/config/sync/core.entity_form_display.node.stanford_event.default.yml
+++ b/config/sync/core.entity_form_display.node.stanford_event.default.yml
@@ -21,6 +21,7 @@ dependencies:
     - field.field.node.stanford_event.su_event_subheadline
     - field.field.node.stanford_event.su_event_telephone
     - field.field.node.stanford_event.su_event_type
+    - field.field.node.stanford_event.su_shared_tags
     - node.type.stanford_event
   module:
     - address
@@ -253,6 +254,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: options_select
+    region: content
+  su_shared_tags:
+    weight: 30
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
     region: content
   title:
     type: string_textfield

--- a/config/sync/core.entity_form_display.node.stanford_event_series.default.yml
+++ b/config/sync/core.entity_form_display.node.stanford_event_series.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.stanford_event_series.su_event_series_subheadline
     - field.field.node.stanford_event_series.su_event_series_type
     - field.field.node.stanford_event_series.su_event_series_weight
+    - field.field.node.stanford_event_series.su_shared_tags
     - node.type.stanford_event_series
   module:
     - field_group
@@ -140,6 +141,16 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: number
+    region: content
+  su_shared_tags:
+    weight: 26
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
     region: content
   title:
     type: string_textfield

--- a/config/sync/core.entity_form_display.node.stanford_news.default.yml
+++ b/config/sync/core.entity_form_display.node.stanford_news.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.stanford_news.su_news_publishing_date
     - field.field.node.stanford_news.su_news_source
     - field.field.node.stanford_news.su_news_topics
+    - field.field.node.stanford_news.su_shared_tags
     - node.type.stanford_news
   module:
     - datetime
@@ -161,6 +162,16 @@ content:
     region: content
   su_news_topics:
     weight: 3
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  su_shared_tags:
+    weight: 26
     settings:
       match_operator: CONTAINS
       match_limit: 10

--- a/config/sync/core.entity_form_display.node.stanford_page.default.yml
+++ b/config/sync/core.entity_form_display.node.stanford_page.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.stanford_page.su_page_components
     - field.field.node.stanford_page.su_page_description
     - field.field.node.stanford_page.su_page_image
+    - field.field.node.stanford_page.su_shared_tags
     - node.type.stanford_page
   module:
     - field_group
@@ -26,6 +27,7 @@ third_party_settings:
         - su_page_image
         - su_page_description
         - su_basic_page_type
+        - su_shared_tags
       parent_name: ''
       weight: 12
       format_type: details_sidebar
@@ -142,6 +144,16 @@ content:
     settings:
       media_types: {  }
     third_party_settings: {  }
+  su_shared_tags:
+    weight: 3
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
   title:
     type: string_textfield
     weight: 0

--- a/config/sync/core.entity_form_display.node.stanford_person.default.yml
+++ b/config/sync/core.entity_form_display.node.stanford_person.default.yml
@@ -30,6 +30,7 @@ dependencies:
     - field.field.node.stanford_person.su_person_short_title
     - field.field.node.stanford_person.su_person_telephone
     - field.field.node.stanford_person.su_person_type_group
+    - field.field.node.stanford_person.su_shared_tags
     - node.type.stanford_person
   module:
     - allowed_formats
@@ -318,6 +319,16 @@ content:
       display_node_count: false
     third_party_settings: {  }
     type: options_shs
+    region: content
+  su_shared_tags:
+    weight: 26
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
     region: content
   title:
     type: string_textfield

--- a/config/sync/core.entity_form_display.node.stanford_publication.default.yml
+++ b/config/sync/core.entity_form_display.node.stanford_publication.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.stanford_publication.su_publication_components
     - field.field.node.stanford_publication.su_publication_cta
     - field.field.node.stanford_publication.su_publication_topics
+    - field.field.node.stanford_publication.su_shared_tags
     - node.type.stanford_publication
   module:
     - inline_entity_form
@@ -75,6 +76,16 @@ content:
     region: content
   su_publication_topics:
     weight: 2
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  su_shared_tags:
+    weight: 26
     settings:
       match_operator: CONTAINS
       match_limit: 10

--- a/config/sync/core.entity_view_display.node.stanford_event.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event.default.yml
@@ -169,22 +169,6 @@ third_party_settings:
                 view_mode: view_mode
             additional: {  }
             weight: -9
-          caebc6fa-aaf6-4415-b4de-04c4512a787a:
-            uuid: caebc6fa-aaf6-4415-b4de-04c4512a787a
-            region: main
-            configuration:
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              id: 'field_block:node:stanford_event:su_shared_tags'
-              formatter:
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-                type: entity_reference_label
-            additional: {  }
-            weight: -4
         third_party_settings: {  }
       -
         layout_id: stanford_events_body

--- a/config/sync/core.entity_view_display.node.stanford_event.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event.default.yml
@@ -724,16 +724,9 @@ content:
     third_party_settings: {  }
     type: entity_reference_label
     region: content
-  su_shared_tags:
-    weight: 119
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: main
 hidden:
   layout_builder__layout: true
   search_api_excerpt: true
   stanford_intranet__access: true
   su_event_schedule: true
+  su_shared_tags: true

--- a/config/sync/core.entity_view_display.node.stanford_event.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.base_field_override.node.stanford_event.title
     - field.field.node.stanford_event.body
     - field.field.node.stanford_event.layout_builder__layout
+    - field.field.node.stanford_event.stanford_intranet__access
     - field.field.node.stanford_event.su_event_alt_loc
     - field.field.node.stanford_event.su_event_audience
     - field.field.node.stanford_event.su_event_components
@@ -21,6 +22,7 @@ dependencies:
     - field.field.node.stanford_event.su_event_subheadline
     - field.field.node.stanford_event.su_event_telephone
     - field.field.node.stanford_event.su_event_type
+    - field.field.node.stanford_event.su_shared_tags
     - node.type.stanford_event
     - views.view.stanford_events
   module:
@@ -167,6 +169,22 @@ third_party_settings:
                 view_mode: view_mode
             additional: {  }
             weight: -9
+          caebc6fa-aaf6-4415-b4de-04c4512a787a:
+            uuid: caebc6fa-aaf6-4415-b4de-04c4512a787a
+            region: main
+            configuration:
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              id: 'field_block:node:stanford_event:su_shared_tags'
+              formatter:
+                label: above
+                settings:
+                  link: true
+                third_party_settings: {  }
+                type: entity_reference_label
+            additional: {  }
+            weight: -4
         third_party_settings: {  }
       -
         layout_id: stanford_events_body
@@ -722,6 +740,14 @@ content:
     third_party_settings: {  }
     type: entity_reference_label
     region: content
+  su_shared_tags:
+    weight: 119
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: main
 hidden:
   layout_builder__layout: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.stanford_event.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event.stanford_card.yml
@@ -6,7 +6,6 @@ dependencies:
     - core.entity_view_mode.node.stanford_card
     - field.field.node.stanford_event.body
     - field.field.node.stanford_event.layout_builder__layout
-    - field.field.node.stanford_event.stanford_intranet__access
     - field.field.node.stanford_event.su_event_alt_loc
     - field.field.node.stanford_event.su_event_audience
     - field.field.node.stanford_event.su_event_components

--- a/config/sync/core.entity_view_display.node.stanford_event.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event.stanford_card.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.stanford_card
     - field.field.node.stanford_event.body
     - field.field.node.stanford_event.layout_builder__layout
+    - field.field.node.stanford_event.stanford_intranet__access
     - field.field.node.stanford_event.su_event_alt_loc
     - field.field.node.stanford_event.su_event_audience
     - field.field.node.stanford_event.su_event_components
@@ -21,6 +22,7 @@ dependencies:
     - field.field.node.stanford_event.su_event_subheadline
     - field.field.node.stanford_event.su_event_telephone
     - field.field.node.stanford_event.su_event_type
+    - field.field.node.stanford_event.su_shared_tags
     - node.type.stanford_event
   module:
     - address
@@ -237,3 +239,4 @@ hidden:
   su_event_schedule: true
   su_event_sponsor: true
   su_event_telephone: true
+  su_shared_tags: true

--- a/config/sync/core.entity_view_display.node.stanford_event.teaser.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event.teaser.yml
@@ -6,7 +6,6 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.stanford_event.body
     - field.field.node.stanford_event.layout_builder__layout
-    - field.field.node.stanford_event.stanford_intranet__access
     - field.field.node.stanford_event.su_event_alt_loc
     - field.field.node.stanford_event.su_event_audience
     - field.field.node.stanford_event.su_event_components

--- a/config/sync/core.entity_view_display.node.stanford_event.teaser.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.stanford_event.body
     - field.field.node.stanford_event.layout_builder__layout
+    - field.field.node.stanford_event.stanford_intranet__access
     - field.field.node.stanford_event.su_event_alt_loc
     - field.field.node.stanford_event.su_event_audience
     - field.field.node.stanford_event.su_event_components
@@ -21,6 +22,7 @@ dependencies:
     - field.field.node.stanford_event.su_event_subheadline
     - field.field.node.stanford_event.su_event_telephone
     - field.field.node.stanford_event.su_event_type
+    - field.field.node.stanford_event.su_shared_tags
     - node.type.stanford_event
   module:
     - address
@@ -184,3 +186,4 @@ hidden:
   su_event_schedule: true
   su_event_sponsor: true
   su_event_telephone: true
+  su_shared_tags: true

--- a/config/sync/core.entity_view_display.node.stanford_event_series.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event_series.default.yml
@@ -279,15 +279,8 @@ content:
     third_party_settings: {  }
     type: number_integer
     region: main
-  su_shared_tags:
-    weight: 108
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: main
 hidden:
   layout_builder__layout: true
   search_api_excerpt: true
   stanford_intranet__access: true
+  su_shared_tags: true

--- a/config/sync/core.entity_view_display.node.stanford_event_series.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event_series.default.yml
@@ -4,12 +4,14 @@ status: true
 dependencies:
   config:
     - field.field.node.stanford_event_series.layout_builder__layout
+    - field.field.node.stanford_event_series.stanford_intranet__access
     - field.field.node.stanford_event_series.su_event_series_components
     - field.field.node.stanford_event_series.su_event_series_dek
     - field.field.node.stanford_event_series.su_event_series_event
     - field.field.node.stanford_event_series.su_event_series_subheadline
     - field.field.node.stanford_event_series.su_event_series_type
     - field.field.node.stanford_event_series.su_event_series_weight
+    - field.field.node.stanford_event_series.su_shared_tags
     - node.type.stanford_event_series
   module:
     - entity_reference_revisions
@@ -105,6 +107,22 @@ third_party_settings:
                 view_mode: view_mode
             additional: {  }
             weight: 3
+          5af53dc4-6d7d-442c-bc7e-11035625b131:
+            uuid: 5af53dc4-6d7d-442c-bc7e-11035625b131
+            region: main
+            configuration:
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              id: 'field_block:node:stanford_event_series:su_shared_tags'
+              formatter:
+                label: above
+                settings:
+                  link: true
+                third_party_settings: {  }
+                type: entity_reference_label
+            additional: {  }
+            weight: 4
         third_party_settings: {  }
       -
         layout_id: jumpstart_ui_one_column
@@ -277,6 +295,14 @@ content:
       prefix_suffix: true
     third_party_settings: {  }
     type: number_integer
+    region: main
+  su_shared_tags:
+    weight: 108
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: main
 hidden:
   layout_builder__layout: true

--- a/config/sync/core.entity_view_display.node.stanford_event_series.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event_series.default.yml
@@ -106,22 +106,6 @@ third_party_settings:
                 view_mode: view_mode
             additional: {  }
             weight: 3
-          5af53dc4-6d7d-442c-bc7e-11035625b131:
-            uuid: 5af53dc4-6d7d-442c-bc7e-11035625b131
-            region: main
-            configuration:
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              id: 'field_block:node:stanford_event_series:su_shared_tags'
-              formatter:
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-                type: entity_reference_label
-            additional: {  }
-            weight: 4
         third_party_settings: {  }
       -
         layout_id: jumpstart_ui_one_column

--- a/config/sync/core.entity_view_display.node.stanford_event_series.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event_series.default.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - field.field.node.stanford_event_series.layout_builder__layout
-    - field.field.node.stanford_event_series.stanford_intranet__access
     - field.field.node.stanford_event_series.su_event_series_components
     - field.field.node.stanford_event_series.su_event_series_dek
     - field.field.node.stanford_event_series.su_event_series_event

--- a/config/sync/core.entity_view_display.node.stanford_event_series.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event_series.stanford_card.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.stanford_event_series.su_event_series_subheadline
     - field.field.node.stanford_event_series.su_event_series_type
     - field.field.node.stanford_event_series.su_event_series_weight
+    - field.field.node.stanford_event_series.su_shared_tags
     - node.type.stanford_event_series
   module:
     - ds
@@ -128,3 +129,4 @@ hidden:
   su_event_series_event: true
   su_event_series_type: true
   su_event_series_weight: true
+  su_shared_tags: true

--- a/config/sync/core.entity_view_display.node.stanford_event_series.teaser.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event_series.teaser.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.stanford_event_series.su_event_series_subheadline
     - field.field.node.stanford_event_series.su_event_series_type
     - field.field.node.stanford_event_series.su_event_series_weight
+    - field.field.node.stanford_event_series.su_shared_tags
     - node.type.stanford_event_series
   module:
     - user
@@ -35,3 +36,4 @@ hidden:
   su_event_series_subheadline: true
   su_event_series_type: true
   su_event_series_weight: true
+  su_shared_tags: true

--- a/config/sync/core.entity_view_display.node.stanford_news.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_news.default.yml
@@ -4,7 +4,6 @@ status: true
 dependencies:
   config:
     - field.field.node.stanford_news.layout_builder__layout
-    - field.field.node.stanford_news.stanford_intranet__access
     - field.field.node.stanford_news.su_news_banner
     - field.field.node.stanford_news.su_news_banner_media_caption
     - field.field.node.stanford_news.su_news_byline

--- a/config/sync/core.entity_view_display.node.stanford_news.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_news.default.yml
@@ -432,14 +432,6 @@ content:
     third_party_settings: {  }
     type: entity_reference_label
     region: content
-  su_shared_tags:
-    weight: 9
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: main
 hidden:
   layout_builder__layout: true
   layout_selection: true
@@ -447,3 +439,4 @@ hidden:
   search_api_excerpt: true
   stanford_intranet__access: true
   su_news_source: true
+  su_shared_tags: true

--- a/config/sync/core.entity_view_display.node.stanford_news.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_news.default.yml
@@ -107,22 +107,6 @@ third_party_settings:
               context_mapping: {  }
             additional: {  }
             weight: 2
-          22a25866-530b-4230-ba0b-8556d5f61b41:
-            uuid: 22a25866-530b-4230-ba0b-8556d5f61b41
-            region: main
-            configuration:
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              id: 'field_block:node:stanford_news:su_shared_tags'
-              formatter:
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-                type: entity_reference_label
-            additional: {  }
-            weight: 5
         third_party_settings: {  }
       -
         layout_id: stanford_news_byline

--- a/config/sync/core.entity_view_display.node.stanford_news.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_news.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.stanford_news.layout_builder__layout
+    - field.field.node.stanford_news.stanford_intranet__access
     - field.field.node.stanford_news.su_news_banner
     - field.field.node.stanford_news.su_news_banner_media_caption
     - field.field.node.stanford_news.su_news_byline
@@ -14,6 +15,7 @@ dependencies:
     - field.field.node.stanford_news.su_news_publishing_date
     - field.field.node.stanford_news.su_news_source
     - field.field.node.stanford_news.su_news_topics
+    - field.field.node.stanford_news.su_shared_tags
     - node.type.stanford_news
     - views.view.stanford_news
   module:
@@ -106,6 +108,22 @@ third_party_settings:
               context_mapping: {  }
             additional: {  }
             weight: 2
+          22a25866-530b-4230-ba0b-8556d5f61b41:
+            uuid: 22a25866-530b-4230-ba0b-8556d5f61b41
+            region: main
+            configuration:
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              id: 'field_block:node:stanford_news:su_shared_tags'
+              formatter:
+                label: above
+                settings:
+                  link: true
+                third_party_settings: {  }
+                type: entity_reference_label
+            additional: {  }
+            weight: 5
         third_party_settings: {  }
       -
         layout_id: stanford_news_byline
@@ -431,6 +449,14 @@ content:
     third_party_settings: {  }
     type: entity_reference_label
     region: content
+  su_shared_tags:
+    weight: 9
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: main
 hidden:
   layout_builder__layout: true
   layout_selection: true

--- a/config/sync/core.entity_view_display.node.stanford_news.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_news.stanford_card.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.stanford_news.su_news_publishing_date
     - field.field.node.stanford_news.su_news_source
     - field.field.node.stanford_news.su_news_topics
+    - field.field.node.stanford_news.su_shared_tags
     - node.type.stanford_news
   module:
     - ds
@@ -156,3 +157,4 @@ hidden:
   su_news_dek: true
   su_news_headline: true
   su_news_publishing_date: true
+  su_shared_tags: true

--- a/config/sync/core.entity_view_display.node.stanford_page.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_page.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.stanford_page.su_page_components
     - field.field.node.stanford_page.su_page_description
     - field.field.node.stanford_page.su_page_image
+    - field.field.node.stanford_page.su_shared_tags
     - node.type.stanford_page
     - system.menu.main
   module:
@@ -52,6 +53,22 @@ third_party_settings:
                 view_mode: view_mode
             additional: {  }
             weight: 0
+          6ffa763b-bc53-40b2-a052-838b4dbe6b7d:
+            uuid: 6ffa763b-bc53-40b2-a052-838b4dbe6b7d
+            region: main
+            configuration:
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              id: 'field_block:node:stanford_page:su_shared_tags'
+              formatter:
+                label: above
+                settings:
+                  link: true
+                third_party_settings: {  }
+                type: entity_reference_label
+            additional: {  }
+            weight: 1
         third_party_settings: {  }
       -
         layout_id: jumpstart_ui_one_column
@@ -219,6 +236,14 @@ content:
       view_mode: default
       link: false
     third_party_settings: {  }
+    region: main
+  su_shared_tags:
+    weight: 8
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: main
 hidden:
   layout_builder__layout: true

--- a/config/sync/core.entity_view_display.node.stanford_page.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_page.default.yml
@@ -221,16 +221,9 @@ content:
       link: false
     third_party_settings: {  }
     region: main
-  su_shared_tags:
-    weight: 8
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: main
 hidden:
   layout_builder__layout: true
   layout_selection: true
   search_api_excerpt: true
   stanford_intranet__access: true
+  su_shared_tags: true

--- a/config/sync/core.entity_view_display.node.stanford_page.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_page.default.yml
@@ -53,22 +53,6 @@ third_party_settings:
                 view_mode: view_mode
             additional: {  }
             weight: 0
-          6ffa763b-bc53-40b2-a052-838b4dbe6b7d:
-            uuid: 6ffa763b-bc53-40b2-a052-838b4dbe6b7d
-            region: main
-            configuration:
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              id: 'field_block:node:stanford_page:su_shared_tags'
-              formatter:
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-                type: entity_reference_label
-            additional: {  }
-            weight: 1
         third_party_settings: {  }
       -
         layout_id: jumpstart_ui_one_column

--- a/config/sync/core.entity_view_display.node.stanford_page.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_page.stanford_card.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.stanford_page.su_page_components
     - field.field.node.stanford_page.su_page_description
     - field.field.node.stanford_page.su_page_image
+    - field.field.node.stanford_page.su_shared_tags
     - node.type.stanford_page
   module:
     - ds
@@ -151,3 +152,4 @@ hidden:
   search_api_excerpt: true
   stanford_intranet__access: true
   su_page_components: true
+  su_shared_tags: true

--- a/config/sync/core.entity_view_display.node.stanford_person.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_person.default.yml
@@ -6,7 +6,6 @@ dependencies:
     - core.base_field_override.node.stanford_person.title
     - field.field.node.stanford_person.body
     - field.field.node.stanford_person.layout_builder__layout
-    - field.field.node.stanford_person.stanford_intranet__access
     - field.field.node.stanford_person.su_person_academic_appt
     - field.field.node.stanford_person.su_person_admin_appts
     - field.field.node.stanford_person.su_person_affiliations

--- a/config/sync/core.entity_view_display.node.stanford_person.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_person.default.yml
@@ -771,14 +771,6 @@ content:
     third_party_settings: {  }
     type: entity_reference_label
     region: content
-  su_shared_tags:
-    weight: 128
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
 hidden:
   layout_builder__layout: true
   search_api_excerpt: true
@@ -787,3 +779,4 @@ hidden:
   su_person_admin_appts: true
   su_person_research_interests: true
   su_person_scholarly_interests: true
+  su_shared_tags: true

--- a/config/sync/core.entity_view_display.node.stanford_person.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_person.default.yml
@@ -221,22 +221,6 @@ third_party_settings:
                 view_mode: view_mode
             additional: {  }
             weight: 0
-          7938dd12-e5df-44d6-ba8f-0019b368ac57:
-            uuid: 7938dd12-e5df-44d6-ba8f-0019b368ac57
-            region: content
-            configuration:
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              id: 'field_block:node:stanford_person:su_shared_tags'
-              formatter:
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-                type: entity_reference_label
-            additional: {  }
-            weight: 0
         third_party_settings: {  }
       -
         layout_id: stanford_person_body

--- a/config/sync/core.entity_view_display.node.stanford_person.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_person.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.base_field_override.node.stanford_person.title
     - field.field.node.stanford_person.body
     - field.field.node.stanford_person.layout_builder__layout
+    - field.field.node.stanford_person.stanford_intranet__access
     - field.field.node.stanford_person.su_person_academic_appt
     - field.field.node.stanford_person.su_person_admin_appts
     - field.field.node.stanford_person.su_person_affiliations
@@ -30,6 +31,7 @@ dependencies:
     - field.field.node.stanford_person.su_person_short_title
     - field.field.node.stanford_person.su_person_telephone
     - field.field.node.stanford_person.su_person_type_group
+    - field.field.node.stanford_person.su_shared_tags
     - node.type.stanford_person
   module:
     - entity_reference_revisions
@@ -218,6 +220,22 @@ third_party_settings:
               context_mapping:
                 entity: layout_builder.entity
                 view_mode: view_mode
+            additional: {  }
+            weight: 0
+          7938dd12-e5df-44d6-ba8f-0019b368ac57:
+            uuid: 7938dd12-e5df-44d6-ba8f-0019b368ac57
+            region: content
+            configuration:
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              id: 'field_block:node:stanford_person:su_shared_tags'
+              formatter:
+                label: above
+                settings:
+                  link: true
+                third_party_settings: {  }
+                type: entity_reference_label
             additional: {  }
             weight: 0
         third_party_settings: {  }
@@ -764,6 +782,14 @@ content:
     region: content
   su_person_type_group:
     weight: 126
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  su_shared_tags:
+    weight: 128
     label: above
     settings:
       link: true

--- a/config/sync/core.entity_view_display.node.stanford_person.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_person.stanford_card.yml
@@ -6,7 +6,6 @@ dependencies:
     - core.entity_view_mode.node.stanford_card
     - field.field.node.stanford_person.body
     - field.field.node.stanford_person.layout_builder__layout
-    - field.field.node.stanford_person.stanford_intranet__access
     - field.field.node.stanford_person.su_person_academic_appt
     - field.field.node.stanford_person.su_person_admin_appts
     - field.field.node.stanford_person.su_person_affiliations

--- a/config/sync/core.entity_view_display.node.stanford_person.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_person.stanford_card.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.stanford_card
     - field.field.node.stanford_person.body
     - field.field.node.stanford_person.layout_builder__layout
+    - field.field.node.stanford_person.stanford_intranet__access
     - field.field.node.stanford_person.su_person_academic_appt
     - field.field.node.stanford_person.su_person_admin_appts
     - field.field.node.stanford_person.su_person_affiliations
@@ -30,6 +31,7 @@ dependencies:
     - field.field.node.stanford_person.su_person_short_title
     - field.field.node.stanford_person.su_person_telephone
     - field.field.node.stanford_person.su_person_type_group
+    - field.field.node.stanford_person.su_shared_tags
     - node.type.stanford_person
   module:
     - ds
@@ -137,3 +139,4 @@ hidden:
   su_person_scholarly_interests: true
   su_person_telephone: true
   su_person_type_group: true
+  su_shared_tags: true

--- a/config/sync/core.entity_view_display.node.stanford_person.teaser.yml
+++ b/config/sync/core.entity_view_display.node.stanford_person.teaser.yml
@@ -31,6 +31,7 @@ dependencies:
     - field.field.node.stanford_person.su_person_short_title
     - field.field.node.stanford_person.su_person_telephone
     - field.field.node.stanford_person.su_person_type_group
+    - field.field.node.stanford_person.su_shared_tags
     - node.type.stanford_person
   module:
     - text
@@ -81,3 +82,4 @@ hidden:
   su_person_short_title: true
   su_person_telephone: true
   su_person_type_group: true
+  su_shared_tags: true

--- a/config/sync/core.entity_view_display.node.stanford_publication.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_publication.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.stanford_publication.su_publication_components
     - field.field.node.stanford_publication.su_publication_cta
     - field.field.node.stanford_publication.su_publication_topics
+    - field.field.node.stanford_publication.su_shared_tags
     - node.type.stanford_publication
     - views.view.stanford_publications
   module:
@@ -67,6 +68,22 @@ third_party_settings:
                 view_mode: view_mode
             additional: {  }
             weight: 3
+          a4e93b88-86b1-43a2-9364-abb036c0fd2d:
+            uuid: a4e93b88-86b1-43a2-9364-abb036c0fd2d
+            region: main
+            configuration:
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              id: 'field_block:node:stanford_publication:su_shared_tags'
+              formatter:
+                label: above
+                settings:
+                  link: true
+                third_party_settings: {  }
+                type: entity_reference_label
+            additional: {  }
+            weight: 4
         third_party_settings: {  }
       -
         layout_id: jumpstart_ui_two_column
@@ -202,7 +219,15 @@ id: node.stanford_publication.default
 targetEntityType: node
 bundle: stanford_publication
 mode: default
-content: {  }
+content:
+  su_shared_tags:
+    weight: 1
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: main
 hidden:
   citation_type: true
   layout_builder__layout: true

--- a/config/sync/core.entity_view_display.node.stanford_publication.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_publication.default.yml
@@ -68,22 +68,6 @@ third_party_settings:
                 view_mode: view_mode
             additional: {  }
             weight: 3
-          a4e93b88-86b1-43a2-9364-abb036c0fd2d:
-            uuid: a4e93b88-86b1-43a2-9364-abb036c0fd2d
-            region: main
-            configuration:
-              label_display: '0'
-              context_mapping:
-                entity: layout_builder.entity
-              id: 'field_block:node:stanford_publication:su_shared_tags'
-              formatter:
-                label: above
-                settings:
-                  link: true
-                third_party_settings: {  }
-                type: entity_reference_label
-            additional: {  }
-            weight: 4
         third_party_settings: {  }
       -
         layout_id: jumpstart_ui_two_column

--- a/config/sync/core.entity_view_display.node.stanford_publication.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_publication.default.yml
@@ -203,15 +203,7 @@ id: node.stanford_publication.default
 targetEntityType: node
 bundle: stanford_publication
 mode: default
-content:
-  su_shared_tags:
-    weight: 1
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: main
+content: {  }
 hidden:
   citation_type: true
   layout_builder__layout: true
@@ -222,3 +214,4 @@ hidden:
   su_publication_components: true
   su_publication_cta: true
   su_publication_topics: true
+  su_shared_tags: true

--- a/config/sync/core.entity_view_display.node.stanford_publication.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_publication.stanford_card.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.stanford_publication.su_publication_components
     - field.field.node.stanford_publication.su_publication_cta
     - field.field.node.stanford_publication.su_publication_topics
+    - field.field.node.stanford_publication.su_shared_tags
     - node.type.stanford_publication
   module:
     - ds
@@ -90,3 +91,4 @@ hidden:
   su_publication_citation: true
   su_publication_components: true
   su_publication_cta: true
+  su_shared_tags: true

--- a/config/sync/core.entity_view_display.node.stanford_publication.teaser.yml
+++ b/config/sync/core.entity_view_display.node.stanford_publication.teaser.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.stanford_publication.su_publication_components
     - field.field.node.stanford_publication.su_publication_cta
     - field.field.node.stanford_publication.su_publication_topics
+    - field.field.node.stanford_publication.su_shared_tags
     - node.type.stanford_publication
   module:
     - user
@@ -32,3 +33,4 @@ hidden:
   su_publication_components: true
   su_publication_cta: true
   su_publication_topics: true
+  su_shared_tags: true

--- a/config/sync/field.field.node.stanford_event.su_shared_tags.yml
+++ b/config/sync/field.field.node.stanford_event.su_shared_tags.yml
@@ -1,0 +1,29 @@
+uuid: ce51c074-61a5-4955-a013-633067ae335e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.su_shared_tags
+    - node.type.stanford_event
+    - taxonomy.vocabulary.shared_tags
+id: node.stanford_event.su_shared_tags
+field_name: su_shared_tags
+entity_type: node
+bundle: stanford_event
+label: 'Shared Tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      shared_tags: shared_tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.stanford_event_series.su_shared_tags.yml
+++ b/config/sync/field.field.node.stanford_event_series.su_shared_tags.yml
@@ -1,0 +1,29 @@
+uuid: 65d22d8c-d068-417c-bffa-4c51a3a6ac71
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.su_shared_tags
+    - node.type.stanford_event_series
+    - taxonomy.vocabulary.shared_tags
+id: node.stanford_event_series.su_shared_tags
+field_name: su_shared_tags
+entity_type: node
+bundle: stanford_event_series
+label: 'Shared Tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      shared_tags: shared_tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.stanford_news.su_shared_tags.yml
+++ b/config/sync/field.field.node.stanford_news.su_shared_tags.yml
@@ -1,0 +1,29 @@
+uuid: e9c4d0e4-833d-4078-b1f2-a2405e2d1c3f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.su_shared_tags
+    - node.type.stanford_news
+    - taxonomy.vocabulary.shared_tags
+id: node.stanford_news.su_shared_tags
+field_name: su_shared_tags
+entity_type: node
+bundle: stanford_news
+label: 'Shared Tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      shared_tags: shared_tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.stanford_page.su_shared_tags.yml
+++ b/config/sync/field.field.node.stanford_page.su_shared_tags.yml
@@ -1,0 +1,29 @@
+uuid: 0815d038-46ee-48c6-a007-d1a6cb2093d8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.su_shared_tags
+    - node.type.stanford_page
+    - taxonomy.vocabulary.shared_tags
+id: node.stanford_page.su_shared_tags
+field_name: su_shared_tags
+entity_type: node
+bundle: stanford_page
+label: 'Shared Tags'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      shared_tags: shared_tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.stanford_person.su_shared_tags.yml
+++ b/config/sync/field.field.node.stanford_person.su_shared_tags.yml
@@ -1,0 +1,29 @@
+uuid: b3366fe0-7d1a-4b69-a3ef-ce6ab64c0221
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.su_shared_tags
+    - node.type.stanford_person
+    - taxonomy.vocabulary.shared_tags
+id: node.stanford_person.su_shared_tags
+field_name: su_shared_tags
+entity_type: node
+bundle: stanford_person
+label: 'Shared Tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      shared_tags: shared_tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.stanford_publication.su_shared_tags.yml
+++ b/config/sync/field.field.node.stanford_publication.su_shared_tags.yml
@@ -1,0 +1,29 @@
+uuid: d7eecd34-cc66-402d-99b6-a446658d7d28
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.su_shared_tags
+    - node.type.stanford_publication
+    - taxonomy.vocabulary.shared_tags
+id: node.stanford_publication.su_shared_tags
+field_name: su_shared_tags
+entity_type: node
+bundle: stanford_publication
+label: 'Shared Tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      shared_tags: shared_tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.node.su_shared_tags.yml
+++ b/config/sync/field.storage.node.su_shared_tags.yml
@@ -1,0 +1,20 @@
+uuid: bd69845b-5983-4660-a834-14836ceeb6ac
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.su_shared_tags
+field_name: su_shared_tags
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/taxonomy.vocabulary.shared_tags.yml
+++ b/config/sync/taxonomy.vocabulary.shared_tags.yml
@@ -1,0 +1,8 @@
+uuid: e77a0064-8945-4a8f-873f-2e203af3f295
+langcode: en
+status: true
+dependencies: {  }
+name: 'Shared Tags'
+vid: shared_tags
+description: 'Freeform tags which may be applied to any content type'
+weight: 0

--- a/tests/codeception/acceptance/SharedTagsCest.php
+++ b/tests/codeception/acceptance/SharedTagsCest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Test the shared tags vocabulary.
+ */
+class SharedTagsCest {
+
+  /**
+   * Validate the Shared Tag vocabulary exists
+   */
+  public function testSharedVocabExists(AcceptanceTester $I) {
+    $I->logInWithRole('site_editor');
+    $I->amOnPage('/admin/structure/taxonomy/manage/shared_tags/overview');
+    $I->seeResponseCodeIs(200);
+  }
+
+  /**
+   * Validate the field exists on basic pages, and validate tag creation
+   * on a basic page.
+   */
+  public function testSharedVocabBasicPage(AcceptanceTester $I) {
+    $I->logInWithRole('site_editor');
+    $I->amOnPage('/node/add/stanford_page');
+    $I->canSee('Shared Tags');
+    $I->fillField('Title', 'Basic Page Test Title');
+    $I->fillField('#edit-su-shared-tags-0-target-id', 'basic page test tag');
+    $I->click('Save');
+    $I->amOnPage('/basic-page-test-title');
+    $I->click('Edit');
+    $I->canSee('basic page test tag');
+    $I->amOnPage('/admin/structure/taxonomy/manage/shared_tags/overview');
+    $I->canSee('basic test tag');
+  }
+
+  /**
+   * Validate the field exists on Publication, and validate tag creation
+   * on a structured content type.
+   */
+  public function testSharedVocabPublication(AcceptanceTester $I) {
+    $I->logInWithRole('site_editor');
+    $I->amOnPage('/node/add/stanford_publication');
+    $I->canSee('Shared Tags');
+    $I->fillField('Title', 'Publication Test Title');
+    $I->fillField('#edit-su-shared-tags-0-target-id', 'publication test tag');
+    $I->click('Save');
+    $I->amOnPage('/publications/publication-test-title');
+    $I->click('Edit');
+    $I->canSee('publication test tag');
+    $I->amOnPage('/admin/structure/taxonomy/manage/shared_tags/overview');
+    $I->canSee('publication test tag');
+  }
+
+  /**
+   * Validate the field exists on Events.
+   */
+  public function testSharedVocabEvent(AcceptanceTester $I) {
+    $I->logInWithRole('site_editor');
+    $I->amOnPage('/node/add/stanford_event');
+    $I->canSee('Shared Tags');
+  }
+
+  /**
+   * Validate the field exists on Event Series.
+   */
+  public function testSharedVocabEventSeries(AcceptanceTester $I) {
+    $I->logInWithRole('site_editor');
+    $I->amOnPage('/node/add/stanford_event_series');
+    $I->canSee('Shared Tags');
+  }
+
+  /**
+   * Validate the field exists on News
+   */
+  public function testSharedVocabNews(AcceptanceTester $I) {
+    $I->logInWithRole('site_editor');
+    $I->amOnPage('/node/add/stanford_news');
+    $I->canSee('Shared Tags');
+  }
+
+  /**
+   * Validate the field exists on Person.
+   */
+  public function testSharedVocabPerson(AcceptanceTester $I) {
+    $I->logInWithRole('site_editor');
+    $I->amOnPage('/node/add/stanford_person');
+    $I->canSee('Shared Tags');
+  }
+
+}

--- a/tests/codeception/acceptance/SharedTagsCest.php
+++ b/tests/codeception/acceptance/SharedTagsCest.php
@@ -26,10 +26,8 @@ class SharedTagsCest {
     $I->fillField('#edit-su-shared-tags-0-target-id', 'basic page test tag');
     $I->click('Save');
     $I->amOnPage('/basic-page-test-title');
-    $I->click('Edit');
-    $I->canSee('basic page test tag');
     $I->amOnPage('/admin/structure/taxonomy/manage/shared_tags/overview');
-    $I->canSee('basic test tag');
+    $I->canSee('basic page test tag');
   }
 
   /**
@@ -44,8 +42,6 @@ class SharedTagsCest {
     $I->fillField('#edit-su-shared-tags-0-target-id', 'publication test tag');
     $I->click('Save');
     $I->amOnPage('/publications/publication-test-title');
-    $I->click('Edit');
-    $I->canSee('publication test tag');
     $I->amOnPage('/admin/structure/taxonomy/manage/shared_tags/overview');
     $I->canSee('publication test tag');
   }


### PR DESCRIPTION
# READY

# Summary
- This PR adds a new vocabulary, "Shared Tags".  It adds the appropriate fields to Basic Pages, and the various structured content types.  It hides the content in the shared tags field from the displays for all content types.  There are some acceptance tests as well.

# Needed By (Date)
- End of the sprint.

# Urgency
- This is functionality we've promised for 2.2.0

# Steps to Test

1. checkout branch
2. drush cim
3. verify the shared tags taxonomy exists.
4. verify the shared tags are added to the forms for basic pages and all the structured content types.
5. verify the shared tags do not appear on the user-facing pages of the site.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- D8CORE-3973, D8CORE-3974, D8CORE-3975

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
