### PR TITLE
D8CORE-4693 Filter events by the second instead of the day

### DIFF
--- a/config/sync/views.view.stanford_events.yml
+++ b/config/sync/views.view.stanford_events.yml
@@ -584,7 +584,7 @@ display:
           value:
             min: ''
             max: ''
-            value: today
+            value: now
             type: offset
           group: 1
           exposed: false
@@ -6213,7 +6213,7 @@ display:
           value:
             min: ''
             max: ''
-            value: today
+            value: now
             type: offset
           group: 1
           exposed: false


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Change the filters on events list to be more granular

# Need Review By (Date)
- 9/30

# Urgency
- medium

# Steps to Test
1. checkout this branch
2. `drush cim -y`
3. create an event that starts 10 minutes ago and ends 5 minutes ago
4. view `/events` and verify that event does not display.
5. change the event to end 10 minutes in the future
6. view `/events` and verify the event displays.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
