### PR TITLE
D8CORE-4704 Fix person list to show nested content

### DIFF
--- a/config/sync/views.view.stanford_person_list_terms_first.yml
+++ b/config/sync/views.view.stanford_person_list_terms_first.yml
@@ -504,58 +504,15 @@ display:
             field_identifier: su_person_first_name_value
           exposed: false
       arguments:
-        parent_target_id:
-          id: parent_target_id
-          table: taxonomy_term__parent
-          field: parent_target_id
-          relationship: none
+        term_node_tid_depth:
+          id: term_node_tid_depth
+          table: node_field_data
+          field: term_node_tid_depth
+          relationship: reverse__node__su_person_type_group
           group_type: group
           admin_label: ''
-          entity_type: taxonomy_term
-          entity_field: parent
-          plugin_id: taxonomy
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: taxonomy_tid
-          default_argument_options:
-            term_page: '1'
-            node: true
-            limit: false
-            vids:
-              stanford_person_types: stanford_person_types
-            anyall: +
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            override: false
-            items_per_page: 25
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: true
-          not: false
-        tid:
-          id: tid
-          table: taxonomy_term_field_data
-          field: tid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: taxonomy_term
-          entity_field: tid
-          plugin_id: taxonomy
+          entity_type: node
+          plugin_id: taxonomy_index_tid_depth
           default_action: default
           exception:
             value: all
@@ -570,7 +527,7 @@ display:
             limit: true
             vids:
               stanford_person_types: stanford_person_types
-            anyall: +
+            anyall: ','
           default_argument_skip_url: false
           summary_options:
             base_path: ''
@@ -586,8 +543,9 @@ display:
             type: none
             fail: 'not found'
           validate_options: {  }
-          break_phrase: true
-          not: false
+          break_phrase: false
+          depth: 10
+          use_taxonomy_term_path: false
       filters:
         status:
           id: status

--- a/tests/codeception/acceptance/Content/PersonCest.php
+++ b/tests/codeception/acceptance/Content/PersonCest.php
@@ -120,6 +120,8 @@ class PersonCest {
 
   /**
    * D8CORE-2613: Taxonomy menu items don't respect the UI.
+   *
+   * @group 4704
    */
   public function testD8Core2613Terms(AcceptanceTester $I) {
     $I->logInWithRole('site_manager');
@@ -156,6 +158,43 @@ class PersonCest {
 
     $I->amOnPage('/people');
     $I->cantSeeLink('Baz');
+
+    $faker = Factory::create();
+    $parent = $I->createEntity([
+      'name' =>'Parent: '. $faker->text(10),
+      'vid' => 'stanford_person_types',
+    ], 'taxonomy_term');
+    $child = $I->createEntity([
+      'name' => 'Child: '.$faker->text(10),
+      'vid' => 'stanford_person_types',
+      'parent' => $parent->id(),
+    ], 'taxonomy_term');
+    $grandchild = $I->createEntity([
+      'name' => 'GrandChild: '.$faker->text(10),
+      'vid' => 'stanford_person_types',
+      'parent' => $child->id(),
+    ], 'taxonomy_term');
+    $great_grandchild = $I->createEntity([
+      'name' =>'Great GrandChild: '. $faker->text(10),
+      'vid' => 'stanford_person_types',
+      'parent' => $grandchild->id(),
+    ], 'taxonomy_term');
+
+    $node = $I->createEntity([
+      'type' => 'stanford_person',
+      'su_person_first_name' => $faker->firstName,
+      'su_person_last_name' => $faker->lastName,
+      'su_person_type_group' => $great_grandchild->id(),
+    ]);
+
+    $I->amOnPage($great_grandchild->toUrl()->toString());
+    $I->canSee($node->label());
+    $I->amOnPage($grandchild->toUrl()->toString());
+    $I->canSee($node->label());
+    $I->amOnPage($child->toUrl()->toString());
+    $I->canSee($node->label());
+    $I->amOnPage($parent->toUrl()->toString());
+    $I->canSee($node->label());
   }
 
   /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Display content tagged with nested taxonomy terms over the 2nd level


# Need Review By (Date)
- 3/16

# Urgency
- medium

# Steps to Test
1. checkout this branch
2. import configs `drush cim -y`
3. create a people type taxonomy term at at least a 3rd level deep.
4. create a person content and tag it with that term you created
5. view the `/people` page
6. see your piece of content
7. click on the parent most term of the term you created
8. see your piece of content again.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
