### PR TITLE
D8CORE-4974 Added a third content block for the local footer

### DIFF
--- a/config/sync/core.entity_form_display.config_pages.stanford_local_footer.default.yml
+++ b/config/sync/core.entity_form_display.config_pages.stanford_local_footer.default.yml
@@ -27,6 +27,7 @@ dependencies:
     - field.field.config_pages.stanford_local_footer.su_local_foot_second_h
     - field.field.config_pages.stanford_local_footer.su_local_foot_social
     - field.field.config_pages.stanford_local_footer.su_local_foot_sunet_t
+    - field.field.config_pages.stanford_local_footer.su_local_foot_tr2_co
     - field.field.config_pages.stanford_local_footer.su_local_foot_tr_co
     - field.field.config_pages.stanford_local_footer.su_local_foot_use_loc
     - field.field.config_pages.stanford_local_footer.su_local_foot_use_logo
@@ -138,6 +139,7 @@ third_party_settings:
       children:
         - su_local_foot_pr_co
         - su_local_foot_se_co
+        - su_local_foot_tr2_co
         - su_local_foot_tr_co
       label: 'Content Blocks'
       region: content
@@ -332,9 +334,17 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  su_local_foot_tr_co:
+  su_local_foot_tr2_co:
     type: text_textarea
     weight: 19
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  su_local_foot_tr_co:
+    type: text_textarea
+    weight: 20
     region: content
     settings:
       rows: 5

--- a/config/sync/core.entity_view_display.config_pages.stanford_local_footer.default.yml
+++ b/config/sync/core.entity_view_display.config_pages.stanford_local_footer.default.yml
@@ -27,6 +27,7 @@ dependencies:
     - field.field.config_pages.stanford_local_footer.su_local_foot_second_h
     - field.field.config_pages.stanford_local_footer.su_local_foot_social
     - field.field.config_pages.stanford_local_footer.su_local_foot_sunet_t
+    - field.field.config_pages.stanford_local_footer.su_local_foot_tr2_co
     - field.field.config_pages.stanford_local_footer.su_local_foot_tr_co
     - field.field.config_pages.stanford_local_footer.su_local_foot_use_loc
     - field.field.config_pages.stanford_local_footer.su_local_foot_use_logo
@@ -54,6 +55,7 @@ third_party_settings:
         - su_local_foot_pr_co
       cell2:
         - su_local_foot_se_co
+        - su_local_foot_tr2_co
       cell3:
         - su_local_foot_tr_co
       address:
@@ -105,14 +107,14 @@ content:
         class: ''
       ds:
         ds_limit: ''
-    weight: 5
+    weight: 6
     region: action_links
   su_local_foot_address:
     type: address_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 4
+    weight: 5
     region: address
   su_local_foot_f_button:
     type: string
@@ -120,21 +122,21 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 14
+    weight: 15
     region: signup_form_field_submit_value
   su_local_foot_f_intro:
     type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 11
+    weight: 12
     region: signup_form_content
   su_local_foot_f_method:
     type: list_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 13
+    weight: 14
     region: signup_form_method
   su_local_foot_f_url:
     type: link
@@ -148,7 +150,7 @@ content:
     third_party_settings:
       field_formatter_class:
         class: ''
-    weight: 12
+    weight: 13
     region: signup_form_action
   su_local_foot_pr_co:
     type: text_default
@@ -171,7 +173,7 @@ content:
         class: ''
       ds:
         ds_limit: ''
-    weight: 8
+    weight: 9
     region: primary_links
   su_local_foot_prime_h:
     type: string
@@ -179,7 +181,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 7
+    weight: 8
     region: primary_links_header
   su_local_foot_se_co:
     type: text_default
@@ -202,7 +204,7 @@ content:
         class: ''
       ds:
         ds_limit: ''
-    weight: 10
+    weight: 11
     region: secondary_links
   su_local_foot_second_h:
     type: string
@@ -210,7 +212,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 9
+    weight: 10
     region: secondary_links_header
   su_local_foot_social:
     type: link
@@ -226,7 +228,7 @@ content:
         class: ''
       ds:
         ds_limit: ''
-    weight: 6
+    weight: 7
     region: social_links
   su_local_foot_sunet_t:
     type: string
@@ -234,14 +236,21 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 15
+    weight: 16
     region: weblogin_text
-  su_local_foot_tr_co:
+  su_local_foot_tr2_co:
     type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
     weight: 3
+    region: cell2
+  su_local_foot_tr_co:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
     region: cell3
 hidden:
   search_api_excerpt: true

--- a/config/sync/field.field.config_pages.stanford_local_footer.su_local_foot_pr_co.yml
+++ b/config/sync/field.field.config_pages.stanford_local_footer.su_local_foot_pr_co.yml
@@ -10,14 +10,12 @@ dependencies:
     - text
 third_party_settings:
   allowed_formats:
-    stanford_minimal_html: stanford_minimal_html
-    stanford_html: '0'
-    plain_text: '0'
+    allowed_formats: {  }
 id: config_pages.stanford_local_footer.su_local_foot_pr_co
 field_name: su_local_foot_pr_co
 entity_type: config_pages
 bundle: stanford_local_footer
-label: 'Primary Content'
+label: 'First Content Block'
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.config_pages.stanford_local_footer.su_local_foot_se_co.yml
+++ b/config/sync/field.field.config_pages.stanford_local_footer.su_local_foot_se_co.yml
@@ -10,14 +10,12 @@ dependencies:
     - text
 third_party_settings:
   allowed_formats:
-    stanford_minimal_html: stanford_minimal_html
-    stanford_html: '0'
-    plain_text: '0'
+    allowed_formats: {  }
 id: config_pages.stanford_local_footer.su_local_foot_se_co
 field_name: su_local_foot_se_co
 entity_type: config_pages
 bundle: stanford_local_footer
-label: 'Secondary Content'
+label: 'Second Content Block'
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.config_pages.stanford_local_footer.su_local_foot_tr2_co.yml
+++ b/config/sync/field.field.config_pages.stanford_local_footer.su_local_foot_tr2_co.yml
@@ -1,21 +1,21 @@
-uuid: e90c0c80-f6da-4f2e-a889-3f5f4c56d80b
+uuid: f7aa78ee-616e-46c7-b521-4f5824eca15f
 langcode: en
 status: true
 dependencies:
   config:
     - config_pages.type.stanford_local_footer
-    - field.storage.config_pages.su_local_foot_tr_co
+    - field.storage.config_pages.su_local_foot_tr2_co
   module:
     - allowed_formats
     - text
 third_party_settings:
   allowed_formats:
     allowed_formats: {  }
-id: config_pages.stanford_local_footer.su_local_foot_tr_co
-field_name: su_local_foot_tr_co
+id: config_pages.stanford_local_footer.su_local_foot_tr2_co
+field_name: su_local_foot_tr2_co
 entity_type: config_pages
 bundle: stanford_local_footer
-label: 'Fourth Content Block'
+label: 'Third Content Block'
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.storage.config_pages.su_local_foot_tr2_co.yml
+++ b/config/sync/field.storage.config_pages.su_local_foot_tr2_co.yml
@@ -1,0 +1,19 @@
+uuid: 218e811e-47c8-435c-badd-629e2c4033ff
+langcode: en
+status: true
+dependencies:
+  module:
+    - config_pages
+    - text
+id: config_pages.su_local_foot_tr2_co
+field_name: su_local_foot_tr2_co
+entity_type: config_pages
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added a "third" content block for the local footer.

# Need Review By (Date)
- 3/5

# Urgency
- medium

# Steps to Test
1. checkout this branch and the branch from https://github.com/SU-SWS/stanford_profile_helper/pull/175
2. `drush cim -y`
3. edit the local footer and populate the 4 content blocks
4. view the local footer on all breakpoints
5. see that it looks as you'd expect. (the order of the items changes at different breakpoints. Not much we can do with that)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
