### PR TITLE
D8CORE-5193 Configure localist importer to forget about old events

### DIFF
--- a/config/sync/migrate_plus.migration.stanford_localist_importer.yml
+++ b/config/sync/migrate_plus.migration.stanford_localist_importer.yml
@@ -18,6 +18,7 @@ source:
   urls: {  }
   data_parser_plugin: json
   item_selector: events
+  orphan_action: forget
   fields:
     -
       name: id


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Forget about events if they are no longer in the feed.
- https://github.com/SU-SWS/stanford_migrate/pull/47

# Need Review By (Date)
- 1/20

# Urgency
- medium

# Steps to Test
1. follow the steps in https://github.com/SU-SWS/stanford_migrate/pull/47

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
