### PR TITLE
Enable minimally branded theme for easier switching

### DIFF
--- a/config/sync/block.block.minimally_branded_subtheme_branding.yml
+++ b/config/sync/block.block.minimally_branded_subtheme_branding.yml
@@ -1,0 +1,23 @@
+uuid: 7ca2a9f5-f4b9-4640-be29-7f5fbe4cb380
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - minimally_branded_subtheme
+id: minimally_branded_subtheme_branding
+theme: minimally_branded_subtheme
+region: header
+weight: 0
+provider: null
+plugin: system_branding_block
+settings:
+  id: system_branding_block
+  label: 'Site branding'
+  label_display: '0'
+  provider: system
+  use_site_logo: true
+  use_site_name: true
+  use_site_slogan: true
+visibility: {  }

--- a/config/sync/block.block.minimally_branded_subtheme_config_pages.yml
+++ b/config/sync/block.block.minimally_branded_subtheme_config_pages.yml
@@ -1,0 +1,29 @@
+uuid: 6619906c-e614-4f1f-8a12-d023a1c76482
+langcode: en
+status: true
+dependencies:
+  module:
+    - config_pages
+  theme:
+    - minimally_branded_subtheme
+id: minimally_branded_subtheme_config_pages
+theme: minimally_branded_subtheme
+region: footer
+weight: 0
+provider: null
+plugin: config_pages_block
+settings:
+  config_page_type: stanford_local_footer
+  config_page_view_mode: full
+  id: config_pages_block
+  label: 'Local Footer'
+  label_display: '0'
+  provider: config_pages
+visibility:
+  config_pages_values_access:
+    id: config_pages_values_access
+    negate: false
+    context_mapping: {  }
+    config_page_field: stanford_local_footer|su_footer_enabled|boolean
+    operator: '=='
+    condition_value: '1'

--- a/config/sync/block.block.minimally_branded_subtheme_config_pages_stanford_global_msg.yml
+++ b/config/sync/block.block.minimally_branded_subtheme_config_pages_stanford_global_msg.yml
@@ -1,0 +1,29 @@
+uuid: cefa00f2-f9dd-44ab-8aef-6c8e78f556ad
+langcode: en
+status: true
+dependencies:
+  module:
+    - config_pages
+  theme:
+    - minimally_branded_subtheme
+id: minimally_branded_subtheme_config_pages_stanford_global_msg
+theme: minimally_branded_subtheme
+region: help
+weight: 0
+provider: null
+plugin: config_pages_block
+settings:
+  config_page_type: stanford_global_message
+  config_page_view_mode: full
+  id: config_pages_block
+  label: 'Global Messages'
+  label_display: 0
+  provider: config_pages
+visibility:
+  config_pages_values_access:
+    id: config_pages_values_access
+    negate: false
+    context_mapping: {  }
+    config_page_field: stanford_global_message|su_global_msg_enabled|boolean
+    operator: '=='
+    condition_value: '1'

--- a/config/sync/block.block.minimally_branded_subtheme_config_pages_stanford_super_footer.yml
+++ b/config/sync/block.block.minimally_branded_subtheme_config_pages_stanford_super_footer.yml
@@ -1,0 +1,29 @@
+uuid: 57100965-ae77-43a5-be4c-c71f21092c47
+langcode: en
+status: true
+dependencies:
+  module:
+    - config_pages
+  theme:
+    - minimally_branded_subtheme
+id: minimally_branded_subtheme_config_pages_stanford_super_footer
+theme: minimally_branded_subtheme
+region: footer
+weight: -4
+provider: null
+plugin: config_pages_block
+settings:
+  config_page_type: stanford_super_footer
+  config_page_view_mode: full
+  id: config_pages_block
+  label: 'Super Footer'
+  label_display: 0
+  provider: config_pages
+visibility:
+  config_pages_values_access:
+    id: config_pages_values_access
+    negate: false
+    context_mapping: {  }
+    config_page_field: stanford_super_footer|su_super_foot_enabled|boolean
+    operator: '=='
+    condition_value: '1'

--- a/config/sync/block.block.minimally_branded_subtheme_content.yml
+++ b/config/sync/block.block.minimally_branded_subtheme_content.yml
@@ -1,0 +1,20 @@
+uuid: 27fb3d93-a4dd-4900-8cd2-1daebbf9b8b3
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - minimally_branded_subtheme
+id: minimally_branded_subtheme_content
+theme: minimally_branded_subtheme
+region: content
+weight: -1
+provider: null
+plugin: system_main_block
+settings:
+  id: system_main_block
+  label: 'Main page content'
+  label_display: '0'
+  provider: system
+visibility: {  }

--- a/config/sync/block.block.minimally_branded_subtheme_help.yml
+++ b/config/sync/block.block.minimally_branded_subtheme_help.yml
@@ -1,0 +1,20 @@
+uuid: 8e2a9c51-2496-4910-a99b-629d74c86901
+langcode: en
+status: true
+dependencies:
+  module:
+    - help
+  theme:
+    - minimally_branded_subtheme
+id: minimally_branded_subtheme_help
+theme: minimally_branded_subtheme
+region: help
+weight: 0
+provider: null
+plugin: help_block
+settings:
+  id: help_block
+  label: Help
+  label_display: '0'
+  provider: help
+visibility: {  }

--- a/config/sync/block.block.minimally_branded_subtheme_local_tasks.yml
+++ b/config/sync/block.block.minimally_branded_subtheme_local_tasks.yml
@@ -1,0 +1,20 @@
+uuid: 75a66db9-107b-46e6-80b5-a24bb25b40a6
+langcode: en
+status: true
+dependencies:
+  theme:
+    - minimally_branded_subtheme
+id: minimally_branded_subtheme_local_tasks
+theme: minimally_branded_subtheme
+region: content
+weight: -3
+provider: null
+plugin: local_tasks_block
+settings:
+  id: local_tasks_block
+  label: Tabs
+  label_display: '0'
+  provider: core
+  primary: true
+  secondary: true
+visibility: {  }

--- a/config/sync/block.block.minimally_branded_subtheme_main_navigation.yml
+++ b/config/sync/block.block.minimally_branded_subtheme_main_navigation.yml
@@ -1,0 +1,25 @@
+uuid: aaa1edf0-1ac4-403a-9f65-8f22454bd7a5
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.main
+  module:
+    - system
+  theme:
+    - minimally_branded_subtheme
+id: minimally_branded_subtheme_main_navigation
+theme: minimally_branded_subtheme
+region: menu
+weight: 0
+provider: null
+plugin: 'system_menu_block:main'
+settings:
+  id: 'system_menu_block:main'
+  label: 'Main navigation'
+  label_display: '0'
+  provider: system
+  level: 1
+  depth: 0
+  expand_all_items: true
+visibility: {  }

--- a/config/sync/block.block.minimally_branded_subtheme_messages.yml
+++ b/config/sync/block.block.minimally_branded_subtheme_messages.yml
@@ -1,0 +1,20 @@
+uuid: bfa7a5eb-d9ed-4cba-83c1-5ae2ee80730a
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - minimally_branded_subtheme
+id: minimally_branded_subtheme_messages
+theme: minimally_branded_subtheme
+region: content
+weight: -5
+provider: null
+plugin: system_messages_block
+settings:
+  id: system_messages_block
+  label: Messages
+  label_display: '0'
+  provider: system
+visibility: {  }

--- a/config/sync/block.block.minimally_branded_subtheme_pagetitle.yml
+++ b/config/sync/block.block.minimally_branded_subtheme_pagetitle.yml
@@ -1,0 +1,31 @@
+uuid: 90f3ec5d-5630-40b2-88d9-17c17f257c93
+langcode: en
+status: true
+dependencies:
+  module:
+    - response_code_condition
+    - system
+  theme:
+    - minimally_branded_subtheme
+id: minimally_branded_subtheme_pagetitle
+theme: minimally_branded_subtheme
+region: content
+weight: -4
+provider: null
+plugin: page_title_block
+settings:
+  id: page_title_block
+  label: 'Page title'
+  label_display: '0'
+  provider: core
+visibility:
+  request_path:
+    id: request_path
+    negate: true
+    context_mapping: {  }
+    pages: "/node/*\r\n/news*\r\n/people*\r\n/events*\r\n/event-series*\r\n/publications*"
+  response_code:
+    id: response_code
+    negate: true
+    context_mapping: {  }
+    response_codes: "404\r\n403"

--- a/config/sync/block.block.minimally_branded_subtheme_search.yml
+++ b/config/sync/block.block.minimally_branded_subtheme_search.yml
@@ -1,0 +1,30 @@
+uuid: 9676adb5-893b-4338-8e8a-e91bcf27c2f4
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.search
+  module:
+    - config_pages
+    - views
+  theme:
+    - minimally_branded_subtheme
+id: minimally_branded_subtheme_search
+theme: minimally_branded_subtheme
+region: search
+weight: 0
+provider: null
+plugin: 'views_exposed_filter_block:search-results'
+settings:
+  id: 'views_exposed_filter_block:search-results'
+  label: ''
+  label_display: '0'
+  provider: views
+  views_label: ''
+visibility:
+  config_pages_values_access:
+    id: config_pages_values_access
+    negate: false
+    config_page_field: stanford_basic_site_settings|su_hide_site_search|boolean
+    operator: '!='
+    condition_value: '1'

--- a/config/sync/block.block.minimally_branded_subtheme_search_form.yml
+++ b/config/sync/block.block.minimally_branded_subtheme_search_form.yml
@@ -1,0 +1,28 @@
+uuid: 22605c70-2bcf-487c-a355-94ec820e8c74
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.search
+  module:
+    - system
+    - views
+  theme:
+    - minimally_branded_subtheme
+id: minimally_branded_subtheme_search_form
+theme: minimally_branded_subtheme
+region: content
+weight: -2
+provider: null
+plugin: 'views_exposed_filter_block:search-results'
+settings:
+  id: 'views_exposed_filter_block:search-results'
+  label: ''
+  label_display: '0'
+  provider: views
+  views_label: ''
+visibility:
+  request_path:
+    id: request_path
+    negate: false
+    pages: /search

--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -5,6 +5,7 @@ ignored_config_entities:
   - 'system.theme:default'
   - '~block.block.seven_*'
   - '~block.block.stanford_basic_*'
+  - '~block.block.minimally_branded_subtheme_*'
   - 'block.block.*'
   - 'google_tag.container.*'
   - 'user.role.custm_*'

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -213,4 +213,5 @@ theme:
   seven: 0
   stanford_basic: 0
   stable9: 0
+  minimally_branded_subtheme: 0
 profile: stanford_profile

--- a/tests/codeception/acceptance/SubThemeCest.php
+++ b/tests/codeception/acceptance/SubThemeCest.php
@@ -100,7 +100,6 @@ class SubThemeCest {
    * @group minimal-subtheme-test
    */
   public function testMinimalSubtheme(AcceptanceTester $I) {
-    $I->runDrush('theme:enable -y minimally_branded_subtheme');
     $I->logInWithRole('administrator');
     $I->amOnPage('/admin/appearance');
     $I->click('Set as default', 'a[title="Set Stanford Minimally Branded Subtheme as default theme"]');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Enable minimally branded theme so devs don't have to do so via drush

# Need Review By (Date)
- 3/17

# Urgency
- high

# Steps to Test
1. checkout the `8.x-2.x` version of the profile
2. do a full site install
3. checkout this branch and the matching branch in https://github.com/SU-SWS/stanford_profile_helper/pull/185
4. do `drush deploy` 2 times
5. verify no errors
6. navigate to `/admin/appearance` and verify the them is available to set as default.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
