### PR TITLE
Fix pathauto parent path generation

### DIFF
--- a/config/sync/pathauto.pattern.default.yml
+++ b/config/sync/pathauto.pattern.default.yml
@@ -7,7 +7,7 @@ dependencies:
 id: default
 label: Default
 type: 'canonical_entities:node'
-pattern: '[node:menu-link:parents:join-path]/[node:title]'
+pattern: '[node:menu-link:parent:url:relative]/[node:title]'
 selection_criteria: {  }
 selection_logic: and
 weight: 0

--- a/tests/codeception/acceptance/Content/BasicPageCest.php
+++ b/tests/codeception/acceptance/Content/BasicPageCest.php
@@ -12,20 +12,25 @@ class BasicPageCest {
 
   /**
    * Test placing a basic page in the menu with a child menu item.
+   *
+   * @group pathauto
    */
   public function testCreatingPage(AcceptanceTester $I) {
     $faker = Factory::create();
     $node_title = $faker->text(20);
 
-    $I->logInWithRole('contributor');
+    $I->logInWithRole('site_manager');
     $I->amOnPage('/node/add/stanford_page');
     $I->fillField('Title', $node_title);
     $I->checkOption('Provide a menu link');
     $I->fillField('Menu link title', "$node_title Item");
     // The label on the menu parent changes in D9 vs D8
     $I->selectOption('Parent link', ' <Main navigation>');
+    $I->uncheckOption('Generate automatic URL alias');
+    $I->fillField('URL alias', '/foo-bar');
     $I->click('Save');
     $I->canSeeLink("$node_title Item");
+    $I->assertStringContainsString('/foo-bar', $I->grabFromCurrentUrl());
 
     $child_title = $faker->text('15');
 
@@ -37,6 +42,7 @@ class BasicPageCest {
     $I->click('Change parent (update list of weights)');
     $I->click('Save');
     $I->canSeeLink("$child_title Item");
+    $I->assertStringContainsString('/foo-bar', $I->grabFromCurrentUrl());
   }
 
   /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed path auto pattern when the parent has a custom url path

# Need Review By (Date)
- 2/30

# Urgency
- medium

# Steps to Test
1. You can view the test or...
2. checkout this branch
3. `drush cim -y`
4. create a page and put it in the main menu but configure a custom url path for the page
5. create another page and put it in the menu below the other page, don't configure a custom url
6. after saving, verify the child page has the same custom url path from the parent.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
