### PR TITLE
D8CORE-5180 D8CORE-5227 Remove alt text on people images

### DIFF
--- a/config/sync/core.entity_view_display.node.stanford_person.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_person.default.yml
@@ -217,6 +217,7 @@ third_party_settings:
                   view_mode: default
                   link: false
                   image_style: medium_square
+                  remove_alt: true
                 third_party_settings:
                   field_formatter_class:
                     class: su-person-photo

--- a/config/sync/views.view.stanford_person.yml
+++ b/config/sync/views.view.stanford_person.yml
@@ -701,34 +701,34 @@ display:
           group_type: group
           admin_label: ''
           label: ''
-          exclude: true
+          exclude: 1
           alter:
-            alter_text: false
+            alter_text: 0
             text: ''
-            make_link: false
+            make_link: 0
             path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
+            absolute: 0
+            external: 0
+            replace_spaces: 0
             path_case: none
-            trim_whitespace: false
+            trim_whitespace: 0
             alt: ''
             rel: ''
             link_class: ''
             prefix: ''
             suffix: ''
             target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
+            nl2br: 0
+            max_length: '0'
+            word_boundary: 1
+            ellipsis: 1
+            more_link: 0
             more_link_text: ''
             more_link_path: ''
-            strip_tags: false
-            trim: false
+            strip_tags: 0
+            trim: 0
             preserve_tags: ''
-            html: false
+            html: 0
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -736,17 +736,18 @@ display:
           element_label_colon: false
           element_wrapper_type: ''
           element_wrapper_class: ''
-          element_default_classes: true
+          element_default_classes: 1
           empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
+          hide_empty: 0
+          empty_zero: 0
+          hide_alter_empty: 1
           click_sort_column: target_id
           type: media_image_formatter
           settings:
             view_mode: default
             image_style: stanford_circle
-            link: false
+            link: 0
+            remove_alt: 1
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -756,7 +757,7 @@ display:
           delta_first_last: false
           multi_type: separator
           separator: ', '
-          field_api_classes: false
+          field_api_classes: 0
           plugin_id: field
         title:
           id: title


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Remove alt text on images on the people node page and the people lists


# Need Review By (Date)
- 3/5

# Urgency
- medium

# Steps to Test
1. Checkout this branch & the branch in https://github.com/SU-SWS/stanford_media/pull/118
2. clear caches and import configs `drush cr; drush cim -y`
3. create a person node with an image. Populate the alt text on the image when uploading
4. view the person node page and verify the image has an empty alt text `alt=""`
5. view the people list page `/people` and verify the same empty alt attribute.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
