### PR TITLE
D8CORE 5750

### DIFF
--- a/config/sync/core.entity_view_display.config_pages.stanford_local_footer.default.yml
+++ b/config/sync/core.entity_view_display.config_pages.stanford_local_footer.default.yml
@@ -37,7 +37,6 @@ dependencies:
     - ds
     - field_formatter_class
     - link
-    - markup
     - options
     - text
 third_party_settings:
@@ -49,7 +48,7 @@ third_party_settings:
       entity_classes: all_classes
       settings:
         pattern:
-          field_templates: only_content
+          field_templates: default
     regions:
       lockup_title:
         - 'dynamic_token_field:config_pages-su_site_name'
@@ -154,13 +153,6 @@ content:
         class: ''
     weight: 13
     region: signup_form_action
-  su_local_foot_help:
-    type: markup
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    weight: 16
-    region: content
   su_local_foot_pr_co:
     type: text_default
     label: hidden
@@ -264,6 +256,7 @@ content:
 hidden:
   search_api_excerpt: true
   su_footer_enabled: true
+  su_local_foot_help: true
   su_local_foot_line_1: true
   su_local_foot_line_2: true
   su_local_foot_line_3: true

--- a/config/sync/core.entity_view_display.node.stanford_event.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_event.stanford_card.yml
@@ -14,12 +14,15 @@ dependencies:
     - field.field.node.stanford_event.su_event_date_time
     - field.field.node.stanford_event.su_event_dek
     - field.field.node.stanford_event.su_event_email
+    - field.field.node.stanford_event.su_event_groups
+    - field.field.node.stanford_event.su_event_keywords
     - field.field.node.stanford_event.su_event_location
     - field.field.node.stanford_event.su_event_map_link
     - field.field.node.stanford_event.su_event_schedule
     - field.field.node.stanford_event.su_event_source
     - field.field.node.stanford_event.su_event_sponsor
     - field.field.node.stanford_event.su_event_subheadline
+    - field.field.node.stanford_event.su_event_subject
     - field.field.node.stanford_event.su_event_telephone
     - field.field.node.stanford_event.su_event_type
     - field.field.node.stanford_event.su_shared_tags
@@ -65,15 +68,6 @@ third_party_settings:
       address:
         - su_event_location
     fields:
-      node_title:
-        plugin_id: node_title
-        weight: 5
-        label: hidden
-        formatter: default
-        settings:
-          link: true
-          wrapper: h2
-          class: ''
       'dynamic_token_field:node-date_end_day':
         plugin_id: 'dynamic_token_field:node-date_end_day'
         weight: 3
@@ -94,6 +88,15 @@ third_party_settings:
         weight: 0
         label: hidden
         formatter: default
+      node_title:
+        plugin_id: node_title
+        weight: 5
+        label: hidden
+        formatter: default
+        settings:
+          link: true
+          wrapper: h2
+          class: ''
 id: node.stanford_event.stanford_card
 targetEntityType: node
 bundle: stanford_event
@@ -115,6 +118,8 @@ content:
       format_type: medium
       format: stanford_events_long
       force_chronological: false
+      add_classes: false
+      time_wrapper: true
     third_party_settings:
       field_formatter_class:
         class: ''
@@ -154,7 +159,11 @@ content:
     label: hidden
     settings:
       link: true
-    third_party_settings: {  }
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+      ds:
+        ds_limit: '1'
     weight: 4
     region: event_type
 hidden:

--- a/config/sync/core.entity_view_display.node.stanford_news.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_news.stanford_card.yml
@@ -46,6 +46,11 @@ third_party_settings:
       news_url:
         - 'dynamic_token_field:node-news_content_url'
     fields:
+      'dynamic_token_field:node-news_content_url':
+        plugin_id: 'dynamic_token_field:node-news_content_url'
+        weight: 4
+        label: hidden
+        formatter: default
       node_title:
         plugin_id: node_title
         weight: 1
@@ -55,11 +60,6 @@ third_party_settings:
           link: false
           wrapper: ''
           class: ''
-      'dynamic_token_field:node-news_content_url':
-        plugin_id: 'dynamic_token_field:node-news_content_url'
-        weight: 4
-        label: hidden
-        formatter: default
 id: node.stanford_news.stanford_card
 targetEntityType: node
 bundle: stanford_news
@@ -111,7 +111,7 @@ content:
       field_formatter_class:
         class: ''
       ds:
-        ds_limit: ''
+        ds_limit: '3'
     weight: 2
     region: news_topics
 hidden:

--- a/config/sync/core.entity_view_display.node.stanford_publication.stanford_card.yml
+++ b/config/sync/core.entity_view_display.node.stanford_publication.stanford_card.yml
@@ -67,7 +67,7 @@ content:
       field_formatter_class:
         class: ''
       ds:
-        ds_limit: ''
+        ds_limit: '3'
     weight: 2
     region: card_body
 hidden:

--- a/config/sync/core.entity_view_display.taxonomy_term.stanford_event_types.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.stanford_event_types.default.yml
@@ -79,7 +79,7 @@ third_party_settings:
                 third_party_settings:
                   field_formatter_class:
                     class: ''
-            weight: 1
+            weight: 2
             additional: {  }
           70d9646f-55ac-460b-bea3-8a04f0a24293:
             uuid: 70d9646f-55ac-460b-bea3-8a04f0a24293
@@ -106,7 +106,7 @@ third_party_settings:
               context_mapping: {  }
               views_label: ''
               items_per_page: none
-            weight: 2
+            weight: 3
             additional: {  }
           2129a4d0-f945-42d8-b117-fedf909b9d3c:
             uuid: 2129a4d0-f945-42d8-b117-fedf909b9d3c
@@ -119,6 +119,17 @@ third_party_settings:
               context_mapping: {  }
               views_label: ''
               items_per_page: none
+            weight: 1
+            additional: {  }
+          231c83ef-82c5-494b-a5ee-33d02a265176:
+            uuid: 231c83ef-82c5-494b-a5ee-33d02a265176
+            region: main
+            configuration:
+              id: jumpstart_ui_skipnav_main_anchor
+              label: 'Main content anchor target'
+              label_display: '0'
+              provider: jumpstart_ui
+              context_mapping: {  }
             weight: 0
             additional: {  }
         third_party_settings: {  }

--- a/config/sync/core.entity_view_display.taxonomy_term.stanford_news_topics.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.stanford_news_topics.default.yml
@@ -79,7 +79,7 @@ third_party_settings:
                 third_party_settings:
                   field_formatter_class:
                     class: ''
-            weight: 1
+            weight: 2
             additional: {  }
           2a5a6a90-b253-44a7-8111-8012baa026ea:
             uuid: 2a5a6a90-b253-44a7-8111-8012baa026ea
@@ -92,7 +92,7 @@ third_party_settings:
               context_mapping: {  }
               views_label: ''
               items_per_page: none
-            weight: 2
+            weight: 3
             additional: {  }
           2d95a649-5387-40ab-9041-2463d3d5c7d7:
             uuid: 2d95a649-5387-40ab-9041-2463d3d5c7d7
@@ -119,6 +119,17 @@ third_party_settings:
               context_mapping: {  }
               views_label: ''
               items_per_page: none
+            weight: 1
+            additional: {  }
+          64511152-17f6-4f55-8b01-e9593d98f334:
+            uuid: 64511152-17f6-4f55-8b01-e9593d98f334
+            region: main
+            configuration:
+              id: jumpstart_ui_skipnav_main_anchor
+              label: 'Main content anchor target'
+              label_display: '0'
+              provider: jumpstart_ui
+              context_mapping: {  }
             weight: 0
             additional: {  }
         third_party_settings: {  }

--- a/config/sync/core.entity_view_display.taxonomy_term.stanford_person_types.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.stanford_person_types.default.yml
@@ -92,7 +92,7 @@ third_party_settings:
                 third_party_settings:
                   field_formatter_class:
                     class: ''
-            weight: 4
+            weight: 5
             additional: {  }
           d48183f8-9763-4ebf-95ff-50835d6f7298:
             uuid: d48183f8-9763-4ebf-95ff-50835d6f7298
@@ -106,6 +106,17 @@ third_party_settings:
               views_label: ''
               items_per_page: none
             weight: 6
+            additional: {  }
+          b448d9f3-f8b3-4ca1-ae45-6b412a8ee0f9:
+            uuid: b448d9f3-f8b3-4ca1-ae45-6b412a8ee0f9
+            region: main
+            configuration:
+              id: jumpstart_ui_skipnav_main_anchor
+              label: 'Main content anchor target'
+              label_display: '0'
+              provider: jumpstart_ui
+              context_mapping: {  }
+            weight: 4
             additional: {  }
         third_party_settings: {  }
   layout_library:

--- a/config/sync/core.entity_view_display.taxonomy_term.stanford_publication_topics.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.stanford_publication_topics.default.yml
@@ -71,7 +71,7 @@ third_party_settings:
               context_mapping: {  }
               views_label: ''
               items_per_page: none
-            weight: 3
+            weight: 4
             additional: {  }
           691a3b23-5601-4580-9af4-2fef58b42282:
             uuid: 691a3b23-5601-4580-9af4-2fef58b42282
@@ -96,7 +96,7 @@ third_party_settings:
               label_display: '0'
               provider: jumpstart_ui
               context_mapping: {  }
-            weight: 2
+            weight: 3
             additional: {  }
           61389484-9462-48da-92fa-e0f05fb01ee9:
             uuid: 61389484-9462-48da-92fa-e0f05fb01ee9
@@ -116,6 +116,17 @@ third_party_settings:
                 third_party_settings:
                   field_formatter_class:
                     class: ''
+            weight: 2
+            additional: {  }
+          69d470da-385d-47b5-956d-8cbc7421801a:
+            uuid: 69d470da-385d-47b5-956d-8cbc7421801a
+            region: main
+            configuration:
+              id: jumpstart_ui_skipnav_main_anchor
+              label: 'Main content anchor target'
+              label_display: '0'
+              provider: jumpstart_ui
+              context_mapping: {  }
             weight: 1
             additional: {  }
         third_party_settings: {  }

--- a/config/sync/field.field.node.stanford_event.su_event_type.yml
+++ b/config/sync/field.field.node.stanford_event.su_event_type.yml
@@ -11,7 +11,7 @@ field_name: su_event_type
 entity_type: node
 bundle: stanford_event
 label: 'Event Types'
-description: ''
+description: 'Add all Event Type terms for this event. Note: Only the first selected term will be displayed to the end-users. The complete list of terms will be displayed at the end of the event page. <a href="https://userguide.sites.stanford.edu/build-and-design/events/events-taxonomy">How to add, edit and delete event terms.</a>'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.stanford_news.su_news_topics.yml
+++ b/config/sync/field.field.node.stanford_news.su_news_topics.yml
@@ -11,7 +11,7 @@ field_name: su_news_topics
 entity_type: node
 bundle: stanford_news
 label: 'News Types'
-description: 'Add all topic terms for your article here. Note, the top 3 topic terms in this list will be displayed on the list page teaser. The complete list of terms will be displayed at the end of the article page. You can rearrange the list using the drag-drop functionality. <a href="https://userguide.sites.stanford.edu/tour/news/how-add-edit-and-delete-news-topics-taxonomy" target="_blank">How to add, edit and delete news topics terms.</a>'
+description: 'Add all News Type terms for this article. Note: Only the top three selected terms will be displayed to the end-users. The complete list of terms will be displayed at the end of the article page. <a href="https://userguide.sites.stanford.edu/tour/news/how-add-edit-and-delete-news-topics-taxonomy">How to add, edit and delete news terms.</a>'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.node.stanford_page.su_basic_page_type.yml
+++ b/config/sync/field.field.node.stanford_page.su_basic_page_type.yml
@@ -10,7 +10,7 @@ id: node.stanford_page.su_basic_page_type
 field_name: su_basic_page_type
 entity_type: node
 bundle: stanford_page
-label: 'Basic Page Type (experimental)'
+label: 'Basic Page Type'
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.node.stanford_publication.su_publication_topics.yml
+++ b/config/sync/field.field.node.stanford_publication.su_publication_topics.yml
@@ -11,7 +11,7 @@ field_name: su_publication_topics
 entity_type: node
 bundle: stanford_publication
 label: 'Publication Types'
-description: 'Add all topic terms for your publication here. Note, the top topic term in this list will be displayed at the top of the publication page. The complete list of terms will be displayed at the end of the publication page. You can rearrange the list using the drag-drop functionality. <a href="https://userguide.sites.stanford.edu/tour/publications#publication-taxonomy">How to add, edit and delete publication topics terms.</a>'
+description: 'Add all News Type terms for this article. Note: Only the top three selected terms will be displayed to the end-users. The complete list of terms will be displayed at the end of the article page. <a href="https://userguide.sites.stanford.edu/build-and-design/taxonomy/publication-taxonomy">How to add, edit and delete news terms.</a>'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/pathauto.pattern.course_nodes.yml
+++ b/config/sync/pathauto.pattern.course_nodes.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: 'courses/[node:su_course_subject][node:su_course_code]'
 selection_criteria:
   35b60486-f02f-420f-83ed-b275e67bbe32:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 35b60486-f02f-420f-83ed-b275e67bbe32
     context_mapping:

--- a/config/sync/pathauto.pattern.event_nodes.yml
+++ b/config/sync/pathauto.pattern.event_nodes.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: 'events/[node:su_event_type:entity:parents]/[node:su_event_type:entity:name]/[node:title]'
 selection_criteria:
   640078f3-4fdd-4235-89c4-cf879ccadd84:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 640078f3-4fdd-4235-89c4-cf879ccadd84
     context_mapping:

--- a/config/sync/pathauto.pattern.event_series.yml
+++ b/config/sync/pathauto.pattern.event_series.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: 'event/series/[node:title]'
 selection_criteria:
   7e335004-e90f-455b-811f-8f26492117ae:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 7e335004-e90f-455b-811f-8f26492117ae
     context_mapping:

--- a/config/sync/pathauto.pattern.news_nodes.yml
+++ b/config/sync/pathauto.pattern.news_nodes.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: 'news/[node:title]'
 selection_criteria:
   7a7d05be-0ed3-47a8-a375-bc151a7ee92d:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 7a7d05be-0ed3-47a8-a375-bc151a7ee92d
     context_mapping:

--- a/config/sync/pathauto.pattern.person.yml
+++ b/config/sync/pathauto.pattern.person.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: 'people/[node:title]'
 selection_criteria:
   9bb8a053-82fe-4ca7-8a84-452b1a42997e:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 9bb8a053-82fe-4ca7-8a84-452b1a42997e
     context_mapping:

--- a/config/sync/pathauto.pattern.stanford_publications.yml
+++ b/config/sync/pathauto.pattern.stanford_publications.yml
@@ -10,7 +10,7 @@ type: 'canonical_entities:node'
 pattern: 'publications/[node:su_publication_topics:0:entity:name]/[node:title]'
 selection_criteria:
   ef034bef-fc25-4dde-ade8-4a026e5b99a7:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: ef034bef-fc25-4dde-ade8-4a026e5b99a7
     context_mapping:

--- a/config/sync/taxonomy.vocabulary.basic_page_types.yml
+++ b/config/sync/taxonomy.vocabulary.basic_page_types.yml
@@ -2,7 +2,7 @@ uuid: 691c9ec9-c242-456b-b134-c4effd13704f
 langcode: en
 status: true
 dependencies: {  }
-name: 'Basic Page Types (Experimental)'
+name: 'Basic Page Types'
 vid: basic_page_types
 description: 'Terms used to group types of basic pages that can be displayed in lists'
 weight: 0

--- a/config/sync/taxonomy.vocabulary.basic_page_types.yml
+++ b/config/sync/taxonomy.vocabulary.basic_page_types.yml
@@ -1,8 +1,24 @@
 uuid: 691c9ec9-c242-456b-b134-c4effd13704f
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - scheduler
+third_party_settings:
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    show_message_after_update: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 name: 'Basic Page Types'
 vid: basic_page_types
-description: 'Terms used to group types of basic pages that can be displayed in lists'
+description: 'Broad categories that specify a type of Basic Page. (i.e. Research Projects)'
 weight: 0

--- a/config/sync/taxonomy.vocabulary.event_audience.yml
+++ b/config/sync/taxonomy.vocabulary.event_audience.yml
@@ -1,8 +1,24 @@
 uuid: f910e8ce-fff9-4502-9113-463a402dbce3
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - scheduler
+third_party_settings:
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    show_message_after_update: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 name: 'Event Audience'
 vid: event_audience
-description: 'A curated list of groups that an event is open to.'
+description: 'A curated list of groups that an Event is open to.'
 weight: 0

--- a/config/sync/taxonomy.vocabulary.stanford_event_types.yml
+++ b/config/sync/taxonomy.vocabulary.stanford_event_types.yml
@@ -1,8 +1,24 @@
 uuid: c1e1b57f-1f00-49a3-a3eb-2f3b1e9d032f
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - scheduler
+third_party_settings:
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    show_message_after_update: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 name: 'Event Types'
 vid: stanford_event_types
-description: 'Terms used to group types of events so they can be displayed in lists.'
+description: 'Broad categories that specify a type of Event. (i.e. Lecture)'
 weight: 0

--- a/config/sync/taxonomy.vocabulary.stanford_news_topics.yml
+++ b/config/sync/taxonomy.vocabulary.stanford_news_topics.yml
@@ -20,5 +20,5 @@ third_party_settings:
     unpublish_revision: false
 name: 'News Types'
 vid: stanford_news_topics
-description: 'List of topics for items'
+description: 'Broad categories that specify a type of News article. (i.e. Blog)'
 weight: 0

--- a/config/sync/taxonomy.vocabulary.stanford_person_types.yml
+++ b/config/sync/taxonomy.vocabulary.stanford_person_types.yml
@@ -1,8 +1,24 @@
 uuid: 4aa6f924-e809-4480-9e04-51b9138d28f4
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - scheduler
+third_party_settings:
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    show_message_after_update: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 name: 'Person Types'
 vid: stanford_person_types
-description: 'Categorization of people'
+description: 'Terms to support grouping of People.'
 weight: 0

--- a/config/sync/taxonomy.vocabulary.stanford_publication_topics.yml
+++ b/config/sync/taxonomy.vocabulary.stanford_publication_topics.yml
@@ -20,5 +20,5 @@ third_party_settings:
     unpublish_revision: false
 name: 'Publication Types'
 vid: stanford_publication_topics
-description: ''
+description: 'Broad categories that specify a type of Publication. (i.e. white-paper)'
 weight: 0

--- a/config/sync/taxonomy.vocabulary.su_shared_tags.yml
+++ b/config/sync/taxonomy.vocabulary.su_shared_tags.yml
@@ -23,5 +23,5 @@ third_party_settings:
     flat: 1
 name: 'Shared Tags'
 vid: su_shared_tags
-description: 'A shared vocabulary across all content'
+description: 'Terms that can be used to describe all content types (i.e. Featured)'
 weight: 0

--- a/config/sync/user.role.site_builder.yml
+++ b/config/sync/user.role.site_builder.yml
@@ -59,7 +59,6 @@ dependencies:
     - role_delegation
     - scheduler
     - shortcut
-    - stanford_courses_importer
     - stanford_media
     - stanford_profile
     - stanford_publication

--- a/config/sync/user.role.site_developer.yml
+++ b/config/sync/user.role.site_developer.yml
@@ -70,7 +70,6 @@ dependencies:
     - scheduler
     - seckit
     - shortcut
-    - stanford_courses_importer
     - stanford_media
     - stanford_profile
     - stanford_publication

--- a/config/sync/user.role.site_manager.yml
+++ b/config/sync/user.role.site_manager.yml
@@ -40,7 +40,6 @@ dependencies:
     - redirect
     - role_delegation
     - scheduler
-    - stanford_courses_importer
     - stanford_migrate
     - stanford_profile
     - stanford_publication

--- a/config/sync/views.view.stanford_basic_pages.yml
+++ b/config/sync/views.view.stanford_basic_pages.yml
@@ -17,7 +17,7 @@ dependencies:
     - user
     - views_taxonomy_term_name_depth
 id: stanford_basic_pages
-label: 'Basic Pages (experimental)'
+label: 'Basic Pages'
 module: views
 description: ''
 tag: ''

--- a/tests/codeception/acceptance/Content/BasicPageCest.php
+++ b/tests/codeception/acceptance/Content/BasicPageCest.php
@@ -89,7 +89,7 @@ class BasicPageCest {
     $I->see('Basic Page Type');
     $I->fillField('Title', $title);
     $I->fillField('Page Description', $description);
-    $I->selectOption('Basic Page Type (experimental)', 'Research Project');
+    $I->selectOption('Basic Page Type', 'Research Project');
     $I->click('Save');
     $I->seeInSource('<meta name="description" content="' . $description . '" />');
   }

--- a/tests/codeception/acceptance/Content/PersonCest.php
+++ b/tests/codeception/acceptance/Content/PersonCest.php
@@ -140,38 +140,38 @@ class PersonCest {
   public function testD8Core2613Terms(AcceptanceTester $I) {
     $I->logInWithRole('site_manager');
 
-    $foo = $I->createEntity([
-      'name' => 'Foo',
+    $term1 = $I->createEntity([
+      'name' => $this->faker->words(2),
       'vid' => 'stanford_person_types',
     ], 'taxonomy_term');
-    $bar = $I->createEntity([
-      'name' => 'Bar',
+    $term2 = $I->createEntity([
+      'name' => $this->faker->words(2),
       'vid' => 'stanford_person_types',
     ], 'taxonomy_term');
-    $baz = $I->createEntity([
-      'name' => 'Baz',
+    $term3 = $I->createEntity([
+      'name' => $this->faker->words(2),
       'vid' => 'stanford_person_types',
-      'parent' => ['target_id' => $foo->id()],
+      'parent' => ['target_id' => $term1->id()],
     ], 'taxonomy_term');
 
     $I->amOnPage('/people');
-    $I->canSeeLink('Foo');
-    $I->canSeeLink('Bar');
-    $I->cantSeeLink('Baz');
+    $I->canSeeLink($term1->label());
+    $I->canSeeLink($term2->label());
+    $I->cantSeeLink($term3->label());
 
-    $I->amOnPage($baz->toUrl('edit-form')->toString());
+    $I->amOnPage($term3->toUrl('edit-form')->toString());
     $I->selectOption('Parent term', '<root>');
     $I->click('Save');
 
     $I->amOnPage('/people');
-    $I->canSeeLink('Baz');
+    $I->canSeeLink($term3->label());
 
-    $I->amOnPage($baz->toUrl('edit-form')->toString());
-    $I->selectOption('Parent term', 'Bar');
+    $I->amOnPage($term3->toUrl('edit-form')->toString());
+    $I->selectOption('Parent term', $term2->label());
     $I->click('Save');
 
     $I->amOnPage('/people');
-    $I->cantSeeLink('Baz');
+    $I->cantSeeLink($term3->label());
 
     $faker = Factory::create();
     $parent = $I->createEntity([


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- D8CORE-5750 Limit event cards to 1 taxonomy term
- D8CORE-5757 Add main content anchor links to term page
   - Event Types
   - News Types
   - People Types
   - Publication Types
- D8CORE-5759 Adjust display settings for the local footer to properly format wysiwyg contents (centered images)
   - All that it really did was wrap the WSYIWYG fields in a class we already use.
- D8CORE-5760 Limit news and publication terms to 3 in card displays
- D8CORE-5767 Remove "Experimental" for basic page types
- D8CORE-5762 Update 7 taxonomy vocabulary descriptions
- D8CORE-5751 Update help text on three fields
   - Event Types
   - News Types
   - Publication Types

# Need Review By (Date)
- Thursday

# Urgency
- High

# Steps to Test
1. checkout this branch
2. import configs
3. Verify each of the items in the summary.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
