### PR TITLE
D8CORE-3158 Enable more paragraph components on news and people

### DIFF
--- a/config/sync/field.field.node.stanford_news.su_news_components.yml
+++ b/config/sync/field.field.node.stanford_news.su_news_components.yml
@@ -5,10 +5,9 @@ dependencies:
   config:
     - field.storage.node.su_news_components
     - node.type.stanford_news
-    - paragraphs.paragraphs_type.stanford_banner
-    - paragraphs.paragraphs_type.stanford_card
-    - paragraphs.paragraphs_type.stanford_media_caption
-    - paragraphs.paragraphs_type.stanford_wysiwyg
+    - paragraphs.paragraphs_type.stanford_person_cta
+    - paragraphs.paragraphs_type.stanford_schedule
+    - paragraphs.paragraphs_type.stanford_spacer
   module:
     - entity_reference_revisions
 id: node.stanford_news.su_news_components
@@ -24,32 +23,40 @@ default_value_callback: ''
 settings:
   handler: 'default:paragraph'
   handler_settings:
-    negate: 0
+    negate: 1
     target_bundles:
-      stanford_wysiwyg: stanford_wysiwyg
-      stanford_banner: stanford_banner
-      stanford_card: stanford_card
-      stanford_media_caption: stanford_media_caption
+      stanford_person_cta: stanford_person_cta
+      stanford_schedule: stanford_schedule
+      stanford_spacer: stanford_spacer
     target_bundles_drag_drop:
       stanford_banner:
-        enabled: true
         weight: 7
+        enabled: false
       stanford_card:
-        enabled: true
         weight: 8
-      stanford_media_caption:
-        enabled: true
-        weight: 9
-      stanford_person_cta:
-        weight: 11
         enabled: false
-      stanford_schedule:
-        weight: 12
-        enabled: false
-      stanford_spacer:
+      stanford_entity:
         weight: 13
         enabled: false
-      stanford_wysiwyg:
+      stanford_gallery:
+        weight: 14
+        enabled: false
+      stanford_lists:
+        weight: 15
+        enabled: false
+      stanford_media_caption:
+        weight: 9
+        enabled: false
+      stanford_person_cta:
         enabled: true
+        weight: 11
+      stanford_schedule:
+        enabled: true
+        weight: 12
+      stanford_spacer:
+        enabled: true
+        weight: 13
+      stanford_wysiwyg:
         weight: -7
+        enabled: false
 field_type: entity_reference_revisions

--- a/config/sync/field.field.node.stanford_person.su_person_components.yml
+++ b/config/sync/field.field.node.stanford_person.su_person_components.yml
@@ -5,10 +5,9 @@ dependencies:
   config:
     - field.storage.node.su_person_components
     - node.type.stanford_person
-    - paragraphs.paragraphs_type.stanford_banner
-    - paragraphs.paragraphs_type.stanford_card
-    - paragraphs.paragraphs_type.stanford_media_caption
-    - paragraphs.paragraphs_type.stanford_wysiwyg
+    - paragraphs.paragraphs_type.stanford_person_cta
+    - paragraphs.paragraphs_type.stanford_schedule
+    - paragraphs.paragraphs_type.stanford_spacer
   module:
     - entity_reference_revisions
 id: node.stanford_person.su_person_components
@@ -24,32 +23,40 @@ default_value_callback: ''
 settings:
   handler: 'default:paragraph'
   handler_settings:
-    negate: 0
+    negate: 1
     target_bundles:
-      stanford_banner: stanford_banner
-      stanford_card: stanford_card
-      stanford_media_caption: stanford_media_caption
-      stanford_wysiwyg: stanford_wysiwyg
+      stanford_person_cta: stanford_person_cta
+      stanford_schedule: stanford_schedule
+      stanford_spacer: stanford_spacer
     target_bundles_drag_drop:
       stanford_banner:
-        enabled: true
         weight: 7
+        enabled: false
       stanford_card:
-        enabled: true
         weight: 8
-      stanford_media_caption:
-        enabled: true
-        weight: 9
-      stanford_person_cta:
-        weight: 11
         enabled: false
-      stanford_schedule:
-        weight: 12
-        enabled: false
-      stanford_spacer:
+      stanford_entity:
         weight: 13
         enabled: false
-      stanford_wysiwyg:
+      stanford_gallery:
+        weight: 14
+        enabled: false
+      stanford_lists:
+        weight: 15
+        enabled: false
+      stanford_media_caption:
+        weight: 9
+        enabled: false
+      stanford_person_cta:
         enabled: true
+        weight: 11
+      stanford_schedule:
+        enabled: true
+        weight: 12
+      stanford_spacer:
+        enabled: true
+        weight: 13
+      stanford_wysiwyg:
         weight: 10
+        enabled: false
 field_type: entity_reference_revisions


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Enable more paragraphs on news and people
  - Mirrors the events components field setting

# Need Review By (Date)
- 5/20

# Urgency
- low

# Steps to Test
1. checkout this branch
2. `drush cim`
3. create a news and people content
4. verify you can use the "List", "Teaser", and "Image Gallery" paragraph types in the components fields.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
