### PR TITLE
D8CORE-4235 Require alt text on gallery images

### DIFF
--- a/config/sync/colorbox.settings.yml
+++ b/config/sync/colorbox.settings.yml
@@ -4,7 +4,7 @@ custom:
   transition_type: elastic
   transition_speed: 350
   opacity: 0.85
-  text_current: '{current} of {total}'
+  text_current: 'Image {current} of {total}'
   text_previous: Previous
   text_next: Next
   text_close: Close

--- a/config/sync/field.field.media.stanford_gallery_images.su_gallery_image.yml
+++ b/config/sync/field.field.media.stanford_gallery_images.su_gallery_image.yml
@@ -24,7 +24,7 @@ settings:
   max_resolution: ''
   min_resolution: ''
   alt_field: true
-  alt_field_required: false
+  alt_field_required: true
   title_field: false
   title_field_required: false
   default_image:

--- a/tests/codeception/functional/Paragraphs/GalleryCest.php
+++ b/tests/codeception/functional/Paragraphs/GalleryCest.php
@@ -11,6 +11,8 @@ class GalleryCest {
 
   /**
    * Create a basic page with a gallery and check the colorbox actions.
+   *
+   * @group mikes
    */
   public function testGallery(FunctionalTester $I) {
     $faker = Factory::create();
@@ -25,11 +27,13 @@ class GalleryCest {
     $I->click('Add media', '.MuiDialog-container');
     $I->waitForText('Drop files here to upload them');
 
-    $I->dropFileInDropzone(__DIR__.'/logo.jpg');
-    $I->dropFileInDropzone(__DIR__.'/wordmark.jpg');
+    $I->dropFileInDropzone(__DIR__ . '/logo.jpg');
+    $I->dropFileInDropzone(__DIR__ . '/wordmark.jpg');
     $I->click('Upload and Continue');
 
     $I->waitForText('The media items have been created but have not yet been saved');
+    $I->fillField('media[0][fields][su_gallery_image][0][alt]', 'Logo');
+    $I->fillField('media[1][fields][su_gallery_image][0][alt]', 'Wordmark');
     $I->click('Save and insert', '.ui-dialog-buttonset');
 
     $I->waitForElementNotVisible('#drupal-modal');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Require alt text on gallery images
- Adjust colorbox settings

# Need Review By (Date)
- 7/8

# Urgency
- low

# Steps to Test
1. checkout this branch
2. `drush cim -y`
3. create a basic page with an image gallery
4. ensure you are required to enter an alt text when you upload an image.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
