### PR TITLE
D8CORE-5729 People term pages: display only child terms groupings

### DIFF
--- a/config/sync/core.entity_view_display.taxonomy_term.stanford_person_types.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.stanford_person_types.default.yml
@@ -74,19 +74,6 @@ third_party_settings:
               expand_all_items: false
             weight: 0
             additional: {  }
-          a26cc41e-5521-4f30-8180-936d156bae3c:
-            uuid: a26cc41e-5521-4f30-8180-936d156bae3c
-            region: main
-            configuration:
-              id: 'views_block:taxonomy_term_pages-results_for'
-              label: ''
-              label_display: '0'
-              provider: views
-              context_mapping: {  }
-              views_label: ''
-              items_per_page: none
-            weight: 3
-            additional: {  }
           7df0de5c-0e64-40d9-b63f-454eb37d3cb5:
             uuid: 7df0de5c-0e64-40d9-b63f-454eb37d3cb5
             region: main

--- a/config/sync/core.entity_view_display.taxonomy_term.stanford_person_types.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.stanford_person_types.default.yml
@@ -6,7 +6,6 @@ dependencies:
     - field.field.taxonomy_term.stanford_person_types.layout_builder__layout
     - system.menu.stanford-person-type
     - taxonomy.vocabulary.stanford_person_types
-    - views.view.stanford_person
     - views.view.taxonomy_term_pages
   module:
     - jumpstart_ui
@@ -75,19 +74,6 @@ third_party_settings:
               expand_all_items: false
             weight: 0
             additional: {  }
-          50fa7466-76c8-4f62-94ff-9143d404cdaf:
-            uuid: 50fa7466-76c8-4f62-94ff-9143d404cdaf
-            region: main
-            configuration:
-              id: 'views_block:stanford_person-term_page_grid'
-              label: ''
-              label_display: '0'
-              provider: views
-              context_mapping: {  }
-              views_label: ''
-              items_per_page: none
-            weight: 5
-            additional: {  }
           a26cc41e-5521-4f30-8180-936d156bae3c:
             uuid: a26cc41e-5521-4f30-8180-936d156bae3c
             region: main
@@ -120,6 +106,19 @@ third_party_settings:
                   field_formatter_class:
                     class: ''
             weight: 4
+            additional: {  }
+          d48183f8-9763-4ebf-95ff-50835d6f7298:
+            uuid: d48183f8-9763-4ebf-95ff-50835d6f7298
+            region: main
+            configuration:
+              id: 'views_block:taxonomy_term_pages-people_terms'
+              label: ''
+              label_display: '0'
+              provider: views
+              context_mapping: {  }
+              views_label: ''
+              items_per_page: none
+            weight: 6
             additional: {  }
         third_party_settings: {  }
   layout_library:

--- a/config/sync/views.view.stanford_person.yml
+++ b/config/sync/views.view.stanford_person.yml
@@ -544,15 +544,11 @@ display:
       style:
         type: html_list
         options:
-          grouping:
-            -
-              field: su_person_type_group
-              rendered: true
-              rendered_strip: false
+          grouping: {  }
           row_class: ''
           default_row_class: true
           type: ul
-          wrapper_class: su-margin-bottom-6
+          wrapper_class: ''
           class: 'su-list-unstyled grid-container-3'
       row:
         type: fields
@@ -1253,69 +1249,6 @@ display:
           text: 'edit this item'
           output_url_as_text: false
           absolute: false
-        su_person_type_group:
-          id: su_person_type_group
-          table: node__su_person_type_group
-          field: su_person_type_group
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: field
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_label
-          settings:
-            link: false
-          group_column: target_id
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
       arguments:
         term_node_tid_depth:
           id: term_node_tid_depth
@@ -1379,4 +1312,3 @@ display:
       tags:
         - 'config:field.storage.node.su_person_photo'
         - 'config:field.storage.node.su_person_short_title'
-        - 'config:field.storage.node.su_person_type_group'

--- a/config/sync/views.view.taxonomy_term_pages.yml
+++ b/config/sync/views.view.taxonomy_term_pages.yml
@@ -3,9 +3,11 @@ langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.stanford_card
+    - field.storage.node.su_person_photo
+    - field.storage.node.su_person_short_title
   module:
     - node
+    - stanford_media
     - taxonomy
     - user
     - views_infinite_scroll
@@ -262,15 +264,14 @@ display:
           separator: ', '
           field_api_classes: false
           convert_spaces: false
-        rendered_entity:
-          id: rendered_entity
-          table: node
-          field: rendered_entity
+        su_person_photo:
+          id: su_person_photo
+          table: node__su_person_photo
+          field: su_person_photo
           relationship: reverse__node__su_person_type_group
           group_type: group
           admin_label: ''
-          entity_type: node
-          plugin_id: rendered_entity
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -300,8 +301,8 @@ display:
             trim: false
             preserve_tags: ''
             html: false
-          element_type: div
-          element_class: su-margin-bottom-3
+          element_type: ''
+          element_class: su-margin-bottom-1
           element_label_type: ''
           element_label_class: ''
           element_label_colon: false
@@ -312,7 +313,253 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          view_mode: stanford_card
+          click_sort_column: target_id
+          type: media_image_formatter
+          settings:
+            view_mode: default
+            link: false
+            image_style: stanford_circle
+            remove_alt: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: reverse__node__su_person_type_group
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: h4
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        su_person_short_title:
+          id: su_person_short_title
+          table: node__su_person_short_title
+          field: su_person_short_title
+          relationship: reverse__node__su_person_type_group
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        edit_node:
+          id: edit_node
+          table: node
+          field: edit_node
+          relationship: reverse__node__su_person_type_group
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_link_edit
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'Edit this item'
+          output_url_as_text: false
+          absolute: true
+        nothing:
+          id: nothing
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: custom
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '<div class="su-margin-bottom-6"></div>'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
       pager:
         type: infinite_scroll
         options:
@@ -379,11 +626,134 @@ display:
             field_identifier: ''
           exposed: false
       arguments:
+        tid:
+          id: tid
+          table: taxonomy_term_field_data
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: tid
+          plugin_id: taxonomy
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: taxonomy_tid
+          default_argument_options:
+            term_page: '1'
+            node: false
+            limit: false
+            vids: {  }
+            anyall: ','
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
         parent_target_id:
           id: parent_target_id
           table: taxonomy_term__parent
           field: parent_target_id
           relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: parent
+          plugin_id: taxonomy
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: taxonomy_tid
+          default_argument_options:
+            term_page: '1'
+            node: false
+            limit: false
+            vids: {  }
+            anyall: ','
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: true
+          not: false
+        parent_target_id_1:
+          id: parent_target_id_1
+          table: taxonomy_term__parent
+          field: parent_target_id
+          relationship: parent_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: parent
+          plugin_id: taxonomy
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: taxonomy_tid
+          default_argument_options:
+            term_page: '1'
+            node: false
+            limit: false
+            vids: {  }
+            anyall: ','
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+        parent_target_id_2:
+          id: parent_target_id_2
+          table: taxonomy_term__parent
+          field: parent_target_id
+          relationship: parent_target_id_1
           group_type: group
           admin_label: ''
           entity_type: taxonomy_term
@@ -435,11 +805,25 @@ display:
           class: 'su-list-unstyled grid-container-3'
       row:
         type: fields
-        options: {  }
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: true
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+          contextual_filters_or: true
       defaults:
         empty: false
+        query: false
         title: false
-        css_class: false
+        css_class: true
         pager: false
         style: false
         row: false
@@ -447,6 +831,7 @@ display:
         fields: false
         sorts: false
         arguments: false
+        header: false
       relationships:
         reverse__node__su_person_type_group:
           id: reverse__node__su_person_type_group
@@ -458,8 +843,43 @@ display:
           entity_type: taxonomy_term
           plugin_id: entity_reverse
           required: true
-      css_class: ''
+        parent_target_id:
+          id: parent_target_id
+          table: taxonomy_term__parent
+          field: parent_target_id
+          relationship: none
+          group_type: group
+          admin_label: Parent
+          entity_type: taxonomy_term
+          entity_field: parent
+          plugin_id: standard
+          required: false
+        parent_target_id_1:
+          id: parent_target_id_1
+          table: taxonomy_term__parent
+          field: parent_target_id
+          relationship: parent_target_id
+          group_type: group
+          admin_label: 'Parent''s Parent'
+          entity_type: taxonomy_term
+          entity_field: parent
+          plugin_id: standard
+          required: false
       display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: '<h2>Results for: {{ name }}</h2>'
+            format: stanford_html
+          tokenize: true
       display_extenders: {  }
       block_category: 'Taxonomy Terms (Views)'
     cache_metadata:
@@ -471,28 +891,8 @@ display:
         - url.query_args
         - user.permissions
       tags:
-        - 'config:core.entity_view_display.node.stanford_event.default'
-        - 'config:core.entity_view_display.node.stanford_event.search_indexing'
-        - 'config:core.entity_view_display.node.stanford_event.stanford_card'
-        - 'config:core.entity_view_display.node.stanford_event.teaser'
-        - 'config:core.entity_view_display.node.stanford_event_series.default'
-        - 'config:core.entity_view_display.node.stanford_event_series.search_indexing'
-        - 'config:core.entity_view_display.node.stanford_event_series.stanford_card'
-        - 'config:core.entity_view_display.node.stanford_event_series.teaser'
-        - 'config:core.entity_view_display.node.stanford_news.default'
-        - 'config:core.entity_view_display.node.stanford_news.search_indexing'
-        - 'config:core.entity_view_display.node.stanford_news.stanford_card'
-        - 'config:core.entity_view_display.node.stanford_page.default'
-        - 'config:core.entity_view_display.node.stanford_page.search_indexing'
-        - 'config:core.entity_view_display.node.stanford_page.stanford_card'
-        - 'config:core.entity_view_display.node.stanford_person.default'
-        - 'config:core.entity_view_display.node.stanford_person.search_indexing'
-        - 'config:core.entity_view_display.node.stanford_person.stanford_card'
-        - 'config:core.entity_view_display.node.stanford_person.teaser'
-        - 'config:core.entity_view_display.node.stanford_publication.default'
-        - 'config:core.entity_view_display.node.stanford_publication.search_indexing'
-        - 'config:core.entity_view_display.node.stanford_publication.stanford_card'
-        - 'config:core.entity_view_display.node.stanford_publication.teaser'
+        - 'config:field.storage.node.su_person_photo'
+        - 'config:field.storage.node.su_person_short_title'
   results_for:
     id: results_for
     display_title: '"Results For" Block'

--- a/config/sync/views.view.taxonomy_term_pages.yml
+++ b/config/sync/views.view.taxonomy_term_pages.yml
@@ -5,11 +5,13 @@ dependencies:
   config:
     - field.storage.node.su_person_photo
     - field.storage.node.su_person_short_title
+    - node.type.stanford_person
   module:
     - node
     - stanford_media
     - taxonomy
     - user
+    - views_custom_cache_tag
     - views_infinite_scroll
 id: taxonomy_term_pages
 label: 'Taxonomy Term Pages'
@@ -582,6 +584,10 @@ display:
             button_text: 'Load More People'
             automatically_load_content: false
             initially_load_all_pages: false
+      cache:
+        type: custom_tag
+        options:
+          custom_tag: 'node_list:stanford_person'
       empty:
         area:
           id: area
@@ -790,6 +796,91 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
+      filters:
+        status:
+          id: status
+          table: taxonomy_index
+          field: status
+          relationship: reverse__node__su_person_type_group
+          group_type: group
+          admin_label: ''
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: reverse__node__su_person_type_group
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            stanford_person: stanford_person
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: html_list
         options:
@@ -815,12 +906,13 @@ display:
         options:
           query_comment: ''
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_tags: {  }
           contextual_filters_or: true
       defaults:
         empty: false
+        cache: false
         query: false
         title: false
         css_class: true
@@ -831,6 +923,8 @@ display:
         fields: false
         sorts: false
         arguments: false
+        filters: false
+        filter_groups: false
         header: false
       relationships:
         reverse__node__su_person_type_group:

--- a/config/sync/views.view.taxonomy_term_pages.yml
+++ b/config/sync/views.view.taxonomy_term_pages.yml
@@ -2,9 +2,13 @@ uuid: 0b4153c5-f622-4afd-bf2c-8f382444f1f9
 langcode: en
 status: true
 dependencies:
+  config:
+    - core.entity_view_mode.node.stanford_card
   module:
+    - node
     - taxonomy
     - user
+    - views_infinite_scroll
 id: taxonomy_term_pages
 label: 'Taxonomy Term Pages'
 module: views
@@ -19,7 +23,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: '"Results For"'
+      title: ''
       fields:
         name:
           id: name
@@ -156,6 +160,10 @@ display:
       filters: {  }
       style:
         type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
       row:
         type: fields
       query:
@@ -180,6 +188,311 @@ display:
         - url
         - user.permissions
       tags: {  }
+  people_terms:
+    id: people_terms
+    display_title: 'People Term List'
+    display_plugin: block
+    position: 2
+    display_options:
+      title: ''
+      fields:
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: term_name
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: h2
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          convert_spaces: false
+        rendered_entity:
+          id: rendered_entity
+          table: node
+          field: rendered_entity
+          relationship: reverse__node__su_person_type_group
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: rendered_entity
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: div
+          element_class: su-margin-bottom-3
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          view_mode: stanford_card
+      pager:
+        type: infinite_scroll
+        options:
+          offset: 0
+          items_per_page: 39
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          views_infinite_scroll:
+            button_text: 'Load More People'
+            automatically_load_content: false
+            initially_load_all_pages: false
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: '<p class="su-intro-text">Sorry, no results found. Try another filter.</p>'
+            format: stanford_html
+          tokenize: false
+      sorts:
+        su_person_last_name_value:
+          id: su_person_last_name_value
+          table: node__su_person_last_name
+          field: su_person_last_name_value
+          relationship: reverse__node__su_person_type_group
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+        weight:
+          id: weight
+          table: taxonomy_term_field_data
+          field: weight
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: weight
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+      arguments:
+        parent_target_id:
+          id: parent_target_id
+          table: taxonomy_term__parent
+          field: parent_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: parent
+          plugin_id: taxonomy
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: taxonomy_tid
+          default_argument_options:
+            term_page: '1'
+            node: false
+            limit: false
+            vids: {  }
+            anyall: ','
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      style:
+        type: html_list
+        options:
+          grouping:
+            -
+              field: name
+              rendered: true
+              rendered_strip: true
+          row_class: ''
+          default_row_class: true
+          type: ul
+          wrapper_class: ''
+          class: 'su-list-unstyled grid-container-3'
+      row:
+        type: fields
+        options: {  }
+      defaults:
+        empty: false
+        title: false
+        css_class: false
+        pager: false
+        style: false
+        row: false
+        relationships: false
+        fields: false
+        sorts: false
+        arguments: false
+      relationships:
+        reverse__node__su_person_type_group:
+          id: reverse__node__su_person_type_group
+          table: taxonomy_term_field_data
+          field: reverse__node__su_person_type_group
+          relationship: none
+          group_type: group
+          admin_label: su_person_type_group
+          entity_type: taxonomy_term
+          plugin_id: entity_reverse
+          required: true
+      css_class: ''
+      display_description: ''
+      display_extenders: {  }
+      block_category: 'Taxonomy Terms (Views)'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags:
+        - 'config:core.entity_view_display.node.stanford_event.default'
+        - 'config:core.entity_view_display.node.stanford_event.search_indexing'
+        - 'config:core.entity_view_display.node.stanford_event.stanford_card'
+        - 'config:core.entity_view_display.node.stanford_event.teaser'
+        - 'config:core.entity_view_display.node.stanford_event_series.default'
+        - 'config:core.entity_view_display.node.stanford_event_series.search_indexing'
+        - 'config:core.entity_view_display.node.stanford_event_series.stanford_card'
+        - 'config:core.entity_view_display.node.stanford_event_series.teaser'
+        - 'config:core.entity_view_display.node.stanford_news.default'
+        - 'config:core.entity_view_display.node.stanford_news.search_indexing'
+        - 'config:core.entity_view_display.node.stanford_news.stanford_card'
+        - 'config:core.entity_view_display.node.stanford_page.default'
+        - 'config:core.entity_view_display.node.stanford_page.search_indexing'
+        - 'config:core.entity_view_display.node.stanford_page.stanford_card'
+        - 'config:core.entity_view_display.node.stanford_person.default'
+        - 'config:core.entity_view_display.node.stanford_person.search_indexing'
+        - 'config:core.entity_view_display.node.stanford_person.stanford_card'
+        - 'config:core.entity_view_display.node.stanford_person.teaser'
+        - 'config:core.entity_view_display.node.stanford_publication.default'
+        - 'config:core.entity_view_display.node.stanford_publication.search_indexing'
+        - 'config:core.entity_view_display.node.stanford_publication.stanford_card'
+        - 'config:core.entity_view_display.node.stanford_publication.teaser'
   results_for:
     id: results_for
     display_title: '"Results For" Block'

--- a/config/sync/views.view.taxonomy_term_pages.yml
+++ b/config/sync/views.view.taxonomy_term_pages.yml
@@ -877,7 +877,7 @@ display:
           plugin_id: text
           empty: false
           content:
-            value: '<h2>Results for: {{ name }}</h2>'
+            value: '<div class="stanford-person-terms-term-link">Results for: {{ name }}</div>'
             format: stanford_html
           tokenize: true
       display_extenders: {  }

--- a/tests/codeception/acceptance/Content/PersonCest.php
+++ b/tests/codeception/acceptance/Content/PersonCest.php
@@ -161,30 +161,43 @@ class PersonCest {
 
     $faker = Factory::create();
     $parent = $I->createEntity([
-      'name' =>'Parent: '. $faker->text(10),
+      'name' => 'Parent: ' . $faker->text(10),
       'vid' => 'stanford_person_types',
     ], 'taxonomy_term');
     $child = $I->createEntity([
-      'name' => 'Child: '.$faker->text(10),
+      'name' => 'Child: ' . $faker->text(10),
       'vid' => 'stanford_person_types',
       'parent' => $parent->id(),
     ], 'taxonomy_term');
     $grandchild = $I->createEntity([
-      'name' => 'GrandChild: '.$faker->text(10),
+      'name' => 'GrandChild: ' . $faker->text(10),
       'vid' => 'stanford_person_types',
       'parent' => $child->id(),
     ], 'taxonomy_term');
     $great_grandchild = $I->createEntity([
-      'name' =>'Great GrandChild: '. $faker->text(10),
+      'name' => 'Great GrandChild: ' . $faker->text(10),
       'vid' => 'stanford_person_types',
       'parent' => $grandchild->id(),
+    ], 'taxonomy_term');
+
+    $another_parent = $I->createEntity([
+      'name' => 'Parent: ' . $faker->words(2, TRUE),
+      'vid' => 'stanford_person_types',
+    ], 'taxonomy_term');
+    $another_child = $I->createEntity([
+      'name' => 'Child: ' . $faker->words(2, TRUE),
+      'vid' => 'stanford_person_types',
+      'parent' => $another_parent->id(),
     ], 'taxonomy_term');
 
     $node = $I->createEntity([
       'type' => 'stanford_person',
       'su_person_first_name' => $faker->firstName,
       'su_person_last_name' => $faker->lastName,
-      'su_person_type_group' => $great_grandchild->id(),
+      'su_person_type_group' => [
+        ['target_id' => $great_grandchild->id()],
+        ['target_id' => $another_child->id()],
+      ],
     ]);
 
     $I->amOnPage($great_grandchild->toUrl()->toString());
@@ -195,6 +208,7 @@ class PersonCest {
     $I->canSee($node->label());
     $I->amOnPage($parent->toUrl()->toString());
     $I->canSee($node->label());
+    $I->cantSee($another_child->label());
   }
 
   /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- If a person is tagged with multiple types/groups, we don't want to display types/groups that are not relevant to the current taxonomy term we are viewing.
- This actually also fixes the ticket D8CORE-5657 which needed the headers of the lists adjusted.

# Need Review By (Date)
- 4/28

# Urgency
- medium

# Steps to Test
1. checkout this branch
2. import configs
3. configure the taxonomy terms so that there are at least 2 parents with some child tags under those.
4. create a person and tag with multiple child terms from different parents
5. view the parent taxonomy term page
6. verify the child from the other parent isn't displayed.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
