### PR TITLE
D8CORE-4339 Allow restriction based on the persons affiliation to the university

### DIFF
--- a/config/sync/config_pages.type.stanford_saml.yml
+++ b/config/sync/config_pages.type.stanford_saml.yml
@@ -36,6 +36,18 @@ third_party_settings:
       column: value
       config_name: stanford_ssp.settings
       config_item: restriction
+    2e223afa-8768-41f6-acdd-cfe15114b930:
+      field: su_simplesaml_affil
+      delta: 0
+      column: value
+      config_name: stanford_ssp.settings
+      config_item: restriction
+    576fa6f9-1295-4d86-b639-0e6cac675d35:
+      field: su_simplesaml_affil
+      delta: -1
+      column: value
+      config_name: stanford_ssp.settings
+      config_item: allowed.affiliations
 id: stanford_saml
 label: SimpleSAML
 context:

--- a/config/sync/core.entity_form_display.config_pages.stanford_saml.default.yml
+++ b/config/sync/core.entity_form_display.config_pages.stanford_saml.default.yml
@@ -23,7 +23,7 @@ third_party_settings:
       format_type: details
       region: content
       format_settings:
-        description: "Restrict who can log into the site by limiting to workgroups or SUNet IDs. Leave these empty to allow any user with a valid SUNet to log in.\r\nThis is an allowed list, not a restive list. The order of process is:\r\n<ol>\r\n<li>User ID: if the user has a matching user id, they will be allowed.</li>\r\n<li>Affiliations: if a user is a member of the chosen affiliations, they will be allowed.</li>\r\n<li>Workgroups: If a user is a member of the configured workgroups, they will be allowed.</li>\r\n</ol>\r\nIf the user does not satisfy any of the three scenarios, they will be denied access. \r\n<strong>Be sure to configure the settings to allow yourself access in some form, otherwise on your next login, you will be denied access.</strong>"
+        description: "Restrict who can log into the site by limiting to workgroups or SUNetIDs. Leave these empty to allow any user with a valid SUNet to log in.\r\nThis is an allowed list, not a restricted list. The order of process is:\r\n<ol>\r\n<li>User ID: if the user has a matching SUNetID, they will be allowed.</li>\r\n<li>Affiliations: if a user is a member of the chosen affiliations, they will be allowed.</li>\r\n<li>Workgroups: If a user is a member of the configured workgroups, they will be allowed.</li>\r\n</ol>\r\nIf the user does not satisfy any of the three scenarios, they will be denied access. \r\n<strong>Be sure to configure the settings to allow yourself access in some form, otherwise on your next login, you will be denied access.</strong>"
         id: ''
         classes: ''
         open: false

--- a/config/sync/core.entity_form_display.config_pages.stanford_saml.default.yml
+++ b/config/sync/core.entity_form_display.config_pages.stanford_saml.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - config_pages.type.stanford_saml
+    - field.field.config_pages.stanford_saml.su_simplesaml_affil
     - field.field.config_pages.stanford_saml.su_simplesaml_allowed
     - field.field.config_pages.stanford_saml.su_simplesaml_roles
     - field.field.config_pages.stanford_saml.su_simplesaml_users
@@ -14,6 +15,7 @@ third_party_settings:
   field_group:
     group_login_restrictions:
       children:
+        - su_simplesaml_affil
         - su_simplesaml_allowed
         - su_simplesaml_users
       parent_name: ''
@@ -21,7 +23,7 @@ third_party_settings:
       format_type: details
       region: content
       format_settings:
-        description: 'Restrict who can log into the site by limiting to workgroups or SUNet IDs. Leave these empty to allow any user with a valid SUNet to log in.'
+        description: "Restrict who can log into the site by limiting to workgroups or SUNet IDs. Leave these empty to allow any user with a valid SUNet to log in.\r\nThis is an allowed list, not a restive list. The order of process is:\r\n<ol>\r\n<li>User ID: if the user has a matching user id, they will be allowed.</li>\r\n<li>Affiliations: if a user is a member of the chosen affiliations, they will be allowed.</li>\r\n<li>Workgroups: If a user is a member of the configured workgroups, they will be allowed.</li>\r\n</ol>\r\nIf the user does not satisfy any of the three scenarios, they will be denied access. \r\n<strong>Be sure to configure the settings to allow yourself access in some form, otherwise on your next login, you will be denied access.</strong>"
         id: ''
         classes: ''
         open: false
@@ -32,8 +34,14 @@ targetEntityType: config_pages
 bundle: stanford_saml
 mode: default
 content:
+  su_simplesaml_affil:
+    weight: 4
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
   su_simplesaml_allowed:
-    weight: 2
+    weight: 5
     settings:
       size: 60
       placeholder: ''
@@ -47,7 +55,7 @@ content:
     type: saml_role_mapping
     region: content
   su_simplesaml_users:
-    weight: 3
+    weight: 6
     settings:
       size: 60
       placeholder: ''

--- a/config/sync/core.entity_view_display.config_pages.stanford_saml.default.yml
+++ b/config/sync/core.entity_view_display.config_pages.stanford_saml.default.yml
@@ -4,14 +4,24 @@ status: true
 dependencies:
   config:
     - config_pages.type.stanford_saml
+    - field.field.config_pages.stanford_saml.su_simplesaml_affil
     - field.field.config_pages.stanford_saml.su_simplesaml_allowed
     - field.field.config_pages.stanford_saml.su_simplesaml_roles
     - field.field.config_pages.stanford_saml.su_simplesaml_users
+  module:
+    - options
 id: config_pages.stanford_saml.default
 targetEntityType: config_pages
 bundle: stanford_saml
 mode: default
 content:
+  su_simplesaml_affil:
+    weight: 3
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
   su_simplesaml_allowed:
     weight: 1
     label: above

--- a/config/sync/field.field.config_pages.stanford_saml.su_simplesaml_affil.yml
+++ b/config/sync/field.field.config_pages.stanford_saml.su_simplesaml_affil.yml
@@ -12,7 +12,7 @@ field_name: su_simplesaml_affil
 entity_type: config_pages
 bundle: stanford_saml
 label: 'Allowed Affiliations'
-description: 'Restrict to the user''s affiliation to the Stanford. View what these affiliations entail at <a href="https://uit.stanford.edu/service/saml/arp/edupa">SAML Affiliation Information</a>.'
+description: 'Restrict to the user''s affiliations to Stanford. View what these affiliations entail at <a href="https://uit.stanford.edu/service/saml/arp/edupa">SAML Affiliation Information</a>.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.config_pages.stanford_saml.su_simplesaml_affil.yml
+++ b/config/sync/field.field.config_pages.stanford_saml.su_simplesaml_affil.yml
@@ -1,0 +1,21 @@
+uuid: c06e058f-cbb0-42c6-a662-d4b0e1a34073
+langcode: en
+status: true
+dependencies:
+  config:
+    - config_pages.type.stanford_saml
+    - field.storage.config_pages.su_simplesaml_affil
+  module:
+    - options
+id: config_pages.stanford_saml.su_simplesaml_affil
+field_name: su_simplesaml_affil
+entity_type: config_pages
+bundle: stanford_saml
+label: 'Allowed Affiliations'
+description: 'Restrict to the user''s affiliation to the Stanford. View what these affiliations entail at <a href="https://uit.stanford.edu/service/saml/arp/edupa">SAML Affiliation Information</a>.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.storage.config_pages.su_simplesaml_affil.yml
+++ b/config/sync/field.storage.config_pages.su_simplesaml_affil.yml
@@ -1,0 +1,36 @@
+uuid: 6e6aa306-06bf-4c34-829d-bab9bb10f787
+langcode: en
+status: true
+dependencies:
+  module:
+    - config_pages
+    - options
+id: config_pages.su_simplesaml_affil
+field_name: su_simplesaml_affil
+entity_type: config_pages
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: affiliate
+      label: Affiliate
+    -
+      value: staff
+      label: Staff
+    -
+      value: students
+      label: Students
+    -
+      value: faculty
+      label: Facult
+    -
+      value: member
+      label: Member
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.config_pages.su_simplesaml_affil.yml
+++ b/config/sync/field.storage.config_pages.su_simplesaml_affil.yml
@@ -22,7 +22,7 @@ settings:
       label: Students
     -
       value: faculty
-      label: Facult
+      label: Faculty
     -
       value: member
       label: Member

--- a/config/sync/stanford_ssp.settings.yml
+++ b/config/sync/stanford_ssp.settings.yml
@@ -8,3 +8,7 @@ allowed_groups: {  }
 allowed_users: {  }
 _core:
   default_config_hash: Xm4MNDvuD7BJ089bXHgqkS7_mOjVgGxnekzaeYLwW7k
+allowed:
+  affiliations: {  }
+  users: {  }
+  groups: {  }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add configurable option to restrict based on user affiliation.

# Need Review By (Date)
- 6/3

# Urgency
- medium

# Steps to Test
1. checkout this branch and the branch in https://github.com/SU-SWS/stanford_ssp/pull/118/files
2. `blt drupal:update`
3. go to `/admin/config/people/simplesaml`
4. choose student affiliation restriction
5. log out
6. try to log back in
7. verify you are denied access.
8. log in with user 1 or re-install your site
9. go back and choose a staff affilitation
10. log out
11. log back in and verify you are granted access.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
