### PR TITLE
D8CORE-4860 Wrap publication importer body text in <p>

### DIFF
--- a/config/sync/migrate_plus.migration.stanford_publications.yml
+++ b/config/sync/migrate_plus.migration.stanford_publications.yml
@@ -25,6 +25,8 @@ source:
     minimal_html: stanford_minimal_html
     alt: ''
     file_destination: 'public://media/publications/'
+    open_paragraph: '<p>'
+    close_paragraph: '</p>'
   fields:
     -
       name: id
@@ -141,10 +143,31 @@ process:
       bundle: stanford_publication_topics
       value_key: name
       ignore_case: true
-  su_publication_text_area:
+  text_body:
     -
       plugin: skip_on_empty
       source: body
+      method: process
+    -
+      plugin: concat
+      source:
+        - constants/open_paragraph
+        - body
+        - constants/close_paragraph
+    -
+      plugin: str_replace
+      search: '/^<p></'
+      replace: '<'
+      regex: true
+    -
+      plugin: str_replace
+      search: '/><\/p>$/'
+      replace: '>'
+      regex: true
+  su_publication_text_area:
+    -
+      plugin: skip_on_empty
+      source: '@text_body'
       method: process
     -
       plugin: entity_revision_generate
@@ -154,7 +177,7 @@ process:
       value_key: su_wysiwyg_text
       ignore_case: true
       values:
-        su_wysiwyg_text/value: body
+        su_wysiwyg_text/value: '@text_body'
         su_wysiwyg_text/format: constants/basic_html
   text_area_target_id:
     -


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- When importing publications, wrap the body text in a `<p>` tag to format the text correctly. But only do that if the imported content isn't already wrapped in html.

# Need Review By (Date)
- 11/19

# Urgency
- high

# Steps to Test
1. checkout this branch
2. `drush cim -y` or `blt drupal:update` or `blt drupal:install`
3. go to `/admin/structure/migrate/manage/default/migrations/stanford_publications/csv-upload` and upload a csv with some body text
4. view the node that was created and verify the body text is wrapped in a `<p>` tag.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
