### PR TITLE
Process Localist html to fix <img> tag styles to attributes

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -36,6 +36,7 @@ module:
   core_event_dispatcher: 0
   crop: 0
   ctools: 0
+  ctools_views: 0
   datetime: 0
   datetime_range: 0
   default_content: 0

--- a/config/sync/filter.format.stanford_html.yml
+++ b/config/sync/filter.format.stanford_html.yml
@@ -57,7 +57,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <em> <strong> <cite> <blockquote cite> <pre class> <code data-* class> <ul type class id> <ol start type class id> <li class id> <dl class> <dt> <dd class> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <div class id> <table class id> <caption> <tbody class> <thead> <tfoot> <th scope class id> <td colspan rowspan class id> <tr id> <sup> <sub> <i class> <hr> <s> <aside class> <drupal-media data-entity-type data-entity-uuid data-align data-caption data-* alt data-view-mode title> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title name class> <p class id> <img class src alt title>'
+      allowed_html: '<br> <b> <em> <strong> <cite> <blockquote cite> <pre class> <code data-* class> <ul type class id> <ol start type class id> <li class id> <dl class> <dt> <dd class> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <div class id> <table class id> <caption> <tbody class> <thead> <tfoot> <th scope class id> <td colspan rowspan class id> <tr id> <sup> <sub> <i class> <hr> <s> <aside class> <drupal-media data-entity-type data-entity-uuid data-align data-caption data-* alt data-view-mode title> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title name class> <p class id> <img class src alt title>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_htmlcorrector:

--- a/config/sync/migrate_plus.migration.stanford_localist_importer.yml
+++ b/config/sync/migrate_plus.migration.stanford_localist_importer.yml
@@ -290,7 +290,16 @@ process:
   status: constants/status
   type: constants/type
   title: title
-  body/value: description
+  body/value:
+    -
+      plugin: skip_on_empty
+      source: description
+      method: process
+    -
+      plugin: str_replace
+      regex: true
+      search: '/style=.*height:(.*)px.*width:(.*)px.*?"/'
+      replace: 'height="$1" width="$2"'
   body/format: constants/stanford_html
   su_event_alt_loc: location_name
   su_event_map_link/uri:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Localist allows <img> tags but uses `style="height: ##px width: ##px"` instead of using height width attributes. Convert the style to attributes.

# Need Review By (Date)
- 3/15

# Urgency
- medium

# Steps to Test
1. checkout this branch
2. `drush cim -y`
3. import SWS localist events
4. view the test event display and verify the height/width attributes are used.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
