### PR TITLE
D8CORE-4653 Add editoria11y module with permissions for contributors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -116,6 +116,7 @@
         "drupal/diff": "^1.0@RC",
         "drupal/domain_301_redirect": "^1.0-alpha0",
         "drupal/ds": "^3.3",
+        "drupal/editoria11y": "^1.0",
         "drupal/element_class_formatter": "^1.1",
         "drupal/environment_indicator": "^4.0",
         "drupal/extlink": "^1.3",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -42,6 +42,7 @@ module:
   ds_extras: 0
   dynamic_page_cache: 0
   editor: 0
+  editoria11y: 0
   element_class_formatter: 0
   encrypt: 0
   entity_reference_revisions: 0

--- a/config/sync/editoria11y.settings.yml
+++ b/config/sync/editoria11y.settings.yml
@@ -1,0 +1,10 @@
+content_root: '#block-stanford-basic-content'
+no_load: ''
+ignore_containers: .su-secondary-nav
+embedded_content_warning: ''
+allow_overflow: ''
+assertiveness: smart
+download_links: ''
+hidden_handlers: ''
+_core:
+  default_config_hash: 8d0nv-vvXs9MZkqD1mhxm8mPeF4yF9fqLLIcVp4cnLQ

--- a/config/sync/user.role.contributor.yml
+++ b/config/sync/user.role.contributor.yml
@@ -70,6 +70,7 @@ permissions:
   - 'view any unpublished stanford_page content'
   - 'view any unpublished stanford_person content'
   - 'view any unpublished stanford_publication content'
+  - 'view editoria11y checker'
   - 'view own unpublished content'
   - 'view own unpublished media'
   - 'view stanford_event revisions'

--- a/config/sync/user.role.site_builder.yml
+++ b/config/sync/user.role.site_builder.yml
@@ -218,6 +218,7 @@ permissions:
   - 'view any unpublished stanford_person content'
   - 'view any unpublished stanford_publication content'
   - 'view config_pages entity'
+  - 'view editoria11y checker'
   - 'view field_media_embeddable_code'
   - 'view own field_media_embeddable_code'
   - 'view own unpublished content'

--- a/config/sync/user.role.site_developer.yml
+++ b/config/sync/user.role.site_developer.yml
@@ -255,6 +255,7 @@ permissions:
   - 'view any unpublished stanford_person content'
   - 'view any unpublished stanford_publication content'
   - 'view config_pages entity'
+  - 'view editoria11y checker'
   - 'view field_media_embeddable_code'
   - 'view own field_media_embeddable_code'
   - 'view own unpublished content'

--- a/config/sync/user.role.site_editor.yml
+++ b/config/sync/user.role.site_editor.yml
@@ -122,6 +122,7 @@ permissions:
   - 'view any unpublished stanford_page content'
   - 'view any unpublished stanford_person content'
   - 'view any unpublished stanford_publication content'
+  - 'view editoria11y checker'
   - 'view own unpublished content'
   - 'view own unpublished media'
   - 'view stanford_event revisions'

--- a/config/sync/user.role.site_manager.yml
+++ b/config/sync/user.role.site_manager.yml
@@ -166,6 +166,7 @@ permissions:
   - 'view any unpublished stanford_page content'
   - 'view any unpublished stanford_person content'
   - 'view any unpublished stanford_publication content'
+  - 'view editoria11y checker'
   - 'view own su_lockup'
   - 'view own unpublished content'
   - 'view own unpublished media'


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added and configured editoria11y module

# Need Review By (Date)
- 8/12

# Urgency
- low

# Steps to Test
1. `composer require su-sws/stanford_profile:dev-D8CORE-4653 --no-update; composer update -n`
2. `drush cim -y`
3. create any node
4. view the editoria11y icon in the bottom right and view your issues/warnings/errors etc

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
