### PR TITLE
D8CORE-4350 Sort publications by month and day along with year

### DIFF
--- a/config/sync/views.view.stanford_publications.yml
+++ b/config/sync/views.view.stanford_publications.yml
@@ -195,6 +195,30 @@ display:
           expose:
             label: ''
           plugin_id: standard
+        su_month_value:
+          id: su_month_value
+          table: citation__su_month
+          field: su_month_value
+          relationship: su_publication_citation
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          plugin_id: standard
+        su_day_value:
+          id: su_day_value
+          table: citation__su_day
+          field: su_day_value
+          relationship: su_publication_citation
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          plugin_id: standard
         title:
           id: title
           table: node_field_data

--- a/tests/codeception/acceptance/Content/PublicationsCest.php
+++ b/tests/codeception/acceptance/Content/PublicationsCest.php
@@ -99,7 +99,6 @@ class PublicationsCest {
 
   /**
    * Publication list should be in date order.
-   * @group mikes
    */
   public function testListSort(AcceptanceTester $I) {
     $I->logInWithRole('site_manager');

--- a/tests/codeception/acceptance/Content/PublicationsCest.php
+++ b/tests/codeception/acceptance/Content/PublicationsCest.php
@@ -78,23 +78,82 @@ class PublicationsCest {
   /**
    * An "Other" publication type should be available.
    */
-  public function testOtherPublication(AcceptanceTester $I){
-      $faker = Factory::create();
-      $I->logInWithRole('site_manager');
-      $I->amOnPage('/node/add/stanford_publication');
-      $I->fillField('Title', 'Test Publication');
-      $I->selectOption('su_publication_citation[actions][bundle]', 'Other');
-      $I->click('Add Citation');
-      $I->fillField('First Name', $faker->firstName);
-      $I->fillField('Last Name/Company', $faker->lastName);
-      $I->fillField('Subtitle', $faker->text);
-      $I->fillField('Publisher', $faker->text);
-      $I->fillField('su_publication_cta[0][uri]', $faker->url);
-      $I->fillField('Link text', $faker->text);
+  public function testOtherPublication(AcceptanceTester $I) {
+    $faker = Factory::create();
+    $I->logInWithRole('site_manager');
+    $I->amOnPage('/node/add/stanford_publication');
+    $I->fillField('Title', 'Test Publication');
+    $I->selectOption('su_publication_citation[actions][bundle]', 'Other');
+    $I->click('Add Citation');
+    $I->fillField('First Name', $faker->firstName);
+    $I->fillField('Last Name/Company', $faker->lastName);
+    $I->fillField('Subtitle', $faker->text);
+    $I->fillField('Publisher', $faker->text);
+    $I->fillField('su_publication_cta[0][uri]', $faker->url);
+    $I->fillField('Link text', $faker->text);
 
-      $I->click('Save');
-      $I->canSee('Test Publication', 'h1');
-      $I->canSee('Publication', '.node-stanford-publication-citation-type');
+    $I->click('Save');
+    $I->canSee('Test Publication', 'h1');
+    $I->canSee('Publication', '.node-stanford-publication-citation-type');
+  }
+
+  /**
+   * Publication list should be in date order.
+   * @group mikes
+   */
+  public function testListSort(AcceptanceTester $I) {
+    $I->logInWithRole('site_manager');
+
+    $I->amOnPage('/node/add/stanford_publication');
+    $I->fillField('Title', 'A June 1st Pub');
+    $I->selectOption('su_publication_citation[actions][bundle]', 'Other');
+    $I->click('Add Citation');
+    $I->fillField('Year', 2020);
+    $I->fillField('Month', 6);
+    $I->fillField('Day', 1);
+    $I->click('Save');
+    $I->canSee('A June 1st Pub', 'h1');
+
+
+    $I->amOnPage('/node/add/stanford_publication');
+    $I->fillField('Title', 'B June 15th Pub');
+    $I->selectOption('su_publication_citation[actions][bundle]', 'Other');
+    $I->click('Add Citation');
+    $I->fillField('Year', 2020);
+    $I->fillField('Month', 6);
+    $I->fillField('Day', 15);
+    $I->click('Save');
+    $I->canSee('B June 15th Pub', 'h1');
+
+    $I->amOnPage('/node/add/stanford_publication');
+    $I->fillField('Title', 'C January Pub');
+    $I->selectOption('su_publication_citation[actions][bundle]', 'Other');
+    $I->click('Add Citation');
+    $I->fillField('Year', 2020);
+    $I->fillField('Month', 1);
+    $I->fillField('Day', 15);
+    $I->click('Save');
+    $I->canSee('C January Pub', 'h1');
+
+    $I->amOnPage('/publications');
+    $titles = $I->grabMultiple('.csl-entry a');
+    foreach($titles as &$title){
+      $title = preg_replace('/[^\da-z ]/i', '', $title);
+    }
+
+    $a_pos = array_search('A June 1st Pub', $titles);
+    $b_pos = array_search('B June 15th Pub', $titles);
+    $c_pos = array_search('C January Pub', $titles);
+
+    $I->assertGreaterThan($b_pos, $a_pos, '"A June 1st Pub" does not display after "B June 15th Pub"');
+    $I->assertGreaterThan($a_pos, $c_pos, '"C January Pub" does not display after "A June 1st Pub"');
+    $I->assertGreaterThan($b_pos, $c_pos, '"C January Pub" does not display after "B June 15th Pub"');
+
+    // Ensure distinct results
+    $titles_counts = array_count_values($titles);
+    $I->assertEquals(1, $titles_counts['A June 1st Pub']);
+    $I->assertEquals(1, $titles_counts['B June 15th Pub']);
+    $I->assertEquals(1, $titles_counts['C January Pub']);
   }
 
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added sort to publication lists to sort by month and day after the year.

# Need Review By (Date)
- 8/12

# Urgency
- medium

# Steps to Test
1. checkout this branch; drush cim -y
2. create 3 publications using either the newspaper or "other" citation, all with the same name but different dates
3. view /publications and verify they are in the correct date order

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
