### PR TITLE
D8CORE-4759 add specific view mode for search indexing for better control

### DIFF
--- a/config/sync/core.entity_view_display.node.stanford_event.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event.default.yml
@@ -586,6 +586,7 @@ third_party_settings:
         - jumpstart_ui_three_column
         - stanford_events_editorial_content
         - stanford_events_body
+      restricted_categories: {  }
 id: node.stanford_event.default
 targetEntityType: node
 bundle: stanford_event

--- a/config/sync/core.entity_view_display.node.stanford_event.search_indexing.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event.search_indexing.yml
@@ -1,0 +1,260 @@
+uuid: 069e8177-0368-4802-a58c-418dd2132650
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_indexing
+    - field.field.node.stanford_event.body
+    - field.field.node.stanford_event.layout_builder__layout
+    - field.field.node.stanford_event.stanford_intranet__access
+    - field.field.node.stanford_event.su_event_alt_loc
+    - field.field.node.stanford_event.su_event_audience
+    - field.field.node.stanford_event.su_event_components
+    - field.field.node.stanford_event.su_event_cta
+    - field.field.node.stanford_event.su_event_date_time
+    - field.field.node.stanford_event.su_event_dek
+    - field.field.node.stanford_event.su_event_email
+    - field.field.node.stanford_event.su_event_location
+    - field.field.node.stanford_event.su_event_map_link
+    - field.field.node.stanford_event.su_event_schedule
+    - field.field.node.stanford_event.su_event_source
+    - field.field.node.stanford_event.su_event_sponsor
+    - field.field.node.stanford_event.su_event_subheadline
+    - field.field.node.stanford_event.su_event_telephone
+    - field.field.node.stanford_event.su_event_type
+    - node.type.stanford_event
+  module:
+    - address
+    - entity_reference_revisions
+    - field_formatter_class
+    - layout_builder
+    - layout_builder_restrictions
+    - layout_library
+    - link
+    - smart_date
+    - text
+    - user
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+  layout_library:
+    enable: false
+  layout_builder_restrictions:
+    allowed_block_categories: {  }
+    entity_view_mode_restriction:
+      whitelisted_blocks:
+        'Chaos Tools': {  }
+        'Config Pages': {  }
+        'Content fields':
+          - 'field_block:node:stanford_event:su_event_audience'
+          - 'field_block:node:stanford_event:uid'
+          - 'field_block:node:stanford_event:created'
+          - 'field_block:node:stanford_event:body'
+          - 'field_block:node:stanford_event:su_event_cta'
+          - 'field_block:node:stanford_event:changed'
+          - 'field_block:node:stanford_event:su_event_components'
+          - 'field_block:node:stanford_event:su_event_email'
+          - 'field_block:node:stanford_event:su_event_telephone'
+          - 'field_block:node:stanford_event:su_event_date_time'
+          - 'field_block:node:stanford_event:su_event_dek'
+          - 'field_block:node:stanford_event:su_event_alt_loc'
+          - 'field_block:node:stanford_event:title'
+          - 'field_block:node:stanford_event:su_event_type'
+          - 'field_block:node:stanford_event:su_event_source'
+          - 'field_block:node:stanford_event:nid'
+          - 'extra_field_block:node:stanford_event:links'
+          - 'field_block:node:stanford_event:su_event_location'
+          - 'field_block:node:stanford_event:su_event_map_link'
+          - 'field_block:node:stanford_event:menu_link'
+          - 'field_block:node:stanford_event:status'
+          - 'field_block:node:stanford_event:su_event_schedule'
+          - 'field_block:node:stanford_event:su_event_sponsor'
+          - 'field_block:node:stanford_event:su_event_subheadline'
+        Devel: {  }
+        'Devel PHP': {  }
+        Forms: {  }
+        'Lists (Views)': {  }
+        Menus:
+          - 'menu_block:stanford-event-types'
+          - 'menu_block:main'
+        'News Lists (Views)':
+          - 'views_block:stanford_news-vertical_teaser_term'
+          - 'views_block:stanford_news-vertical_teaser_term_list'
+          - 'views_block:stanford_news-block_1'
+          - 'views_block:stanford_news-term_block'
+        'People Lists (Views)':
+          - 'views_block:stanford_person-grid_list_all'
+          - 'views_block:stanford_person_list_terms_first-person_list_grid'
+        'SimpleSAMLphp Authentication': {  }
+        'Stanford News': {  }
+        'Stanford SimpleSAML PHP': {  }
+        System:
+          - system_messages_block
+      blacklisted_blocks: {  }
+      allowed_layouts:
+        - jumpstart_ui_one_column
+        - jumpstart_ui_one_column_overlay
+        - jumpstart_ui_two_column
+        - jumpstart_ui_three_column
+        - stanford_events_editorial_content
+        - stanford_events_body
+      restricted_categories: {  }
+id: node.stanford_event.search_indexing
+targetEntityType: node
+bundle: stanford_event
+mode: search_indexing
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  su_event_alt_loc:
+    type: string
+    weight: 13
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  su_event_audience:
+    weight: 10
+    label: hidden
+    settings:
+      link: false
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+      ds:
+        ds_limit: ''
+    type: entity_reference_label
+    region: content
+  su_event_components:
+    type: entity_reference_revisions_entity_view
+    weight: 5
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  su_event_cta:
+    weight: 9
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  su_event_date_time:
+    type: smartdate_default
+    weight: 12
+    region: content
+    label: hidden
+    settings:
+      format: default
+      force_chronological: false
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+  su_event_dek:
+    weight: 3
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  su_event_email:
+    weight: 7
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  su_event_location:
+    weight: 6
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: address_default
+    region: content
+  su_event_map_link:
+    type: link
+    weight: 14
+    region: content
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+  su_event_schedule:
+    type: entity_reference_revisions_entity_view
+    weight: 11
+    region: content
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+  su_event_source:
+    type: link
+    weight: 15
+    region: content
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+  su_event_sponsor:
+    weight: 4
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  su_event_subheadline:
+    weight: 2
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  su_event_telephone:
+    weight: 8
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  su_event_type:
+    weight: 1
+    label: hidden
+    settings:
+      link: false
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+    type: entity_reference_label
+    region: content
+hidden:
+  layout_builder__layout: true
+  links: true
+  search_api_excerpt: true
+  stanford_intranet__access: true

--- a/config/sync/core.entity_view_display.node.stanford_event_series.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event_series.default.yml
@@ -222,6 +222,7 @@ third_party_settings:
         - jumpstart_ui_three_column
         - stanford_events_editorial_content
         - stanford_events_body
+      restricted_categories: {  }
 id: node.stanford_event_series.default
 targetEntityType: node
 bundle: stanford_event_series

--- a/config/sync/core.entity_view_display.node.stanford_event_series.search_indexing.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event_series.search_indexing.yml
@@ -1,0 +1,135 @@
+uuid: b464a147-f500-4ef2-93a2-eaa33ff33455
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_indexing
+    - field.field.node.stanford_event_series.layout_builder__layout
+    - field.field.node.stanford_event_series.stanford_intranet__access
+    - field.field.node.stanford_event_series.su_event_series_components
+    - field.field.node.stanford_event_series.su_event_series_dek
+    - field.field.node.stanford_event_series.su_event_series_event
+    - field.field.node.stanford_event_series.su_event_series_subheadline
+    - field.field.node.stanford_event_series.su_event_series_type
+    - field.field.node.stanford_event_series.su_event_series_weight
+    - node.type.stanford_event_series
+  module:
+    - ds
+    - entity_reference_revisions
+    - field_formatter_class
+    - layout_builder
+    - layout_builder_restrictions
+    - layout_library
+    - user
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+  layout_library:
+    enable: false
+  layout_builder_restrictions:
+    allowed_block_categories: {  }
+    entity_view_mode_restriction:
+      whitelisted_blocks:
+        'Chaos Tools': {  }
+        'Config Pages': {  }
+        'Content fields':
+          - 'field_block:node:stanford_event_series:uid'
+          - 'field_block:node:stanford_event_series:created'
+          - 'field_block:node:stanford_event_series:changed'
+          - 'field_block:node:stanford_event_series:su_event_series_components'
+          - 'field_block:node:stanford_event_series:su_event_series_dek'
+          - 'field_block:node:stanford_event_series:su_event_series_event'
+          - 'field_block:node:stanford_event_series:nid'
+          - 'extra_field_block:node:stanford_event_series:links'
+          - 'field_block:node:stanford_event_series:menu_link'
+          - 'field_block:node:stanford_event_series:status'
+          - 'field_block:node:stanford_event_series:su_event_series_subheadline'
+          - 'field_block:node:stanford_event_series:title'
+          - 'field_block:node:stanford_event_series:su_event_series_type'
+          - 'field_block:node:stanford_event_series:su_event_series_weight'
+        'Devel PHP': {  }
+        Menus:
+          - 'menu_block:stanford-event-types'
+          - 'menu_block:main'
+        'News Lists (Views)':
+          - 'views_block:stanford_news-vertical_teaser_term'
+          - 'views_block:stanford_news-vertical_teaser_term_list'
+          - 'views_block:stanford_news-block_1'
+          - 'views_block:stanford_news-term_block'
+        'People Lists (Views)':
+          - 'views_block:stanford_person-grid_list_all'
+          - 'views_block:stanford_person_list_terms_first-person_list_grid'
+        'SimpleSAMLphp Authentication': {  }
+        'Stanford News': {  }
+        'Stanford SimpleSAML PHP': {  }
+        System:
+          - system_messages_block
+      blacklisted_blocks: {  }
+      allowed_layouts:
+        - jumpstart_ui_one_column
+        - jumpstart_ui_one_column_overlay
+        - jumpstart_ui_two_column
+        - jumpstart_ui_three_column
+        - stanford_events_editorial_content
+        - stanford_events_body
+      restricted_categories: {  }
+id: node.stanford_event_series.search_indexing
+targetEntityType: node
+bundle: stanford_event_series
+mode: search_indexing
+content:
+  su_event_series_components:
+    type: entity_reference_revisions_entity_view
+    weight: 4
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  su_event_series_dek:
+    type: string
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  su_event_series_event:
+    weight: 3
+    label: hidden
+    settings:
+      view_mode: search_indexing
+      link: false
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+      ds:
+        ds_limit: ''
+    type: entity_reference_entity_view
+    region: content
+  su_event_series_subheadline:
+    type: string
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  su_event_series_type:
+    type: entity_reference_label
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      link: false
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+hidden:
+  layout_builder__layout: true
+  links: true
+  search_api_excerpt: true
+  stanford_intranet__access: true
+  su_event_series_weight: true

--- a/config/sync/core.entity_view_display.node.stanford_news.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_news.default.yml
@@ -354,6 +354,7 @@ third_party_settings:
         - jumpstart_ui_three_column
         - stanford_news_byline
         - ds_reset
+      restricted_categories: {  }
   layout_library:
     enable: false
 id: node.stanford_news.default

--- a/config/sync/core.entity_view_display.node.stanford_news.search_indexing.yml
+++ b/config/sync/core.entity_view_display.node.stanford_news.search_indexing.yml
@@ -1,0 +1,152 @@
+uuid: 0af96d84-4821-4907-a7e7-f5c6ce4cd028
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_indexing
+    - field.field.node.stanford_news.layout_builder__layout
+    - field.field.node.stanford_news.stanford_intranet__access
+    - field.field.node.stanford_news.su_news_banner
+    - field.field.node.stanford_news.su_news_banner_media_caption
+    - field.field.node.stanford_news.su_news_byline
+    - field.field.node.stanford_news.su_news_components
+    - field.field.node.stanford_news.su_news_dek
+    - field.field.node.stanford_news.su_news_featured_media
+    - field.field.node.stanford_news.su_news_publishing_date
+    - field.field.node.stanford_news.su_news_source
+    - field.field.node.stanford_news.su_news_topics
+    - node.type.stanford_news
+  module:
+    - datetime
+    - entity_reference_revisions
+    - field_formatter_class
+    - layout_builder
+    - layout_builder_restrictions
+    - layout_library
+    - link
+    - stanford_media
+    - user
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+  layout_builder_restrictions:
+    allowed_block_categories: {  }
+    entity_view_mode_restriction:
+      whitelisted_blocks:
+        'Chaos Tools': {  }
+        'Config Pages': {  }
+        Menus:
+          - 'menu_block:main'
+          - 'menu_block:news-topics'
+        'SimpleSAMLphp Authentication': {  }
+        System:
+          - system_messages_block
+        core:
+          - page_title_block
+      blacklisted_blocks: {  }
+      allowed_layouts:
+        - jumpstart_ui_one_column
+        - jumpstart_ui_two_column
+        - jumpstart_ui_three_column
+        - stanford_news_byline
+        - ds_reset
+      restricted_categories: {  }
+  layout_library:
+    enable: false
+id: node.stanford_news.search_indexing
+targetEntityType: node
+bundle: stanford_news
+mode: search_indexing
+content:
+  su_news_banner:
+    type: media_responsive_image_formatter
+    weight: 8
+    region: content
+    label: hidden
+    settings:
+      view_mode: default
+      image_style: full_responsive
+      link: false
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+  su_news_banner_media_caption:
+    weight: 5
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  su_news_byline:
+    weight: 3
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  su_news_components:
+    type: entity_reference_revisions_entity_view
+    weight: 6
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  su_news_dek:
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  su_news_featured_media:
+    type: entity_reference_entity_view
+    weight: 4
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+    region: content
+  su_news_publishing_date:
+    type: datetime_custom
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      timezone_override: ''
+      date_format: 'F d, Y'
+    third_party_settings: {  }
+  su_news_source:
+    type: link
+    weight: 7
+    region: content
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+  su_news_topics:
+    weight: 0
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+hidden:
+  layout_builder__layout: true
+  layout_selection: true
+  links: true
+  search_api_excerpt: true
+  stanford_intranet__access: true

--- a/config/sync/core.entity_view_display.node.stanford_page.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_page.default.yml
@@ -169,6 +169,7 @@ third_party_settings:
         - jumpstart_ui_three_column
       whitelisted_blocks: {  }
       blacklisted_blocks: {  }
+      restricted_categories: {  }
     allowed_block_categories: {  }
 id: node.stanford_page.default
 targetEntityType: node

--- a/config/sync/core.entity_view_display.node.stanford_page.search_indexing.yml
+++ b/config/sync/core.entity_view_display.node.stanford_page.search_indexing.yml
@@ -1,0 +1,94 @@
+uuid: b547fa62-8bab-43e2-95a9-080de4d53251
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_indexing
+    - field.field.node.stanford_page.layout_builder__layout
+    - field.field.node.stanford_page.layout_selection
+    - field.field.node.stanford_page.stanford_intranet__access
+    - field.field.node.stanford_page.su_basic_page_type
+    - field.field.node.stanford_page.su_page_banner
+    - field.field.node.stanford_page.su_page_components
+    - field.field.node.stanford_page.su_page_description
+    - field.field.node.stanford_page.su_page_image
+    - node.type.stanford_page
+  module:
+    - entity_reference_revisions
+    - layout_builder
+    - layout_builder_restrictions
+    - layout_library
+    - user
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+  layout_library:
+    enable: true
+  layout_builder_restrictions:
+    entity_view_mode_restriction:
+      allowed_blocks:
+        'Chaos Tools': {  }
+        'Content fields':
+          - 'field_block:node:stanford_page:su_page_banner'
+          - 'field_block:node:stanford_page:su_page_components'
+          - 'field_block:node:stanford_page:title'
+        Forms: {  }
+        Help: {  }
+        Menus:
+          - 'menu_block:footer'
+          - 'system_menu_block:footer'
+          - 'menu_block:main'
+          - 'system_menu_block:main'
+        'SimpleSAMLphp Authentication': {  }
+        'Stanford SimpleSAML PHP': {  }
+        System: {  }
+        'User fields': {  }
+        core: {  }
+      allowed_layouts:
+        - jumpstart_ui_one_column
+        - jumpstart_ui_two_column
+        - jumpstart_ui_three_column
+      whitelisted_blocks: {  }
+      blacklisted_blocks: {  }
+      restricted_categories: {  }
+    allowed_block_categories: {  }
+id: node.stanford_page.search_indexing
+targetEntityType: node
+bundle: stanford_page
+mode: search_indexing
+content:
+  su_page_banner:
+    type: entity_reference_revisions_entity_view
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  su_page_components:
+    type: entity_reference_revisions_entity_view
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+  su_page_description:
+    type: string
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden:
+  layout_builder__layout: true
+  layout_selection: true
+  links: true
+  search_api_excerpt: true
+  stanford_intranet__access: true
+  su_basic_page_type: true
+  su_page_image: true

--- a/config/sync/core.entity_view_display.node.stanford_person.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_person.default.yml
@@ -580,6 +580,7 @@ third_party_settings:
         - stanford_person_header
         - stanford_person_body
         - ds_reset
+      restricted_categories: {  }
   layout_library:
     enable: false
 id: node.stanford_person.default

--- a/config/sync/core.entity_view_display.node.stanford_person.search_indexing.yml
+++ b/config/sync/core.entity_view_display.node.stanford_person.search_indexing.yml
@@ -1,0 +1,287 @@
+uuid: 7b3c8710-997e-4492-a034-77e395bb90a1
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_indexing
+    - field.field.node.stanford_person.body
+    - field.field.node.stanford_person.layout_builder__layout
+    - field.field.node.stanford_person.stanford_intranet__access
+    - field.field.node.stanford_person.su_person_academic_appt
+    - field.field.node.stanford_person.su_person_admin_appts
+    - field.field.node.stanford_person.su_person_affiliations
+    - field.field.node.stanford_person.su_person_components
+    - field.field.node.stanford_person.su_person_education
+    - field.field.node.stanford_person.su_person_email
+    - field.field.node.stanford_person.su_person_fax
+    - field.field.node.stanford_person.su_person_first_name
+    - field.field.node.stanford_person.su_person_full_title
+    - field.field.node.stanford_person.su_person_last_name
+    - field.field.node.stanford_person.su_person_links
+    - field.field.node.stanford_person.su_person_location_address
+    - field.field.node.stanford_person.su_person_location_name
+    - field.field.node.stanford_person.su_person_mail_code
+    - field.field.node.stanford_person.su_person_map_url
+    - field.field.node.stanford_person.su_person_mobile_phone
+    - field.field.node.stanford_person.su_person_photo
+    - field.field.node.stanford_person.su_person_profile_link
+    - field.field.node.stanford_person.su_person_research
+    - field.field.node.stanford_person.su_person_research_interests
+    - field.field.node.stanford_person.su_person_scholarly_interests
+    - field.field.node.stanford_person.su_person_short_title
+    - field.field.node.stanford_person.su_person_telephone
+    - field.field.node.stanford_person.su_person_type_group
+    - node.type.stanford_person
+  module:
+    - entity_reference_revisions
+    - layout_builder
+    - layout_builder_restrictions
+    - layout_library
+    - link
+    - text
+    - user
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+  layout_builder_restrictions:
+    allowed_block_categories: {  }
+    entity_view_mode_restriction:
+      whitelisted_blocks: {  }
+      blacklisted_blocks: {  }
+      allowed_layouts:
+        - jumpstart_ui_one_column
+        - jumpstart_ui_two_column
+        - jumpstart_ui_three_column
+        - stanford_person_header
+        - stanford_person_body
+        - ds_reset
+      restricted_categories: {  }
+  layout_library:
+    enable: false
+id: node.stanford_person.search_indexing
+targetEntityType: node
+bundle: stanford_person
+mode: search_indexing
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  su_person_academic_appt:
+    type: string
+    weight: 21
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  su_person_admin_appts:
+    type: string
+    weight: 22
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  su_person_affiliations:
+    weight: 7
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  su_person_components:
+    type: entity_reference_revisions_entity_view
+    weight: 25
+    region: content
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+  su_person_education:
+    weight: 8
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  su_person_email:
+    weight: 15
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  su_person_fax:
+    weight: 12
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  su_person_first_name:
+    weight: 4
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  su_person_full_title:
+    weight: 6
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  su_person_last_name:
+    weight: 5
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  su_person_links:
+    weight: 17
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  su_person_location_address:
+    weight: 14
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  su_person_location_name:
+    weight: 13
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  su_person_mail_code:
+    weight: 16
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  su_person_map_url:
+    weight: 18
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  su_person_mobile_phone:
+    weight: 11
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  su_person_photo:
+    type: entity_reference_entity_view
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    region: content
+  su_person_profile_link:
+    weight: 20
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  su_person_research:
+    weight: 9
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  su_person_research_interests:
+    type: string
+    weight: 24
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  su_person_scholarly_interests:
+    type: text_default
+    weight: 23
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  su_person_short_title:
+    weight: 3
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  su_person_telephone:
+    weight: 10
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  su_person_type_group:
+    weight: 19
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+hidden:
+  layout_builder__layout: true
+  search_api_excerpt: true
+  stanford_intranet__access: true

--- a/config/sync/core.entity_view_display.node.stanford_publication.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_publication.default.yml
@@ -201,6 +201,7 @@ third_party_settings:
       whitelisted_blocks: {  }
       blacklisted_blocks: {  }
       allowed_layouts: {  }
+      restricted_categories: {  }
 id: node.stanford_publication.default
 targetEntityType: node
 bundle: stanford_publication

--- a/config/sync/core.entity_view_display.node.stanford_publication.search_indexing.yml
+++ b/config/sync/core.entity_view_display.node.stanford_publication.search_indexing.yml
@@ -1,0 +1,83 @@
+uuid: 8a548e00-c180-489a-9c37-c5fa47fe8709
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_indexing
+    - field.field.node.stanford_publication.layout_builder__layout
+    - field.field.node.stanford_publication.stanford_intranet__access
+    - field.field.node.stanford_publication.su_publication_citation
+    - field.field.node.stanford_publication.su_publication_components
+    - field.field.node.stanford_publication.su_publication_cta
+    - field.field.node.stanford_publication.su_publication_topics
+    - node.type.stanford_publication
+  module:
+    - entity_reference_revisions
+    - layout_builder
+    - layout_builder_restrictions
+    - layout_library
+    - link
+    - user
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+  layout_library:
+    enable: false
+  layout_builder_restrictions:
+    allowed_block_categories: {  }
+    entity_view_mode_restriction:
+      whitelisted_blocks: {  }
+      blacklisted_blocks: {  }
+      allowed_layouts: {  }
+      restricted_categories: {  }
+id: node.stanford_publication.search_indexing
+targetEntityType: node
+bundle: stanford_publication
+mode: search_indexing
+content:
+  su_publication_citation:
+    type: entity_reference_label
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      link: false
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+  su_publication_components:
+    type: entity_reference_revisions_entity_view
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+  su_publication_cta:
+    type: link
+    weight: 3
+    region: content
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+  su_publication_topics:
+    type: entity_reference_label
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+hidden:
+  citation_type: true
+  layout_builder__layout: true
+  links: true
+  search_api_excerpt: true
+  stanford_intranet__access: true

--- a/config/sync/core.entity_view_mode.node.search_indexing.yml
+++ b/config/sync/core.entity_view_mode.node.search_indexing.yml
@@ -1,0 +1,10 @@
+uuid: a6269e21-a064-410a-a1d0-81e6c86d21b9
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.search_indexing
+label: 'Search Indexing'
+targetEntityType: node
+cache: true

--- a/config/sync/search_api.index.full_site_content.yml
+++ b/config/sync/search_api.index.full_site_content.yml
@@ -7,6 +7,7 @@ dependencies:
     - search_api
   config:
     - search_api.server.database_search
+    - core.entity_view_mode.node.search_indexing
 id: full_site_content
 name: 'Full Site Content'
 description: ''
@@ -28,14 +29,21 @@ field_settings:
         anonymous: anonymous
       view_mode:
         'entity:node':
-          stanford_event: default
-          stanford_event_series: default
-          stanford_news: default
-          stanford_page: default
-          stanford_person: default
-          stanford_publication: default
+          stanford_event: search_indexing
+          stanford_event_series: search_indexing
+          stanford_news: search_indexing
+          stanford_page: search_indexing
+          stanford_person: search_indexing
+          stanford_publication: search_indexing
+  role_access:
+    label: 'Role-based access information'
+    property_path: search_api_role_access
+    type: string
+    indexed_locked: true
+    type_locked: true
+    hidden: true
   status:
-    label: null
+    label: status
     datasource_id: 'entity:node'
     property_path: status
     type: boolean
@@ -53,7 +61,7 @@ field_settings:
       module:
         - node
   uid:
-    label: null
+    label: uid
     datasource_id: 'entity:node'
     property_path: uid
     type: integer
@@ -96,17 +104,35 @@ processor_settings:
     alt: true
     tags:
       b: 2
-      em: 1
       h1: 5
       h2: 3
       h3: 2
       strong: 2
-      u: 1
     weights:
       preprocess_index: -15
       preprocess_query: -15
+  ignore_character:
+    all_fields: false
+    fields:
+      - rendered_item
+      - title
+    ignorable: '[''¿¡!?,.:;]'
+    ignorable_classes:
+      - Pc
+      - Pd
+      - Pe
+      - Pf
+      - Pi
+      - Po
+      - Ps
+    weights:
+      preprocess_index: -10
+      preprocess_query: -10
   language_with_fallback: {  }
   rendered_item: {  }
+  role_access:
+    weights:
+      preprocess_query: -30
   stemmer:
     all_fields: true
     fields:
@@ -117,6 +143,14 @@ processor_settings:
     weights:
       preprocess_index: 0
       preprocess_query: 0
+  type_boost:
+    boosts:
+      'entity:node':
+        datasource_boost: !!float 1
+        bundle_boosts:
+          stanford_page: !!float 3
+    weights:
+      preprocess_index: 0
 tracker_settings:
   default:
     indexing_order: fifo

--- a/config/sync/search_api.index.full_site_content.yml
+++ b/config/sync/search_api.index.full_site_content.yml
@@ -143,6 +143,49 @@ processor_settings:
     weights:
       preprocess_index: 0
       preprocess_query: 0
+  stopwords:
+    all_fields: false
+    fields:
+      - rendered_item
+    stopwords:
+      - a
+      - an
+      - and
+      - are
+      - as
+      - at
+      - be
+      - but
+      - by
+      - for
+      - if
+      - in
+      - into
+      - is
+      - it
+      - 'no'
+      - not
+      - of
+      - 'on'
+      - or
+      - s
+      - such
+      - t
+      - that
+      - the
+      - their
+      - then
+      - there
+      - these
+      - they
+      - this
+      - to
+      - was
+      - will
+      - with
+    weights:
+      preprocess_index: -5
+      preprocess_query: -2
   type_boost:
     boosts:
       'entity:node':


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added a view mode and configured it for all content types. This will be used for indexing. It'll prevent the unwanted indexing of accessibility parts and sidebar menu

# Need Review By (Date)
- 9/30

# Urgency
- low

# Steps to Test
1. checkout this branch
2. `blt drupal:update` or `drush cim -y`
3. `drush sapi-i` to re-index content
4. search for the title of a page like "About"
5. verify you don't see "Main content start" in the search result text.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)

