### PR TITLE
D8CORE-2594 Allow menu placement under unpublished pages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -152,7 +152,7 @@
         "drupal/views_bulk_operations": "^3.6",
         "drupal/xmlsitemap": "^1.0",
         "onlyextart/colorbox": "dev-master#e58476becbc89dc671093d1bcd9f99b2167fa8f7",
-        "su-sws/drupal-patches": "dev-D8CORE-2594 as 8.0.8",
+        "su-sws/drupal-patches": "^8.0",
         "su-sws/jumpstart_ui": "dev-8.x-1.x",
         "su-sws/nobots": "dev-8.x-2.x",
         "su-sws/react_paragraphs": "dev-8.x-2.x",

--- a/composer.json
+++ b/composer.json
@@ -152,7 +152,7 @@
         "drupal/views_bulk_operations": "^3.6",
         "drupal/xmlsitemap": "^1.0",
         "onlyextart/colorbox": "dev-master#e58476becbc89dc671093d1bcd9f99b2167fa8f7",
-        "su-sws/drupal-patches": "^8.0",
+        "su-sws/drupal-patches": "dev-D8CORE-2594 as 8.0.8",
         "su-sws/jumpstart_ui": "dev-8.x-1.x",
         "su-sws/nobots": "dev-8.x-2.x",
         "su-sws/react_paragraphs": "dev-8.x-2.x",

--- a/tests/codeception/acceptance/Content/BasicPageCest.php
+++ b/tests/codeception/acceptance/Content/BasicPageCest.php
@@ -103,8 +103,6 @@ class BasicPageCest {
 
   /**
    * A site manager should be able to place a page under an unpublished page.
-   *
-   * @group mikes
    */
   public function testUnpublishedMenuItems(AcceptanceTester $I){
     $I->logInWithRole('site_manager');

--- a/tests/codeception/acceptance/Content/BasicPageCest.php
+++ b/tests/codeception/acceptance/Content/BasicPageCest.php
@@ -101,5 +101,34 @@ class BasicPageCest {
     $I->canSee('Created new term');
   }
 
+  /**
+   * A site manager should be able to place a page under an unpublished page.
+   *
+   * @group mikes
+   */
+  public function testUnpublishedMenuItems(AcceptanceTester $I){
+    $I->logInWithRole('site_manager');
+    $I->amOnPage('/node/add/stanford_page');
+    $I->fillField('Title', 'Unpublished Parent');
+    $I->checkOption('Provide a menu link');
+    $I->fillField('Menu link title', 'Unpublished Parent');
+    $I->uncheckOption('Published');
+    $I->click('Save');
+    $I->canSee('Unpublished Parent', 'h1');
+
+    $I->amOnPage('/node/add/stanford_page');
+    $I->fillField('Title', 'Child Page');
+    $I->checkOption('Provide a menu link');
+    $I->fillField('Menu link title', 'Child Page');
+    $I->selectOption('Parent link', '-- Unpublished Parent');
+    $I->click('Change parent (update list of weights)');
+    $I->uncheckOption('Published');
+    $I->click('Save');
+    $I->canSee('Child Page', 'h1');
+
+    $I->click('Edit', '.tabs__tab');
+    $I->click('Save');
+    $I->assertEquals('/unpublished-parent/child-page', $I->grabFromCurrentUrl());
+  }
 
 }

--- a/tests/codeception/functional/Paragraphs/GalleryCest.php
+++ b/tests/codeception/functional/Paragraphs/GalleryCest.php
@@ -11,8 +11,6 @@ class GalleryCest {
 
   /**
    * Create a basic page with a gallery and check the colorbox actions.
-   *
-   * @group mikes
    */
   public function testGallery(FunctionalTester $I) {
     $faker = Factory::create();


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- https://github.com/SU-SWS/drupal-patches/pull/4
- Allow users the ability to place a node under an unpublished node in the menu.

# Need Review By (Date)
- 7/8 would be nice

# Urgency
- low

# Steps to Test
1. `composer require su-sws/stanford_profile:dev-D8CORE-2594 --no-update`
2. `rm -rf docroot/core; composer update -n`
3. log in and add a contributor or site manager role & remove your administrator role
4. create an unpublished node and place it in the menu
5. create another node and verify you can place it in the menu under the unpublished node.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
