### PR TITLE
D8CORE-2937: making the person title an h4 for accessibility

### DIFF
--- a/config/sync/views.view.stanford_person.yml
+++ b/config/sync/views.view.stanford_person.yml
@@ -9,6 +9,7 @@ dependencies:
     - node.type.stanford_person
   module:
     - node
+    - stanford_fields
     - stanford_media
     - user
     - views_infinite_scroll
@@ -762,34 +763,34 @@ display:
           group_type: group
           admin_label: ''
           label: ''
-          exclude: false
+          exclude: 0
           alter:
-            alter_text: true
-            text: "{{ su_person_photo }}\r\n{{ title }}"
-            make_link: true
+            alter_text: 1
+            text: "{{ su_person_photo }}\r\n<h4>{{ title }}</h4>"
+            make_link: 1
             path: '{{ view_node }}'
-            absolute: false
-            external: false
-            replace_spaces: false
+            absolute: 0
+            external: 0
+            replace_spaces: 0
             path_case: none
-            trim_whitespace: false
+            trim_whitespace: 0
             alt: ''
             rel: ''
             link_class: ''
             prefix: ''
             suffix: ''
             target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
+            nl2br: 0
+            max_length: '0'
+            word_boundary: 1
+            ellipsis: 1
+            more_link: 0
             more_link_text: ''
             more_link_path: ''
-            strip_tags: false
-            trim: false
+            strip_tags: 0
+            trim: 0
             preserve_tags: ''
-            html: false
+            html: 0
           element_type: div
           element_class: ''
           element_label_type: div
@@ -797,15 +798,15 @@ display:
           element_label_colon: false
           element_wrapper_type: div
           element_wrapper_class: ''
-          element_default_classes: true
+          element_default_classes: 1
           empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
+          hide_empty: 0
+          empty_zero: 0
+          hide_alter_empty: 1
           click_sort_column: value
           type: string
           settings:
-            link_to_entity: false
+            link_to_entity: 0
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -815,7 +816,7 @@ display:
           delta_first_last: false
           multi_type: separator
           separator: ', '
-          field_api_classes: false
+          field_api_classes: 0
           plugin_id: field
         su_person_short_title:
           id: su_person_short_title

--- a/config/sync/views.view.stanford_person_list_terms_first.yml
+++ b/config/sync/views.view.stanford_person_list_terms_first.yml
@@ -292,7 +292,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "{{ su_person_photo }} \r\n{{ title }}"
+            text: "{{ su_person_photo }} \r\n<h4>{{ title }}</h4>"
             make_link: true
             path: '{{ view_node }}'
             absolute: false


### PR DESCRIPTION
# NOT READY FOR REVIEW
@pookmish and I agreed to put this in holding for the time being.

# Summary
- Changing the person name on the person grid to be an `h4`. 

# Review By (Date)
- 8/1

# Criticality
- Med - accessibility
- Affects the People grid which is all sites using it.
- Affects the Person List

# Urgency
- Med

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Checkout the CSS changes: https://github.com/SU-SWS/stanford_person/pull/149
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Navigate to /People page and a filtered page. 
4. Verify there is no visible difference but you see the `h4` in the code.
4. Create a people list
5. Verify there is no visible difference but you see the `h4` in the code.

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? Yes
- https://github.com/SU-SWS/stanford_profile/pull/438

## Front End Validation
- [ ] Design is approved by @ user?
- [ ] HTML validation: Is the markup using the appropriate semantic tags and [passes validation](https://validator.w3.org/nu/)? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [x] Cross-browser testing: Has been performed? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Automated accessibility: Scans performed? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [x] Manual accessibility: Manually tested? Or, [D8CORE-4666](https://stanfordits.atlassian.net/browse/D8CORE-4666)

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- People Module

# Associated Issues and/or People
- [D8CORE_2937](https://stanfordits.atlassian.net/browse/D8CORE-2937)
- https://github.com/SU-SWS/stanford_profile/pull/438
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- @rebeccahongsf I tried the change on SAA Victoria and saw no change.

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
