### PR TITLE
D8CORE-4668 Allow new google analytics account id format `G-`

### DIFF
--- a/config/sync/field.field.config_pages.stanford_basic_site_settings.su_google_analytics.yml
+++ b/config/sync/field.field.config_pages.stanford_basic_site_settings.su_google_analytics.yml
@@ -10,7 +10,7 @@ field_name: su_google_analytics
 entity_type: config_pages
 bundle: stanford_basic_site_settings
 label: 'Google Analytics Account'
-description: 'This ID is unique to each site you want to track separately, and is in the form of UA-xxxxxxx-yy. To get a Web Property ID, <a href="https://marketingplatform.google.com/about/analytics/">register your site with Google Analytics</a>, or if you already have registered your site, go to your Google Analytics Settings page to see the ID next to every site profile. Find more information in the documentation.'
+description: 'This ID is unique to each site you want to track separately, and is in the form of UA-xxxxxxx-yy or G-xxxxxxxxx. To get a Web Property ID, <a href="https://marketingplatform.google.com/about/analytics/">register your site with Google Analytics</a>, or if you already have registered your site, go to your Google Analytics Settings page to see the ID next to every site profile. <a href="https://developers.google.com/analytics/resources/concepts/gaConceptsAccounts#webProperty">Find more information in the documentation.</a>'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field_validation.rule_set.config_pages_stanford_basic_site_settings.yml
+++ b/config/sync/field_validation.rule_set.config_pages_stanford_basic_site_settings.yml
@@ -14,6 +14,6 @@ field_validation_rules:
     weight: 1
     field_name: su_google_analytics
     column: value
-    error_message: 'A valid Google Analytics Web Property ID is case sensitive and formatted like UA-xxxxxxx-yy.'
+    error_message: 'A valid Google Analytics Web Property ID is case sensitive and formatted like UA-xxxxxxx-yy or G-xxxxxxxxxx.'
     data:
-      setting: /^UA-\d+-\d+$/
+      setting: /^(?:UA-\d+-\d+|G-\w+)$/

--- a/tests/codeception/acceptance/Users/RolesCest.php
+++ b/tests/codeception/acceptance/Users/RolesCest.php
@@ -229,7 +229,7 @@ class RolesCest {
         continue;
       }
 
-      $I->cantSeeLink($link_text, $path);
+      $I->cantSeeLink($link_text, $path ?? '');
     }
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Updated the regex to allow `G-xxxxx` format google account ID.

# Need Review By (Date)
- 9/15

# Urgency
- medium

# Steps to Test
1. Checkout this branch
2. `drush cim -y`
3. go to the site settings page `/admin/config/system/basic-site-settings`
4. enter a google account id in the form `G-xxxxxxxx`
5. Verify you can save. (the google code won't be added to the pages because not on prod.)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
