### PR TITLE
D8CORE-4504 Added mathjax for latex formula support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -130,6 +130,7 @@
         "drupal/layout_library": "^1.0-beta1",
         "drupal/link_title_formatter": "^1.1",
         "drupal/linkit": "^6.0",
+        "drupal/mathjax": "^3.0",
         "drupal/menu_admin_per_menu": "^1.0",
         "drupal/menu_block": "dev-1.x#567becffbb0589e824fb053f15fb38a5846e7276",
         "drupal/menu_link_weight": "^1.0-beta3",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -70,8 +70,8 @@ module:
   imagemagick: 0
   inline_entity_form: 0
   inline_form_errors: 0
-  jumpstart_ui: 0
   jsonapi: 0
+  jumpstart_ui: 0
   key: 0
   layout_builder: 0
   layout_builder_modal: 0
@@ -81,6 +81,7 @@ module:
   link: 0
   link_title_formatter: 0
   linkit: 0
+  mathjax: 0
   media: 0
   media_duplicate_validation: 0
   media_library: 0

--- a/config/sync/editor.editor.stanford_html.yml
+++ b/config/sync/editor.editor.stanford_html.yml
@@ -54,13 +54,13 @@ settings:
             - '-'
             - A11ychecker
   plugins:
-    stylescombo:
-      styles: "a.su-button|Button\r\na.su-button--big|Big Button\r\na.su-button--secondary|Secondary Button\r\na.su-link--action|Action Link\r\np.plain-text|Normal\r\np.su-intro-text|Intro Text\r\np.su-font-splash|Splash Font\r\np.su-quote-text|Quote Text\r\np.su-drop-cap|Drop Cap First Letter\r\np.su-related-text|Card Text\r\np.su-callout-text|Callout Text\r\np.su-subheading|Sub Title"
-    language:
-      language_list: un
     drupallink:
       linkit_enabled: true
       linkit_profile: default
+    language:
+      language_list: un
+    stylescombo:
+      styles: "a.su-button|Button\r\na.su-button--big|Big Button\r\na.su-button--secondary|Secondary Button\r\na.su-link--action|Action Link\r\np.plain-text|Normal\r\np.su-intro-text|Intro Text\r\np.su-font-splash|Splash Font\r\np.su-quote-text|Quote Text\r\np.su-drop-cap|Drop Cap First Letter\r\np.su-related-text|Card Text\r\np.su-callout-text|Callout Text\r\np.su-subheading|Sub Title"
 image_upload:
   status: false
   scheme: public

--- a/config/sync/filter.format.stanford_html.yml
+++ b/config/sync/filter.format.stanford_html.yml
@@ -13,6 +13,7 @@ dependencies:
   module:
     - editor
     - linkit
+    - mathjax
     - media
     - stanford_media
 name: HTML
@@ -23,31 +24,31 @@ filters:
     id: editor_file_reference
     provider: editor
     status: false
-    weight: -42
+    weight: -40
     settings: {  }
   filter_caption:
     id: filter_caption
     provider: filter
     status: true
-    weight: -48
+    weight: -47
     settings: {  }
   filter_html_escape:
     id: filter_html_escape
     provider: filter
     status: false
-    weight: -43
+    weight: -41
     settings: {  }
   filter_align:
     id: filter_align
     provider: filter
     status: true
-    weight: -49
+    weight: -48
     settings: {  }
   filter_url:
     id: filter_url
     provider: filter
     status: true
-    weight: -46
+    weight: -45
     settings:
       filter_url_length: 72
   filter_html:
@@ -63,32 +64,32 @@ filters:
     id: filter_htmlcorrector
     provider: filter
     status: true
-    weight: -44
+    weight: -43
     settings: {  }
   filter_autop:
     id: filter_autop
     provider: filter
     status: false
-    weight: -41
+    weight: -39
     settings: {  }
   filter_html_image_secure:
     id: filter_html_image_secure
     provider: filter
     status: false
-    weight: -40
+    weight: -38
     settings: {  }
   linkit:
     id: linkit
     provider: linkit
     status: true
-    weight: -45
+    weight: -44
     settings:
       title: true
   media_embed:
     id: media_embed
     provider: media
     status: true
-    weight: -47
+    weight: -46
     settings:
       default_view_mode: default
       allowed_media_types:
@@ -110,5 +111,11 @@ filters:
     id: stanford_media_embed_markup
     provider: stanford_media
     status: true
-    weight: 0
+    weight: -42
+    settings: {  }
+  filter_mathjax:
+    id: filter_mathjax
+    provider: mathjax
+    status: true
+    weight: -49
     settings: {  }

--- a/config/sync/mathjax.settings.yml
+++ b/config/sync/mathjax.settings.yml
@@ -1,0 +1,7 @@
+use_cdn: 1
+cdn_url: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
+config_type: 0
+default_config_string: '{"tex2jax":{"inlineMath":[["$","$"],["\\(","\\)"]],"processEscapes":"true"},"showProcessingMessages":"false","messageStyle":"none"}'
+enable_for_admin: 0
+_core:
+  default_config_hash: UOFmZIwiZl6qJ50XXrC2r_F26ZTYR_3-d93LAnL8J4w


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- MathJax for Latex support in the wysiwyg

# Need Review By (Date)
- 7/8

# Urgency
- medium

# Steps to Test
1. `composer require su-sws/stanford_profile:dev-D8CORE-4504`
2. `blt drupal:update`
3. create a basic page
4. in the wysiwyg put a latex formula in like `\[ x^n + y^n = z^n \]`
5. save and verify the page displays a mathematical formula.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
