### PR TITLE
preg_replace of null is deprecated in php 8, use strings

### DIFF
--- a/src/Config/ConfigOverrides.php
+++ b/src/Config/ConfigOverrides.php
@@ -110,7 +110,7 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
    *   Is Acquia environment.
    */
   protected function isProdEnv() {
-    $ah_env = $_ENV['AH_SITE_ENVIRONMENT'] ?? NULL;
+    $ah_env = $_ENV['AH_SITE_ENVIRONMENT'] ?? '';
     return $ah_env == 'prod' || preg_match('/^\d*live$/', $ah_env);
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- ensure `preg_replace` subject is a string for php 8.1

# Need Review By (Date)
- 

# Urgency
- 

# Steps to Test

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
