### PR TITLE
Configure layout builder restrictions consistently

### DIFF
--- a/config/sync/core.entity_view_display.node.stanford_event.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event.default.yml
@@ -528,65 +528,110 @@ third_party_settings:
   layout_library:
     enable: false
   layout_builder_restrictions:
-    allowed_block_categories: {  }
+    allowed_block_categories:
+      - 'Basic Page Type Lists (Views)'
+      - 'Chaos Tools'
+      - 'Config Pages'
+      - 'Content fields'
+      - 'Custom block types'
+      - 'Custom blocks'
+      - Devel
+      - 'Devel PHP'
+      - 'Events Lists (Views)'
+      - Forms
+      - Help
+      - 'Inline blocks'
+      - 'Jumpstart UI'
+      - 'Lists (Views)'
+      - Menus
+      - 'News Lists (Views)'
+      - 'PDB React'
+      - 'People Lists (Views)'
+      - 'Publication (Views)'
+      - React
+      - 'SimpleSAMLphp Authentication'
+      - 'Stanford News'
+      - 'Stanford Profile Helper'
+      - 'Stanford SimpleSAML PHP'
+      - System
+      - Views
+      - core
     entity_view_mode_restriction:
       allowed_layouts:
         - jumpstart_ui_one_column
-        - jumpstart_ui_one_column_overlay
         - jumpstart_ui_two_column
         - jumpstart_ui_three_column
-        - stanford_events_editorial_content
-        - stanford_events_body
-      blacklisted_blocks: {  }
-      whitelisted_blocks:
-        'Chaos Tools': {  }
-        'Config Pages': {  }
+      blacklisted_blocks:
         'Content fields':
-          - 'field_block:node:stanford_event:su_event_audience'
           - 'field_block:node:stanford_event:uid'
           - 'field_block:node:stanford_event:created'
-          - 'field_block:node:stanford_event:body'
-          - 'field_block:node:stanford_event:su_event_cta'
-          - 'field_block:node:stanford_event:changed'
-          - 'field_block:node:stanford_event:su_event_components'
-          - 'field_block:node:stanford_event:su_event_email'
-          - 'field_block:node:stanford_event:su_event_telephone'
-          - 'field_block:node:stanford_event:su_event_date_time'
-          - 'field_block:node:stanford_event:su_event_dek'
-          - 'field_block:node:stanford_event:su_event_alt_loc'
-          - 'field_block:node:stanford_event:title'
-          - 'field_block:node:stanford_event:su_event_type'
-          - 'field_block:node:stanford_event:su_event_source'
+          - 'field_block:node:stanford_event:type'
+          - 'field_block:node:stanford_event:revision_default'
+          - 'field_block:node:stanford_event:default_langcode'
           - 'field_block:node:stanford_event:nid'
+          - 'field_block:node:stanford_event:langcode'
           - 'extra_field_block:node:stanford_event:links'
-          - 'field_block:node:stanford_event:su_event_location'
-          - 'field_block:node:stanford_event:su_event_map_link'
           - 'field_block:node:stanford_event:menu_link'
+          - 'field_block:node:stanford_event:promote'
           - 'field_block:node:stanford_event:status'
-          - 'field_block:node:stanford_event:su_event_schedule'
-          - 'field_block:node:stanford_event:su_event_sponsor'
-          - 'field_block:node:stanford_event:su_event_subheadline'
-        Devel: {  }
-        'Devel PHP': {  }
-        Forms: {  }
-        'Lists (Views)': {  }
+          - 'field_block:node:stanford_event:rh_action'
+          - 'field_block:node:stanford_event:rh_redirect_fallback_action'
+          - 'field_block:node:stanford_event:rh_redirect'
+          - 'field_block:node:stanford_event:rh_redirect_response'
+          - 'field_block:node:stanford_event:revision_timestamp'
+          - 'field_block:node:stanford_event:vid'
+          - 'field_block:node:stanford_event:revision_log'
+          - 'field_block:node:stanford_event:revision_translation_affected'
+          - 'field_block:node:stanford_event:revision_uid'
+          - 'extra_field_block:node:stanford_event:search_api_excerpt'
+          - 'field_block:node:stanford_event:sticky'
+          - 'field_block:node:stanford_event:unpublish_on'
+          - 'field_block:user:user:changed'
+          - 'field_block:user:user:created'
+          - 'field_block:user:user:default_langcode'
+          - 'field_block:user:user:su_display_name'
+          - 'field_block:user:user:mail'
+          - 'field_block:user:user:init'
+          - 'field_block:user:user:langcode'
+          - 'field_block:user:user:access'
+          - 'field_block:user:user:login'
+          - 'extra_field_block:user:user:member_for'
+          - 'field_block:user:user:name'
+          - 'field_block:user:user:preferred_admin_langcode'
+          - 'field_block:user:user:preferred_langcode'
+          - 'field_block:user:user:role_change'
+          - 'field_block:user:user:roles'
+          - 'extra_field_block:user:user:search_api_excerpt'
+          - 'field_block:user:user:timezone'
+          - 'field_block:user:user:uid'
+          - 'field_block:user:user:status'
+      whitelisted_blocks:
         Menus:
           - 'menu_block:stanford-event-types'
+          - 'system_menu_block:stanford-event-types'
           - 'menu_block:main'
-        'News Lists (Views)':
-          - 'views_block:stanford_news-vertical_teaser_term'
-          - 'views_block:stanford_news-vertical_teaser_term_list'
-          - 'views_block:stanford_news-block_1'
-          - 'views_block:stanford_news-term_block'
-        'People Lists (Views)':
-          - 'views_block:stanford_person-grid_list_all'
-          - 'views_block:stanford_person_list_terms_first-person_list_grid'
-        'SimpleSAMLphp Authentication': {  }
-        'Stanford News': {  }
-        'Stanford SimpleSAML PHP': {  }
+          - 'system_menu_block:main'
+          - 'system_menu_block:stanford-person-type'
+          - 'menu_block:stanford-person-type'
+          - 'system_menu_block:stanford-publication-topics'
+          - 'menu_block:stanford-publication-topics'
+          - 'system_menu_block:news-topics'
+          - 'menu_block:news-topics'
         System:
-          - system_messages_block
-      restricted_categories: {  }
+          - system_breadcrumb_block
+        core:
+          - page_title_block
+      restricted_categories:
+        - 'Chaos Tools'
+        - 'Config Pages'
+        - Forms
+        - Help
+        - 'Lists (Views)'
+        - React
+        - 'SimpleSAMLphp Authentication'
+        - 'Stanford Profile Helper'
+        - 'Stanford SimpleSAML PHP'
+        - Views
 id: node.stanford_event.default
 targetEntityType: node
 bundle: stanford_event

--- a/config/sync/core.entity_view_display.node.stanford_event_series.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event_series.default.yml
@@ -177,52 +177,111 @@ third_party_settings:
   layout_library:
     enable: false
   layout_builder_restrictions:
-    allowed_block_categories: {  }
+    allowed_block_categories:
+      - 'Basic Page Type Lists (Views)'
+      - 'Chaos Tools'
+      - 'Config Pages'
+      - 'Content fields'
+      - 'Custom block types'
+      - 'Custom blocks'
+      - Devel
+      - 'Devel PHP'
+      - 'Events Lists (Views)'
+      - Forms
+      - Help
+      - 'Inline blocks'
+      - 'Jumpstart UI'
+      - 'Lists (Views)'
+      - Menus
+      - 'News Lists (Views)'
+      - 'PDB React'
+      - 'People Lists (Views)'
+      - 'Publication (Views)'
+      - React
+      - 'SimpleSAMLphp Authentication'
+      - 'Stanford News'
+      - 'Stanford Profile Helper'
+      - 'Stanford SimpleSAML PHP'
+      - System
+      - Views
+      - core
     entity_view_mode_restriction:
       allowed_layouts:
         - jumpstart_ui_one_column
         - jumpstart_ui_one_column_overlay
         - jumpstart_ui_two_column
         - jumpstart_ui_three_column
-        - stanford_events_editorial_content
-        - stanford_events_body
-      blacklisted_blocks: {  }
-      whitelisted_blocks:
-        'Chaos Tools': {  }
-        'Config Pages': {  }
+      blacklisted_blocks:
         'Content fields':
           - 'field_block:node:stanford_event_series:uid'
           - 'field_block:node:stanford_event_series:created'
-          - 'field_block:node:stanford_event_series:changed'
-          - 'field_block:node:stanford_event_series:su_event_series_components'
-          - 'field_block:node:stanford_event_series:su_event_series_dek'
-          - 'field_block:node:stanford_event_series:su_event_series_event'
+          - 'field_block:node:stanford_event_series:type'
+          - 'field_block:node:stanford_event_series:revision_default'
+          - 'field_block:node:stanford_event_series:default_langcode'
           - 'field_block:node:stanford_event_series:nid'
+          - 'field_block:node:stanford_event_series:langcode'
           - 'extra_field_block:node:stanford_event_series:links'
           - 'field_block:node:stanford_event_series:menu_link'
+          - 'field_block:node:stanford_event_series:promote'
           - 'field_block:node:stanford_event_series:status'
-          - 'field_block:node:stanford_event_series:su_event_series_subheadline'
-          - 'field_block:node:stanford_event_series:title'
-          - 'field_block:node:stanford_event_series:su_event_series_type'
-          - 'field_block:node:stanford_event_series:su_event_series_weight'
-        'Devel PHP': {  }
+          - 'field_block:node:stanford_event_series:rh_action'
+          - 'field_block:node:stanford_event_series:rh_redirect_fallback_action'
+          - 'field_block:node:stanford_event_series:rh_redirect'
+          - 'field_block:node:stanford_event_series:rh_redirect_response'
+          - 'field_block:node:stanford_event_series:revision_timestamp'
+          - 'field_block:node:stanford_event_series:vid'
+          - 'field_block:node:stanford_event_series:revision_log'
+          - 'field_block:node:stanford_event_series:revision_translation_affected'
+          - 'field_block:node:stanford_event_series:revision_uid'
+          - 'extra_field_block:node:stanford_event_series:search_api_excerpt'
+          - 'field_block:node:stanford_event_series:sticky'
+          - 'field_block:node:stanford_event_series:unpublish_on'
+          - 'field_block:user:user:changed'
+          - 'field_block:user:user:created'
+          - 'field_block:user:user:default_langcode'
+          - 'field_block:user:user:su_display_name'
+          - 'field_block:user:user:mail'
+          - 'field_block:user:user:init'
+          - 'field_block:user:user:langcode'
+          - 'field_block:user:user:access'
+          - 'field_block:user:user:login'
+          - 'extra_field_block:user:user:member_for'
+          - 'field_block:user:user:name'
+          - 'field_block:user:user:preferred_admin_langcode'
+          - 'field_block:user:user:preferred_langcode'
+          - 'field_block:user:user:role_change'
+          - 'field_block:user:user:roles'
+          - 'extra_field_block:user:user:search_api_excerpt'
+          - 'field_block:user:user:timezone'
+          - 'field_block:user:user:uid'
+          - 'field_block:user:user:status'
+      whitelisted_blocks:
         Menus:
+          - 'system_menu_block:stanford-event-types'
           - 'menu_block:stanford-event-types'
           - 'menu_block:main'
-        'News Lists (Views)':
-          - 'views_block:stanford_news-vertical_teaser_term'
-          - 'views_block:stanford_news-vertical_teaser_term_list'
-          - 'views_block:stanford_news-block_1'
-          - 'views_block:stanford_news-term_block'
-        'People Lists (Views)':
-          - 'views_block:stanford_person-grid_list_all'
-          - 'views_block:stanford_person_list_terms_first-person_list_grid'
-        'SimpleSAMLphp Authentication': {  }
-        'Stanford News': {  }
-        'Stanford SimpleSAML PHP': {  }
+          - 'system_menu_block:main'
+          - 'system_menu_block:stanford-person-type'
+          - 'menu_block:stanford-person-type'
+          - 'system_menu_block:stanford-publication-topics'
+          - 'menu_block:stanford-publication-topics'
+          - 'system_menu_block:news-topics'
+          - 'menu_block:news-topics'
         System:
-          - system_messages_block
-      restricted_categories: {  }
+          - system_breadcrumb_block
+        core:
+          - page_title_block
+      restricted_categories:
+        - 'Chaos Tools'
+        - 'Config Pages'
+        - Forms
+        - Help
+        - 'Lists (Views)'
+        - React
+        - 'SimpleSAMLphp Authentication'
+        - 'Stanford Profile Helper'
+        - 'Stanford SimpleSAML PHP'
+        - Views
 id: node.stanford_event_series.default
 targetEntityType: node
 bundle: stanford_event_series

--- a/config/sync/core.entity_view_display.node.stanford_news.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_news.default.yml
@@ -334,27 +334,111 @@ third_party_settings:
             additional: {  }
         third_party_settings: {  }
   layout_builder_restrictions:
-    allowed_block_categories: {  }
+    allowed_block_categories:
+      - 'Basic Page Type Lists (Views)'
+      - 'Chaos Tools'
+      - 'Config Pages'
+      - 'Content fields'
+      - 'Custom block types'
+      - 'Custom blocks'
+      - Devel
+      - 'Devel PHP'
+      - 'Events Lists (Views)'
+      - Forms
+      - Help
+      - 'Inline blocks'
+      - 'Jumpstart UI'
+      - 'Lists (Views)'
+      - Menus
+      - 'News Lists (Views)'
+      - 'PDB React'
+      - 'People Lists (Views)'
+      - 'Publication (Views)'
+      - React
+      - 'SimpleSAMLphp Authentication'
+      - 'Stanford News'
+      - 'Stanford Profile Helper'
+      - 'Stanford SimpleSAML PHP'
+      - System
+      - Views
+      - core
     entity_view_mode_restriction:
       allowed_layouts:
         - jumpstart_ui_one_column
         - jumpstart_ui_two_column
         - jumpstart_ui_three_column
         - stanford_news_byline
-        - ds_reset
-      blacklisted_blocks: {  }
+      blacklisted_blocks:
+        'Content fields':
+          - 'field_block:node:stanford_news:uid'
+          - 'field_block:node:stanford_news:created'
+          - 'field_block:node:stanford_news:type'
+          - 'field_block:node:stanford_news:revision_default'
+          - 'field_block:node:stanford_news:default_langcode'
+          - 'field_block:node:stanford_news:nid'
+          - 'field_block:node:stanford_news:langcode'
+          - 'extra_field_block:node:stanford_news:links'
+          - 'field_block:node:stanford_news:menu_link'
+          - 'field_block:node:stanford_news:promote'
+          - 'field_block:node:stanford_news:status'
+          - 'field_block:node:stanford_news:rh_action'
+          - 'field_block:node:stanford_news:rh_redirect_fallback_action'
+          - 'field_block:node:stanford_news:rh_redirect'
+          - 'field_block:node:stanford_news:rh_redirect_response'
+          - 'field_block:node:stanford_news:revision_timestamp'
+          - 'field_block:node:stanford_news:vid'
+          - 'field_block:node:stanford_news:revision_log'
+          - 'field_block:node:stanford_news:revision_translation_affected'
+          - 'field_block:node:stanford_news:revision_uid'
+          - 'extra_field_block:node:stanford_news:search_api_excerpt'
+          - 'field_block:node:stanford_news:sticky'
+          - 'field_block:node:stanford_news:unpublish_on'
+          - 'field_block:user:user:changed'
+          - 'field_block:user:user:created'
+          - 'field_block:user:user:default_langcode'
+          - 'field_block:user:user:su_display_name'
+          - 'field_block:user:user:mail'
+          - 'field_block:user:user:init'
+          - 'field_block:user:user:langcode'
+          - 'field_block:user:user:access'
+          - 'field_block:user:user:login'
+          - 'extra_field_block:user:user:member_for'
+          - 'field_block:user:user:name'
+          - 'field_block:user:user:preferred_admin_langcode'
+          - 'field_block:user:user:preferred_langcode'
+          - 'field_block:user:user:role_change'
+          - 'field_block:user:user:roles'
+          - 'extra_field_block:user:user:search_api_excerpt'
+          - 'field_block:user:user:timezone'
+          - 'field_block:user:user:uid'
+          - 'field_block:user:user:status'
       whitelisted_blocks:
-        'Chaos Tools': {  }
-        'Config Pages': {  }
         Menus:
+          - 'menu_block:stanford-event-types'
+          - 'system_menu_block:stanford-event-types'
+          - 'system_menu_block:main'
           - 'menu_block:main'
+          - 'system_menu_block:stanford-person-type'
+          - 'menu_block:stanford-person-type'
+          - 'system_menu_block:stanford-publication-topics'
+          - 'menu_block:stanford-publication-topics'
+          - 'system_menu_block:news-topics'
           - 'menu_block:news-topics'
-        'SimpleSAMLphp Authentication': {  }
         System:
-          - system_messages_block
+          - system_breadcrumb_block
         core:
           - page_title_block
-      restricted_categories: {  }
+      restricted_categories:
+        - 'Chaos Tools'
+        - 'Config Pages'
+        - Forms
+        - Help
+        - 'Lists (Views)'
+        - React
+        - 'SimpleSAMLphp Authentication'
+        - 'Stanford Profile Helper'
+        - 'Stanford SimpleSAML PHP'
+        - Views
   layout_library:
     enable: false
 id: node.stanford_news.default

--- a/config/sync/core.entity_view_display.node.stanford_page.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_page.default.yml
@@ -144,33 +144,111 @@ third_party_settings:
   layout_library:
     enable: true
   layout_builder_restrictions:
+    allowed_block_categories:
+      - 'Basic Page Type Lists (Views)'
+      - 'Chaos Tools'
+      - 'Config Pages'
+      - 'Content fields'
+      - 'Custom block types'
+      - 'Custom blocks'
+      - Devel
+      - 'Devel PHP'
+      - 'Events Lists (Views)'
+      - Forms
+      - Help
+      - 'Inline blocks'
+      - 'Jumpstart UI'
+      - 'Lists (Views)'
+      - Menus
+      - 'News Lists (Views)'
+      - 'PDB React'
+      - 'People Lists (Views)'
+      - 'Publication (Views)'
+      - React
+      - 'SimpleSAMLphp Authentication'
+      - 'Stanford News'
+      - 'Stanford Profile Helper'
+      - 'Stanford SimpleSAML PHP'
+      - System
+      - Views
+      - core
     entity_view_mode_restriction:
       allowed_layouts:
         - jumpstart_ui_one_column
         - jumpstart_ui_two_column
         - jumpstart_ui_three_column
-      blacklisted_blocks: {  }
-      whitelisted_blocks: {  }
-      restricted_categories: {  }
-      allowed_blocks:
-        'Chaos Tools': {  }
+      blacklisted_blocks:
         'Content fields':
-          - 'field_block:node:stanford_page:su_page_banner'
-          - 'field_block:node:stanford_page:su_page_components'
-          - 'field_block:node:stanford_page:title'
-        Forms: {  }
-        Help: {  }
+          - 'field_block:node:stanford_page:uid'
+          - 'field_block:node:stanford_page:created'
+          - 'field_block:node:stanford_page:type'
+          - 'field_block:node:stanford_page:revision_default'
+          - 'field_block:node:stanford_page:default_langcode'
+          - 'field_block:node:stanford_page:nid'
+          - 'field_block:node:stanford_page:langcode'
+          - 'field_block:node:stanford_page:layout_selection'
+          - 'extra_field_block:node:stanford_page:links'
+          - 'field_block:node:stanford_page:menu_link'
+          - 'field_block:node:stanford_page:promote'
+          - 'field_block:node:stanford_page:status'
+          - 'field_block:node:stanford_page:rh_action'
+          - 'field_block:node:stanford_page:rh_redirect_fallback_action'
+          - 'field_block:node:stanford_page:rh_redirect'
+          - 'field_block:node:stanford_page:rh_redirect_response'
+          - 'field_block:node:stanford_page:revision_timestamp'
+          - 'field_block:node:stanford_page:vid'
+          - 'field_block:node:stanford_page:revision_log'
+          - 'field_block:node:stanford_page:revision_translation_affected'
+          - 'field_block:node:stanford_page:revision_uid'
+          - 'extra_field_block:node:stanford_page:search_api_excerpt'
+          - 'field_block:node:stanford_page:sticky'
+          - 'field_block:node:stanford_page:unpublish_on'
+          - 'field_block:user:user:changed'
+          - 'field_block:user:user:created'
+          - 'field_block:user:user:default_langcode'
+          - 'field_block:user:user:su_display_name'
+          - 'field_block:user:user:mail'
+          - 'field_block:user:user:init'
+          - 'field_block:user:user:langcode'
+          - 'field_block:user:user:access'
+          - 'field_block:user:user:login'
+          - 'extra_field_block:user:user:member_for'
+          - 'field_block:user:user:name'
+          - 'field_block:user:user:preferred_admin_langcode'
+          - 'field_block:user:user:preferred_langcode'
+          - 'field_block:user:user:role_change'
+          - 'field_block:user:user:roles'
+          - 'extra_field_block:user:user:search_api_excerpt'
+          - 'field_block:user:user:timezone'
+          - 'field_block:user:user:uid'
+          - 'field_block:user:user:status'
+      whitelisted_blocks:
         Menus:
-          - 'menu_block:footer'
-          - 'system_menu_block:footer'
+          - 'system_menu_block:stanford-event-types'
+          - 'menu_block:stanford-event-types'
           - 'menu_block:main'
           - 'system_menu_block:main'
-        'SimpleSAMLphp Authentication': {  }
-        'Stanford SimpleSAML PHP': {  }
-        System: {  }
-        'User fields': {  }
-        core: {  }
-    allowed_block_categories: {  }
+          - 'system_menu_block:stanford-person-type'
+          - 'menu_block:stanford-person-type'
+          - 'system_menu_block:stanford-publication-topics'
+          - 'menu_block:stanford-publication-topics'
+          - 'system_menu_block:news-topics'
+          - 'menu_block:news-topics'
+        System:
+          - system_breadcrumb_block
+        core:
+          - page_title_block
+      restricted_categories:
+        - 'Chaos Tools'
+        - 'Config Pages'
+        - Forms
+        - Help
+        - 'Lists (Views)'
+        - React
+        - 'SimpleSAMLphp Authentication'
+        - 'Stanford Profile Helper'
+        - 'Stanford SimpleSAML PHP'
+        - Views
 id: node.stanford_page.default
 targetEntityType: node
 bundle: stanford_page

--- a/config/sync/core.entity_view_display.node.stanford_person.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_person.default.yml
@@ -570,7 +570,34 @@ third_party_settings:
             additional: {  }
         third_party_settings: {  }
   layout_builder_restrictions:
-    allowed_block_categories: {  }
+    allowed_block_categories:
+      - 'Basic Page Type Lists (Views)'
+      - 'Chaos Tools'
+      - 'Config Pages'
+      - 'Content fields'
+      - 'Custom block types'
+      - 'Custom blocks'
+      - Devel
+      - 'Devel PHP'
+      - 'Events Lists (Views)'
+      - Forms
+      - Help
+      - 'Inline blocks'
+      - 'Jumpstart UI'
+      - 'Lists (Views)'
+      - Menus
+      - 'News Lists (Views)'
+      - 'PDB React'
+      - 'People Lists (Views)'
+      - 'Publication (Views)'
+      - React
+      - 'SimpleSAMLphp Authentication'
+      - 'Stanford News'
+      - 'Stanford Profile Helper'
+      - 'Stanford SimpleSAML PHP'
+      - System
+      - Views
+      - core
     entity_view_mode_restriction:
       allowed_layouts:
         - jumpstart_ui_one_column
@@ -578,10 +605,77 @@ third_party_settings:
         - jumpstart_ui_three_column
         - stanford_person_header
         - stanford_person_body
-        - ds_reset
-      blacklisted_blocks: {  }
-      whitelisted_blocks: {  }
-      restricted_categories: {  }
+      blacklisted_blocks:
+        'Content fields':
+          - 'field_block:node:stanford_person:uid'
+          - 'field_block:node:stanford_person:created'
+          - 'field_block:node:stanford_person:type'
+          - 'field_block:node:stanford_person:revision_default'
+          - 'field_block:node:stanford_person:default_langcode'
+          - 'field_block:node:stanford_person:nid'
+          - 'field_block:node:stanford_person:langcode'
+          - 'extra_field_block:node:stanford_person:links'
+          - 'field_block:node:stanford_person:menu_link'
+          - 'field_block:node:stanford_person:promote'
+          - 'field_block:node:stanford_person:status'
+          - 'field_block:node:stanford_person:rh_action'
+          - 'field_block:node:stanford_person:rh_redirect_fallback_action'
+          - 'field_block:node:stanford_person:rh_redirect'
+          - 'field_block:node:stanford_person:rh_redirect_response'
+          - 'field_block:node:stanford_person:revision_timestamp'
+          - 'field_block:node:stanford_person:vid'
+          - 'field_block:node:stanford_person:revision_log'
+          - 'field_block:node:stanford_person:revision_translation_affected'
+          - 'field_block:node:stanford_person:revision_uid'
+          - 'extra_field_block:node:stanford_person:search_api_excerpt'
+          - 'field_block:node:stanford_person:sticky'
+          - 'field_block:node:stanford_person:unpublish_on'
+          - 'field_block:user:user:changed'
+          - 'field_block:user:user:created'
+          - 'field_block:user:user:default_langcode'
+          - 'field_block:user:user:su_display_name'
+          - 'field_block:user:user:mail'
+          - 'field_block:user:user:init'
+          - 'field_block:user:user:langcode'
+          - 'field_block:user:user:access'
+          - 'field_block:user:user:login'
+          - 'extra_field_block:user:user:member_for'
+          - 'field_block:user:user:name'
+          - 'field_block:user:user:preferred_admin_langcode'
+          - 'field_block:user:user:preferred_langcode'
+          - 'field_block:user:user:role_change'
+          - 'field_block:user:user:roles'
+          - 'extra_field_block:user:user:search_api_excerpt'
+          - 'field_block:user:user:timezone'
+          - 'field_block:user:user:uid'
+          - 'field_block:user:user:status'
+      whitelisted_blocks:
+        Menus:
+          - 'system_menu_block:stanford-event-types'
+          - 'menu_block:stanford-event-types'
+          - 'system_menu_block:main'
+          - 'menu_block:main'
+          - 'menu_block:stanford-person-type'
+          - 'system_menu_block:stanford-person-type'
+          - 'menu_block:stanford-publication-topics'
+          - 'system_menu_block:stanford-publication-topics'
+          - 'system_menu_block:news-topics'
+          - 'menu_block:news-topics'
+        System:
+          - system_breadcrumb_block
+        core:
+          - page_title_block
+      restricted_categories:
+        - 'Chaos Tools'
+        - 'Config Pages'
+        - Forms
+        - Help
+        - 'Lists (Views)'
+        - React
+        - 'SimpleSAMLphp Authentication'
+        - 'Stanford Profile Helper'
+        - 'Stanford SimpleSAML PHP'
+        - Views
   layout_library:
     enable: false
 id: node.stanford_person.default

--- a/config/sync/core.entity_view_display.node.stanford_publication.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_publication.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.stanford_publication.su_publication_citation
     - field.field.node.stanford_publication.su_publication_components
     - field.field.node.stanford_publication.su_publication_cta
+    - field.field.node.stanford_publication.su_publication_image
     - field.field.node.stanford_publication.su_publication_topics
     - node.type.stanford_publication
     - views.view.stanford_publications
@@ -196,12 +197,110 @@ third_party_settings:
   layout_library:
     enable: false
   layout_builder_restrictions:
-    allowed_block_categories: {  }
+    allowed_block_categories:
+      - 'Basic Page Type Lists (Views)'
+      - 'Chaos Tools'
+      - 'Config Pages'
+      - 'Content fields'
+      - 'Custom block types'
+      - 'Custom blocks'
+      - Devel
+      - 'Devel PHP'
+      - 'Events Lists (Views)'
+      - Forms
+      - Help
+      - 'Inline blocks'
+      - 'Jumpstart UI'
+      - 'Lists (Views)'
+      - Menus
+      - 'News Lists (Views)'
+      - 'PDB React'
+      - 'People Lists (Views)'
+      - 'Publication (Views)'
+      - React
+      - 'SimpleSAMLphp Authentication'
+      - 'Stanford News'
+      - 'Stanford Profile Helper'
+      - 'Stanford SimpleSAML PHP'
+      - System
+      - Views
+      - core
     entity_view_mode_restriction:
-      allowed_layouts: {  }
-      blacklisted_blocks: {  }
-      whitelisted_blocks: {  }
-      restricted_categories: {  }
+      allowed_layouts:
+        - jumpstart_ui_one_column
+        - jumpstart_ui_two_column
+        - jumpstart_ui_three_column
+      blacklisted_blocks:
+        'Content fields':
+          - 'field_block:node:stanford_publication:uid'
+          - 'field_block:node:stanford_publication:created'
+          - 'field_block:node:stanford_publication:type'
+          - 'field_block:node:stanford_publication:revision_default'
+          - 'field_block:node:stanford_publication:default_langcode'
+          - 'field_block:node:stanford_publication:nid'
+          - 'field_block:node:stanford_publication:langcode'
+          - 'extra_field_block:node:stanford_publication:links'
+          - 'field_block:node:stanford_publication:menu_link'
+          - 'field_block:node:stanford_publication:promote'
+          - 'field_block:node:stanford_publication:status'
+          - 'field_block:node:stanford_publication:rh_action'
+          - 'field_block:node:stanford_publication:rh_redirect_fallback_action'
+          - 'field_block:node:stanford_publication:rh_redirect'
+          - 'field_block:node:stanford_publication:rh_redirect_response'
+          - 'field_block:node:stanford_publication:revision_timestamp'
+          - 'field_block:node:stanford_publication:vid'
+          - 'field_block:node:stanford_publication:revision_log'
+          - 'field_block:node:stanford_publication:revision_translation_affected'
+          - 'field_block:node:stanford_publication:revision_uid'
+          - 'extra_field_block:node:stanford_publication:search_api_excerpt'
+          - 'field_block:node:stanford_publication:sticky'
+          - 'field_block:node:stanford_publication:unpublish_on'
+          - 'field_block:user:user:changed'
+          - 'field_block:user:user:created'
+          - 'field_block:user:user:default_langcode'
+          - 'field_block:user:user:su_display_name'
+          - 'field_block:user:user:mail'
+          - 'field_block:user:user:init'
+          - 'field_block:user:user:langcode'
+          - 'field_block:user:user:access'
+          - 'field_block:user:user:login'
+          - 'extra_field_block:user:user:member_for'
+          - 'field_block:user:user:name'
+          - 'field_block:user:user:preferred_admin_langcode'
+          - 'field_block:user:user:preferred_langcode'
+          - 'field_block:user:user:roles'
+          - 'field_block:user:user:role_change'
+          - 'extra_field_block:user:user:search_api_excerpt'
+          - 'field_block:user:user:timezone'
+          - 'field_block:user:user:uid'
+          - 'field_block:user:user:status'
+      whitelisted_blocks:
+        Menus:
+          - 'system_menu_block:stanford-event-types'
+          - 'menu_block:stanford-event-types'
+          - 'menu_block:main'
+          - 'system_menu_block:main'
+          - 'system_menu_block:stanford-person-type'
+          - 'menu_block:stanford-person-type'
+          - 'system_menu_block:stanford-publication-topics'
+          - 'menu_block:stanford-publication-topics'
+          - 'menu_block:news-topics'
+          - 'system_menu_block:news-topics'
+        System:
+          - system_breadcrumb_block
+        core:
+          - page_title_block
+      restricted_categories:
+        - 'Chaos Tools'
+        - 'Config Pages'
+        - Forms
+        - Help
+        - 'Lists (Views)'
+        - React
+        - 'SimpleSAMLphp Authentication'
+        - 'Stanford Profile Helper'
+        - 'Stanford SimpleSAML PHP'
+        - Views
 id: node.stanford_publication.default
 targetEntityType: node
 bundle: stanford_publication


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Restrict a bunch of unnecessary blocks available in layout builder and made them consistent for all content types.

# Need Review By (Date)
- 3/17

# Urgency
- high

# Steps to Test
1. checkout this branch
2. config import
3. edit/create a basic page
4. edit the layout builder
5. verify there are fewer and only applicable available blocks available. (no "Powered by Drupal" or other blocks that shouldn't be available.)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
