### PR TITLE
D8CORE-4194 Add url text for the link on media w caption paragraph

### DIFF
--- a/config/sync/core.entity_view_display.paragraph.stanford_media_caption.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.stanford_media_caption.default.yml
@@ -48,11 +48,13 @@ content:
     label: hidden
     settings:
       trim_length: null
-      url_only: true
       url_plain: true
+      url_only: false
       rel: '0'
       target: '0'
-    third_party_settings: {  }
+    third_party_settings:
+      field_formatter_class:
+        class: ''
     type: link
     region: media_link
   su_media_caption_media:

--- a/config/sync/field.field.paragraph.stanford_media_caption.su_media_caption_link.yml
+++ b/config/sync/field.field.paragraph.stanford_media_caption.su_media_caption_link.yml
@@ -19,5 +19,5 @@ default_value: {  }
 default_value_callback: ''
 settings:
   link_type: 17
-  title: 0
+  title: 2
 field_type: link


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Make media with caption link title required.
- https://github.com/SU-SWS/jumpstart_ui/pull/101
- https://github.com/SU-SWS/stanford_profile_helper/pull/126

# Need Review By (Date)
- 6/3

# Urgency
- medium

# Steps to Test
1. checkout this branch
2. checkout the branch in https://github.com/SU-SWS/jumpstart_ui/pull/101
3. checkout the branch in https://github.com/SU-SWS/stanford_profile_helper/pull/126
4. (optional) sync to amptesting. `drush sql:sync @amptesting.01test @self`
3. `blt drupal:update`
4. `drush cr`
5. Create a basic page and put a "Media with Caption" on it
6. Populate the link field
7. view the page and verify the image is "clickable"
8. verify the screen reader reads the link and the image separately.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
