### PR TITLE
D8CORE-4246 Add fontawesome module for wysiwyg icon support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -123,6 +123,7 @@
         "drupal/field_group": "^3.0@rc",
         "drupal/field_permissions": "^1.0@RC",
         "drupal/field_validation": "^1.0-alpha",
+        "drupal/fontawesome": "^2.19",
         "drupal/google_analytics": "^3.1",
         "drupal/google_tag": "^1.4",
         "drupal/imagemagick": "^3.1",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -62,6 +62,7 @@ module:
   file_mdm_font: 0
   filter: 0
   focal_point: 0
+  fontawesome: 0
   google_analytics: 0
   google_tag: 0
   hal: 0

--- a/config/sync/filter.format.stanford_html.yml
+++ b/config/sync/filter.format.stanford_html.yml
@@ -57,7 +57,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <em> <strong> <cite> <blockquote cite> <pre class> <code data-* class> <ul type class> <ol start type class> <li class> <dl class> <dt> <dd class> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <div class> <table class> <caption> <tbody class> <thead> <tfoot> <th scope class> <td colspan rowspan class> <tr> <sup> <sub> <i class> <hr> <s> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title name class> <p class> <drupal-media data-entity-type data-entity-uuid data-align data-caption data-* alt> <aside class>'
+      allowed_html: '<br> <em> <strong> <cite> <blockquote cite> <pre class> <code data-* class> <ul type class> <ol start type class> <li class> <dl class> <dt> <dd class> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <div class> <table class> <caption> <tbody class> <thead> <tfoot> <th scope class> <td colspan rowspan class> <tr> <sup> <sub> <i class> <hr> <s> <aside class> <drupal-media data-entity-type data-entity-uuid data-align data-caption data-* alt data-view-mode title> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title name class> <p class>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_htmlcorrector:

--- a/config/sync/fontawesome.settings.yml
+++ b/config/sync/fontawesome.settings.yml
@@ -1,0 +1,17 @@
+tag: span
+method: webfonts
+load_assets: true
+use_cdn: true
+external_svg_location: 'https://use.fontawesome.com/releases/v5.13.1/css/all.css'
+use_shim: true
+external_shim_location: 'https://use.fontawesome.com/releases/v5.13.1/css/v4-shims.css'
+use_solid_file: true
+use_regular_file: true
+use_light_file: true
+use_brands_file: true
+use_duotone_file: true
+external_svg_integrity: ''
+bypass_validation: false
+_core:
+  default_config_hash: 1b5NVo6pE0ii3h75UXz50aqP5vS8UHfkJl9DD4HNQzQ
+allow_pseudo_elements: true


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add the fontawesome module so that the icons display in the wysiwyg

# Need Review By (Date)
- 11/19

# Urgency
- medium

# Steps to Test
1. `composer require su-sws/stanford_profile:dev-D8CORE-4246`
2. `blt drupal:update` or `blt drupal:install`
3. create a page with a text area
4. fill the text area with some text like `<p class="fab fa-drupal">This is some text</p>`
5. view the ckeditor in normal style and verify the icon displays while editing.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
