### PR TITLE
D8CORE-4090 D8CORE-2888 D8CORE-4126: accessbility changes to the news…

### DIFF
--- a/config/sync/views.view.stanford_news.yml
+++ b/config/sync/views.view.stanford_news.yml
@@ -394,7 +394,7 @@ display:
           delta_offset: 0
           delta_reversed: false
           delta_first_last: false
-          multi_type: separator
+          multi_type: ul
           separator: ', '
           field_api_classes: false
           plugin_id: field
@@ -826,11 +826,14 @@ display:
             format: stanford_html
           plugin_id: text
       style:
-        type: default
+        type: html_list
         options:
           grouping: {  }
           row_class: ''
           default_row_class: 1
+          type: ul
+          wrapper_class: su-item-list__wrapper
+          class: su-news-list
       row:
         type: ui_patterns
         options:
@@ -1072,11 +1075,14 @@ display:
             format: stanford_html
           plugin_id: text
       style:
-        type: default
+        type: html_list
         options:
           grouping: {  }
           row_class: ''
           default_row_class: true
+          type: ul
+          wrapper_class: su-news-list__wrapper
+          class: su-news-list
       row:
         type: ui_patterns
         options:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- D8CORE-2888: Rebuild the News list into a HTML `<ul>`
- D8CORE-4090: Addressed the order of the news items to work better for screen readers.
   - Used flex to move the date to the right visual place.
   - Able to tab thru the content in the right way.
   - Focus ring around the `h2` and the `img`.
   - Removed duplicate `href`
- D8CORE-4126: Made the taxonomy terms  a HTML `<ul>` 

# Needed By (Date)
- 6/2
- Need time for testing

# Urgency
- High

# Steps to Test

1. Pull in this change.
2. Pull in the [Profile change](https://github.com/SU-SWS/stanford_news/pull/124).
2. Create news items.
3. Look at the /news page.
4. Notice the news articles are now in a list like this:
![image](https://user-images.githubusercontent.com/1187335/119904632-7a233e00-beff-11eb-9b6d-ed922bc962b2.png)
5. Notice the article details are in an `<article>` tag
![image](https://user-images.githubusercontent.com/1187335/119904759-b8b8f880-beff-11eb-82c6-97af3e1080e6.png)
6. Notice the terms are now in an unordered list.

# Affected Projects or Products or pages
- News
- Subtheme need checking
-  /news
- /news/term-name
- taxonomy terms in a list and a news card

# Associated Issues and/or People
-  D8CORE-4090
- D8CORE-2888
- D8CORE-4126
- https://github.com/SU-SWS/stanford_profile/pull/425
- https://github.com/SU-SWS/stanford_news/pull/124
- @cjwest 
- @rebeccahongsf 
- @jdwjdwjdw 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
