### PR TITLE
D8CORE-4996 Remove taxonomy term on basic page card and list displays

### DIFF
--- a/config/sync/block.block.config_pages.yml
+++ b/config/sync/block.block.config_pages.yml
@@ -9,7 +9,7 @@ dependencies:
 id: config_pages
 theme: stanford_basic
 region: footer
-weight: -3
+weight: 0
 provider: null
 plugin: config_pages_block
 settings:

--- a/config/sync/core.entity_view_display.node.stanford_page.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_page.stanford_card.yml
@@ -90,18 +90,6 @@ targetEntityType: node
 bundle: stanford_page
 mode: stanford_card
 content:
-  su_basic_page_type:
-    type: entity_reference_label
-    weight: 2
-    region: card_super_headline
-    label: hidden
-    settings:
-      link: false
-    third_party_settings:
-      field_formatter_class:
-        class: su-basic-page-types__categories
-      ds:
-        ds_limit: ''
   su_page_banner:
     type: entity_reference_revisions_entity_view
     weight: 0
@@ -115,7 +103,7 @@ content:
         class: 'su-media su-media--image su-card__media'
   su_page_description:
     type: string
-    weight: 4
+    weight: 3
     region: card_body
     label: hidden
     settings:
@@ -150,4 +138,5 @@ hidden:
   links: true
   search_api_excerpt: true
   stanford_intranet__access: true
+  su_basic_page_type: true
   su_page_components: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -192,9 +192,10 @@ module:
   paragraphs: 11
   stanford_profile: 1000
 theme:
-  stable9: 0
+  stable: 0
   seven: 0
   stanford_basic: 0
+  stable9: 0
 profile: stanford_profile
 _core:
   default_config_hash: R4IF-ClDHXxblLcG0L7MgsLvfBIMAvi_skumNFQwkDc

--- a/config/sync/stanford_basic.settings.yml
+++ b/config/sync/stanford_basic.settings.yml
@@ -19,3 +19,4 @@ lockup:
   line3: ''
   line4: ''
   line5: ''
+nav_dropdown_enabled: 1

--- a/config/sync/views.view.stanford_basic_pages.yml
+++ b/config/sync/views.view.stanford_basic_pages.yml
@@ -13,7 +13,6 @@ dependencies:
     - paragraphs
     - stanford_fields
     - stanford_media
-    - taxonomy
     - ui_patterns_views
     - user
     - views_taxonomy_term_name_depth
@@ -73,9 +72,9 @@ display:
         options:
           default_field_elements: 0
           inline:
-            term_node_tid: 0
             title: 0
             su_page_description: 0
+            su_banner_image: 0
             su_page_image: 0
             edit_node: 0
           separator: ''
@@ -93,94 +92,27 @@ display:
             lockup: a
             media: default
           pattern_mapping:
-            'views_row:term_node_tid':
-              destination: category
-              weight: 0
-              plugin: views_row
-              source: term_node_tid
             'views_row:title':
               destination: title
-              weight: 1
+              weight: 0
               plugin: views_row
               source: title
             'views_row:su_page_description':
               destination: description
-              weight: 2
+              weight: 1
               plugin: views_row
               source: su_page_description
             'views_row:su_page_image':
               destination: page_image
-              weight: 3
+              weight: 2
               plugin: views_row
               source: su_page_image
             'views_row:edit_node':
               destination: footer
-              weight: 4
+              weight: 3
               plugin: views_row
               source: edit_node
       fields:
-        term_node_tid:
-          id: term_node_tid
-          table: node_field_data
-          field: term_node_tid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          type: separator
-          separator: ', '
-          link_to_taxonomy: false
-          limit: true
-          vids:
-            basic_page_types: basic_page_types
-            cap_org_codes: '0'
-            event_audience: '0'
-            stanford_event_types: '0'
-            stanford_news_topics: '0'
-            stanford_person_types: '0'
-            stanford_publication_topics: '0'
-          entity_type: node
-          plugin_id: taxonomy_index_tid
         title:
           id: title
           table: node_field_data

--- a/tests/codeception/acceptance/Paragraphs/ListsCest.php
+++ b/tests/codeception/acceptance/Paragraphs/ListsCest.php
@@ -454,7 +454,8 @@ class ListsCest {
 
 
     $I->amOnPage($node->toUrl()->toString());
-    $I->canSee($type_term->label());
+    $I->canSee($basic_page_entity->label());
+    $I->cantSee($type_term->label());
   }
 
   /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removed the taxonomy term on list displays

# Need Review By (Date)
- 11/19

# Urgency
- medium

# Steps to Test
1. checkout this branch
2. `drush cim -y` or `blt drupal:update` or `blt drupal:install`
3. create a couple basic pages and tag them with some terms
4. create a list page of basic pages
5. verify you don't see the taxonomy term on the list itmes.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
