### PR TITLE
D8CORE-5629 Adjust profile link url for stanford only profiles

### DIFF
--- a/config/sync/migrate_plus.migration.su_stanford_person.yml
+++ b/config/sync/migrate_plus.migration.su_stanford_person.yml
@@ -124,6 +124,10 @@ source:
       name: scholarly_interests_tersetext
       label: 'Scholarly and Research Interests'
       selector: currentResearchInterests/terseText/html
+    -
+      name: community
+      label: community
+      selector: community
   ids:
     sunetid:
       type: string
@@ -171,7 +175,18 @@ process:
       delimiter: /
       source:
         - constants/link_domain
+        - community
         - profile_id
+    -
+      plugin: str_replace
+      search:
+        - 'stanford/'
+        - 'hidden/'
+        - 'public/'
+      replace:
+        - 'intranet/'
+        - 'intranet/'
+        - ''
   su_person_profile_link/title: constants/link_text
   image_timestamp:
     -


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- "Stanford Only" profiles have a different link url. The API returns a flag to identify which ones we need to change

# Need Review By (Date)
- 4/30

# Urgency
- medium

# Steps to Test
1. checkout this branch
2. import configs.
3. enter some API credentials for the people importer. (reach out to me for those credentials)
4. import a stanford only profile (reach out to me for that sunetid)
5. view the imported profile
6. verify the link on the profile goes to the profile, not a 404 page.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
