### PR TITLE
D8CORE-4677 Use an access token to fetch stanford-only profile images from CAP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -165,6 +165,7 @@
         "su-sws/stanford_events": "dev-8.x-1.x",
         "su-sws/stanford_fields": "dev-8.x-1.x",
         "su-sws/stanford_image_styles": "dev-8.x-1.x",
+        "su-sws/stanford_media": "dev-D8CORE-4677 as 8.x-1.x",
         "su-sws/stanford_news": "dev-8.x-2.x",
         "su-sws/stanford_notifications": "dev-8.x-1.x",
         "su-sws/stanford_person": "dev-8.x-1.x",

--- a/composer.json
+++ b/composer.json
@@ -165,7 +165,7 @@
         "su-sws/stanford_events": "dev-8.x-1.x",
         "su-sws/stanford_fields": "dev-8.x-1.x",
         "su-sws/stanford_image_styles": "dev-8.x-1.x",
-        "su-sws/stanford_media": "dev-D8CORE-4677 as 8.x-1.x",
+        "su-sws/stanford_migrate": "dev-D8CORE-4677 as dev-8.x-1.x",
         "su-sws/stanford_news": "dev-8.x-2.x",
         "su-sws/stanford_notifications": "dev-8.x-1.x",
         "su-sws/stanford_person": "dev-8.x-1.x",

--- a/composer.json
+++ b/composer.json
@@ -165,7 +165,6 @@
         "su-sws/stanford_events": "dev-8.x-1.x",
         "su-sws/stanford_fields": "dev-8.x-1.x",
         "su-sws/stanford_image_styles": "dev-8.x-1.x",
-        "su-sws/stanford_migrate": "dev-D8CORE-4677 as dev-8.x-1.x",
         "su-sws/stanford_news": "dev-8.x-2.x",
         "su-sws/stanford_notifications": "dev-8.x-1.x",
         "su-sws/stanford_person": "dev-8.x-1.x",

--- a/config/sync/migrate_plus.migration.su_stanford_person.yml
+++ b/config/sync/migrate_plus.migration.su_stanford_person.yml
@@ -20,6 +20,7 @@ source:
     link_text: 'View Full Stanford Profile'
     file_destination: 'public://media/person/'
     file_extension: .jpg
+    photo_params: '?placeHolderImage=false&access_token='
   urls: {  }
   item_selector: values
   fields:
@@ -67,6 +68,10 @@ source:
       name: profile_photo
       label: 'Profile Photo'
       selector: profilePhotos/bigger/url
+    -
+      name: large_profile_photo
+      label: 'Large Profile Photo'
+      selector: 'profilePhotos/350x522/url'
     -
       name: appointments
       label: 'Administrative Appointments'
@@ -187,7 +192,7 @@ process:
       replace: ''
     -
       plugin: concat
-  image_path:
+  photo_destination:
     plugin: concat
     source:
       - constants/file_destination
@@ -195,11 +200,19 @@ process:
       - separator
       - '@image_timestamp'
       - constants/file_extension
+  cap_token:
+    plugin: oauth2_access_token
+  photo_source:
+    plugin: concat
+    source:
+      - large_profile_photo
+      - constants/photo_params
+      - '@cap_token'
   image_file:
     -
       plugin: skip_on_empty
       method: process
-      source: profile_photo
+      source: '@photo_source'
     -
       plugin: image_dimension_skip
       method: process
@@ -207,7 +220,7 @@ process:
       height: 10
     -
       plugin: file_import
-      destination: '@image_path'
+      destination: '@photo_destination'
       id_only: true
       reuse: true
   su_person_photo/target_id:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Download stanford-only profile photos using the access_token.

# Need Review By (Date)
- 11/19

# Urgency
- high

# Steps to Test
1. checkout this branch.
2. checkout the same branch in https://github.com/SU-SWS/stanford_migrate/pull/42
3. `blt drupal:update`
4. Use public cap credentials. (see me for what those are) and enter those on `/admin/config/importers/person-importer`
5. use my sunet to import on that page with the credentials
6. import the profile `drush mim su_stanford_person`
7. view the created content and verify it uses the default image
8. switch the cap credentials to stanford-only credentials. (see me for what those are)
9. update the content `drush mim su_stanford_person --update`
10. view the content from earlier and verify the image was imported.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
