### PR TITLE
D8CORE-4972 Provide aria-label input for links on paragraphs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -159,6 +159,7 @@
         "drupal/layout_builder_modal": "^1.0",
         "drupal/layout_builder_restrictions": "^2.2",
         "drupal/layout_library": "^1.0-beta1",
+        "drupal/link_attributes": "^1.11",
         "drupal/link_title_formatter": "^2.0",
         "drupal/linkit": "^6.0",
         "drupal/markup": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -207,7 +207,7 @@
         "seboettg/citeproc-php": "2.4.1",
         "su-sws/drupal-patches": "^8.0",
         "su-sws/nobots": "dev-8.x-2.x",
-        "su-sws/react_paragraphs": "dev-D8CORE-4972",
+        "su-sws/react_paragraphs": "8.x-dev",
         "su-sws/stanford_actions": "8.x-dev",
         "su-sws/stanford_fields": "8.x-dev",
         "su-sws/stanford_media": "8.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -207,7 +207,7 @@
         "seboettg/citeproc-php": "2.4.1",
         "su-sws/drupal-patches": "^8.0",
         "su-sws/nobots": "dev-8.x-2.x",
-        "su-sws/react_paragraphs": "8.x-dev",
+        "su-sws/react_paragraphs": "dev-D8CORE-4972",
         "su-sws/stanford_actions": "8.x-dev",
         "su-sws/stanford_fields": "8.x-dev",
         "su-sws/stanford_media": "8.x-dev",

--- a/config/sync/core.entity_form_display.paragraph.stanford_banner.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.stanford_banner.default.yml
@@ -10,7 +10,7 @@ dependencies:
     - field.field.paragraph.stanford_banner.su_banner_sup_header
     - paragraphs.paragraphs_type.stanford_banner
   module:
-    - link
+    - link_attributes
     - media_library
     - text
 id: paragraph.stanford_banner.default
@@ -35,12 +35,21 @@ content:
       placeholder: ''
     third_party_settings: {  }
   su_banner_button:
-    type: link_default
+    type: link_attributes
     weight: 4
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
+      enabled_attributes:
+        aria-label: true
+        id: false
+        name: false
+        target: false
+        rel: false
+        class: false
+        accesskey: false
+        title: false
     third_party_settings: {  }
   su_banner_header:
     type: string_textfield

--- a/config/sync/core.entity_form_display.paragraph.stanford_card.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.stanford_card.default.yml
@@ -11,7 +11,7 @@ dependencies:
     - field.field.paragraph.stanford_card.su_card_super_header
     - paragraphs.paragraphs_type.stanford_card
   module:
-    - link
+    - link_attributes
     - media_library
     - text
 id: paragraph.stanford_card.default
@@ -36,12 +36,21 @@ content:
       placeholder: ''
     third_party_settings: {  }
   su_card_link:
-    type: link_default
+    type: link_attributes
     weight: 4
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
+      enabled_attributes:
+        aria-label: true
+        id: false
+        name: false
+        target: false
+        rel: false
+        class: false
+        accesskey: false
+        title: false
     third_party_settings: {  }
   su_card_link_display:
     type: options_select

--- a/config/sync/core.entity_form_display.paragraph.stanford_entity.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.stanford_entity.default.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.paragraph.stanford_entity.su_entity_item
     - paragraphs.paragraphs_type.stanford_entity
   module:
-    - link
+    - link_attributes
     - text
 id: paragraph.stanford_entity.default
 targetEntityType: paragraph
@@ -17,12 +17,21 @@ bundle: stanford_entity
 mode: default
 content:
   su_entity_button:
-    type: link_default
+    type: link_attributes
     weight: 3
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
+      enabled_attributes:
+        aria-label: true
+        id: false
+        name: false
+        target: false
+        rel: false
+        class: false
+        accesskey: false
+        title: false
     third_party_settings: {  }
   su_entity_description:
     type: text_textarea

--- a/config/sync/core.entity_form_display.paragraph.stanford_gallery.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.stanford_gallery.default.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.paragraph.stanford_gallery.su_gallery_images
     - paragraphs.paragraphs_type.stanford_gallery
   module:
-    - link
+    - link_attributes
     - media_library
     - text
 id: paragraph.stanford_gallery.default
@@ -18,12 +18,21 @@ bundle: stanford_gallery
 mode: default
 content:
   su_gallery_button:
-    type: link_default
+    type: link_attributes
     weight: 3
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
+      enabled_attributes:
+        aria-label: true
+        id: false
+        name: false
+        target: false
+        rel: false
+        class: false
+        accesskey: false
+        title: false
     third_party_settings: {  }
   su_gallery_description:
     type: text_textarea

--- a/config/sync/core.entity_form_display.paragraph.stanford_lists.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.stanford_lists.default.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.paragraph.stanford_lists.su_list_view
     - paragraphs.paragraphs_type.stanford_lists
   module:
-    - link
+    - link_attributes
     - text
     - viewfield
 id: paragraph.stanford_lists.default
@@ -18,12 +18,21 @@ bundle: stanford_lists
 mode: default
 content:
   su_list_button:
-    type: link_default
+    type: link_attributes
     weight: 3
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
+      enabled_attributes:
+        aria-label: true
+        id: false
+        name: false
+        target: false
+        rel: false
+        class: false
+        accesskey: false
+        title: false
     third_party_settings: {  }
   su_list_description:
     type: text_textarea

--- a/config/sync/core.entity_form_display.paragraph.stanford_media_caption.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.stanford_media_caption.default.yml
@@ -8,7 +8,7 @@ dependencies:
     - field.field.paragraph.stanford_media_caption.su_media_caption_media
     - paragraphs.paragraphs_type.stanford_media_caption
   module:
-    - link
+    - link_attributes
     - media_library
     - text
 id: paragraph.stanford_media_caption.default
@@ -25,12 +25,21 @@ content:
       placeholder: ''
     third_party_settings: {  }
   su_media_caption_link:
-    type: link_default
+    type: link_attributes
     weight: 2
     region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
+      enabled_attributes:
+        aria-label: true
+        id: false
+        name: false
+        target: false
+        rel: false
+        class: false
+        accesskey: false
+        title: false
     third_party_settings: {  }
   su_media_caption_media:
     type: media_library_widget

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -93,6 +93,7 @@ module:
   layout_discovery: 0
   layout_library: 0
   link: 0
+  link_attributes: 0
   link_title_formatter: 0
   linkit: 0
   markup: 0

--- a/config/sync/field.field.paragraph.stanford_banner.su_banner_button.yml
+++ b/config/sync/field.field.paragraph.stanford_banner.su_banner_button.yml
@@ -12,7 +12,7 @@ field_name: su_banner_button
 entity_type: paragraph
 bundle: stanford_banner
 label: Button
-description: 'A call to action link that shows up below the main body content.'
+description: "A call to action link that shows up below the main body content.<br>\r\nUse the \"Aria Label\" to provide more descriptive information to the user when the \"Link Text\" provide general or less specific information. For Example: If the link text is simply \"Read More\", set the Aria Label to something like \"Read more about the department policies\"."
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.paragraph.stanford_card.su_card_link.yml
+++ b/config/sync/field.field.paragraph.stanford_card.su_card_link.yml
@@ -12,7 +12,7 @@ field_name: su_card_link
 entity_type: paragraph
 bundle: stanford_card
 label: Link
-description: 'This is the text that will display on the site'
+description: "This is the text that will display on the site<br>\r\nUse the \"Aria Label\" to provide more descriptive information to the user when the \"Link Text\" provide general or less specific information. For Example: If the link text is simply \"Read More\", set the Aria Label to something like \"Read more about the department policies\"."
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.paragraph.stanford_entity.su_entity_button.yml
+++ b/config/sync/field.field.paragraph.stanford_entity.su_entity_button.yml
@@ -12,7 +12,7 @@ field_name: su_entity_button
 entity_type: paragraph
 bundle: stanford_entity
 label: Button
-description: 'This button will appear below the content items.'
+description: "This button will appear below the content items.<br>\r\nUse the \"Aria Label\" to provide more descriptive information to the user when the \"Link Text\" provide general or less specific information. For Example: If the link text is simply \"Read More\", set the Aria Label to something like \"Read more about the department policies\"."
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.paragraph.stanford_gallery.su_gallery_button.yml
+++ b/config/sync/field.field.paragraph.stanford_gallery.su_gallery_button.yml
@@ -12,7 +12,7 @@ field_name: su_gallery_button
 entity_type: paragraph
 bundle: stanford_gallery
 label: Button
-description: ''
+description: 'Use the "Aria Label" to provide more descriptive information to the user when the "Link Text" provide general or less specific information. For Example: If the link text is simply "Read More", set the Aria Label to something like "Read more about the department policies".'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.paragraph.stanford_lists.su_list_button.yml
+++ b/config/sync/field.field.paragraph.stanford_lists.su_list_button.yml
@@ -12,7 +12,7 @@ field_name: su_list_button
 entity_type: paragraph
 bundle: stanford_lists
 label: Button
-description: 'This button will appear at the end of the list view.'
+description: "This button will appear at the end of the list view.<br>\r\nUse the \"Aria Label\" to provide more descriptive information to the user when the \"Link Text\" provide general or less specific information. For Example: If the link text is simply \"Read More\", set the Aria Label to something like \"Read more about the department policies\"."
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.paragraph.stanford_media_caption.su_media_caption_link.yml
+++ b/config/sync/field.field.paragraph.stanford_media_caption.su_media_caption_link.yml
@@ -12,7 +12,7 @@ field_name: su_media_caption_link
 entity_type: paragraph
 bundle: stanford_media_caption
 label: Link
-description: 'Link the media to something. Only works with images. '
+description: "Link the media to something. Only works with images.<br>\r\nUse the \"Aria Label\" to provide more descriptive information to the user when the \"Link Text\" provide general or less specific information. For Example: If the link text is simply \"Read More\", set the Aria Label to something like \"Read more about the department policies\"."
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/filter.format.stanford_html.yml
+++ b/config/sync/filter.format.stanford_html.yml
@@ -58,7 +58,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <b> <em> <strong> <cite> <blockquote cite> <pre class> <code data-* class> <ul type class id> <ol start type class id> <li class id> <dl class> <dt> <dd class> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <div class id> <table class id> <caption> <tbody class> <thead> <tfoot> <th scope class id> <td colspan rowspan class id> <tr id> <sup> <sub> <i class> <hr> <s> <aside class> <drupal-media data-entity-type data-entity-uuid data-align data-caption data-* alt data-view-mode title> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title name class> <p class id> <img class src alt title><abbr id title>'
+      allowed_html: '<br> <b> <em> <strong> <cite> <blockquote cite> <pre class> <code data-* class> <ul type class id> <ol start type class id> <li class id> <dl class> <dt> <dd class> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <div class id> <table class id> <caption> <tbody class> <thead> <tfoot> <th scope class id> <td colspan rowspan class id> <tr id> <sup> <sub> <i class> <hr> <s> <aside class> <drupal-media data-entity-type data-entity-uuid data-align data-caption data-* alt data-view-mode title> <a href aria-label hreflang data-entity-substitution data-entity-type data-entity-uuid title name class> <p class id> <img class src alt title><abbr id title>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_htmlcorrector:

--- a/config/sync/filter.format.stanford_minimal_html.yml
+++ b/config/sync/filter.format.stanford_minimal_html.yml
@@ -15,7 +15,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<br> <p class id> <div class id> <em> <strong> <cite> <blockquote cite> <code> <dd> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title class id>'
+      allowed_html: '<br> <p class id> <div class id> <em> <strong> <cite> <blockquote cite> <code> <dd> <a href aria-label hreflang data-entity-substitution data-entity-type data-entity-uuid title class id>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_htmlcorrector:

--- a/modules/jumpstart_ui/jumpstart_ui.module
+++ b/modules/jumpstart_ui/jumpstart_ui.module
@@ -40,13 +40,18 @@ function jumpstart_ui_preprocess_ds_entity_view(&$variables) {
     $link_attributes_key = NULL;
     switch ($variables['content']['#id']) {
       case 'hero':
-        $link_field = reset($variables['content']['#ds_configuration']['regions']['hero_button_link']);
-        $link_attributes_key = 'hero_cta_attributes';
+
+        if (isset($variables['content']['#ds_configuration']['regions']['hero_button_link'])) {
+          $link_field = reset($variables['content']['#ds_configuration']['regions']['hero_button_link']);
+          $link_attributes_key = 'hero_cta_attributes';
+        }
         break;
 
-      case'card':
-        $link_field = reset($variables['content']['#ds_configuration']['regions']['card_link']);
-        $link_attributes_key = 'card_cta_attributes';
+      case 'card':
+        if (isset($variables['content']['#ds_configuration']['regions']['card_link'])) {
+          $link_field = reset($variables['content']['#ds_configuration']['regions']['card_link']);
+          $link_attributes_key = 'card_cta_attributes';
+        }
         break;
     }
 

--- a/modules/jumpstart_ui/jumpstart_ui.module
+++ b/modules/jumpstart_ui/jumpstart_ui.module
@@ -29,6 +29,7 @@ function jumpstart_ui_page_attachments(array &$page) {
   }
 
 }
+
 /**
  * Implements hook_preprocess_HOOK().
  */

--- a/modules/jumpstart_ui/jumpstart_ui.module
+++ b/modules/jumpstart_ui/jumpstart_ui.module
@@ -8,9 +8,10 @@
  */
 
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
-use Drupal\ui_patterns\UiPatterns;
 use Drupal\ui_patterns\Element\PatternContext;
+use Drupal\ui_patterns\UiPatterns;
 
 /**
  * Implements hook_page_attachments().
@@ -27,6 +28,38 @@ function jumpstart_ui_page_attachments(array &$page) {
     $page['#attached']['library'][] = 'jumpstart_ui/jumpstart_ui';
   }
 
+}
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function jumpstart_ui_preprocess_ds_entity_view(&$variables) {
+  /** @var \Drupal\Core\Entity\FieldableEntityInterface $entity */
+  $entity = $variables['content']['#entity'];
+  if ($variables['content']['#type'] == 'pattern') {
+    $link_field = NULL;
+    $link_attributes_key = NULL;
+    switch ($variables['content']['#id']) {
+      case 'hero':
+        $link_field = reset($variables['content']['#ds_configuration']['regions']['hero_button_link']);
+        $link_attributes_key = 'hero_cta_attributes';
+        break;
+
+      case'card':
+        $link_field = reset($variables['content']['#ds_configuration']['regions']['card_link']);
+        $link_attributes_key = 'card_cta_attributes';
+        break;
+    }
+
+    if (
+      $link_field &&
+      $entity->hasField($link_field) &&
+      $entity->get($link_field)->count()
+    ) {
+      $link = $entity->get($link_field);
+      $options = $link->get(0)->get('options')->getValue();
+      $variables['content']['#fields'][$link_attributes_key] = new Attribute($options['attributes'] ?? []);
+    }
+  }
 }
 
 /**

--- a/tests/codeception/acceptance/Content/PublicationsCest.php
+++ b/tests/codeception/acceptance/Content/PublicationsCest.php
@@ -9,6 +9,23 @@ use Faker\Factory;
  */
 class PublicationsCest {
 
+  /**
+   * Faker generator.
+   *
+   * @var \Faker\Generator
+   */
+  protected $faker;
+
+  /**
+   * Keyed array of values to save to review later.
+   *
+   * @var array
+   */
+  protected $values = [];
+
+  /**
+   * Test constructor.
+   */
   public function __construct() {
     $this->faker = Factory::create();
   }
@@ -17,48 +34,47 @@ class PublicationsCest {
    * Create a book citation
    */
   public function testBookCitation(AcceptanceTester $I) {
+    $this->values['term_name'] = $this->faker->words(3, TRUE);
+    $this->values['node_title'] = $this->faker->words(3, TRUE);
     $term = $I->createEntity([
       'vid' => 'stanford_publication_topics',
-      'name' => 'Foo Bar',
+      'name' => $this->values['term_name'],
     ], 'taxonomy_term');
 
-    $faker = Factory::create();
     $I->logInWithRole('site_manager');
     $I->amOnPage('/node/add/stanford_publication');
-    $I->fillField('Title', 'Test Publication');
+    $I->fillField('Title', $this->values['node_title']);
     $I->selectOption('Publication Types', $term->label());
     $I->selectOption('su_publication_citation[actions][bundle]', 'Book');
     $I->click('Add Citation');
-    $I->fillField('First Name', $faker->firstName);
-    $I->fillField('Last Name/Company', $faker->lastName);
-    $I->fillField('Subtitle', $faker->text);
-    $I->fillField('Publication Place', $faker->text);
-    $I->fillField('Publisher', $faker->text);
-    $I->fillField('Year', $faker->numberBetween(1900, 2020));
-    $I->fillField('su_publication_cta[0][uri]', $faker->url);
-    $I->fillField('Link text', $faker->text);
+    $I->fillField('First Name', $this->faker->firstName);
+    $I->fillField('Last Name/Company', $this->faker->lastName);
+    $I->fillField('Subtitle', $this->faker->text);
+    $I->fillField('Publication Place', $this->faker->text);
+    $I->fillField('Publisher', $this->faker->text);
+    $I->fillField('Year', $this->faker->numberBetween(1900, 2020));
+    $I->fillField('su_publication_cta[0][uri]', $this->faker->url);
+    $I->fillField('Link text', $this->faker->text);
 
     $I->click('Save');
-    $I->canSee('Test Publication', 'h1');
+    $I->canSee($this->values['node_title'], 'h1');
   }
 
   /**
    * Test out the list pages.
    */
   public function testAllPublicationListPage(AcceptanceTester $I) {
-    $faker = Factory::create();
     $this->testBookCitation($I);
     $I->amOnPage('/publications');
-    $I->canSee('Test Publication');
-    $I->click('Foo Bar');
-    $I->assertEquals('/publications/foo-bar', $I->grabFromCurrentUrl());
-    $I->canSee('Foo Bar', 'h1');
-    $I->canSee('Test Publication');
-    $I->canSeeLink('Foo Bar');
+    $I->canSee($this->values['node_title']);
+    $I->click($this->values['term_name']);
+    $I->canSee($this->values['term_name'], 'h1');
+    $I->canSee($this->values['node_title']);
+    $I->canSeeLink($this->values['term_name']);
 
     $term = $I->createEntity([
       'vid' => 'stanford_publication_topics',
-      'name' => $faker->text(10),
+      'name' => $this->faker->text(10),
     ], 'taxonomy_term');
     \Drupal::service('cache.render')->deleteAll();
     \Drupal::service('router.builder')->rebuild();
@@ -73,7 +89,7 @@ class PublicationsCest {
     $I->logInWithRole('site_manager');
     $term = $I->createEntity([
       'vid' => 'stanford_publication_topics',
-      'name' => 'Foo',
+      'name' => $this->faker->words(2, TRUE),
     ], 'taxonomy_term');
     $I->amOnPage($term->toUrl('edit-form')->toString());
     $I->cantSee('Published');
@@ -83,21 +99,21 @@ class PublicationsCest {
    * An "Other" publication type should be available.
    */
   public function testOtherPublication(AcceptanceTester $I) {
-    $faker = Factory::create();
+    $this->values['node_title'] = $this->faker->words(3, TRUE);
     $I->logInWithRole('site_manager');
     $I->amOnPage('/node/add/stanford_publication');
-    $I->fillField('Title', 'Test Publication');
+    $I->fillField('Title', $this->values['node_title']);
     $I->selectOption('su_publication_citation[actions][bundle]', 'Other');
     $I->click('Add Citation');
-    $I->fillField('First Name', $faker->firstName);
-    $I->fillField('Last Name/Company', $faker->lastName);
-    $I->fillField('Subtitle', $faker->text);
-    $I->fillField('Publisher', $faker->text);
-    $I->fillField('su_publication_cta[0][uri]', $faker->url);
-    $I->fillField('Link text', $faker->text);
+    $I->fillField('First Name', $this->faker->firstName);
+    $I->fillField('Last Name/Company', $this->faker->lastName);
+    $I->fillField('Subtitle', $this->faker->text);
+    $I->fillField('Publisher', $this->faker->text);
+    $I->fillField('su_publication_cta[0][uri]', $this->faker->url);
+    $I->fillField('Link text', $this->faker->text);
 
     $I->click('Save');
-    $I->canSee('Test Publication', 'h1');
+    $I->canSee($this->values['node_title'], 'h1');
     $I->canSee('Publication', '.node-stanford-publication-citation-type');
   }
 
@@ -105,38 +121,42 @@ class PublicationsCest {
    * Publication list should be in date order.
    */
   public function testListSort(AcceptanceTester $I) {
+    $this->values['a_node_title'] = 'A' . $this->faker->words(3, TRUE);
+    $this->values['b_node_title'] = 'B' . $this->faker->words(3, TRUE);
+    $this->values['c_node_title'] = 'C' . $this->faker->words(3, TRUE);
+
     $I->logInWithRole('site_manager');
 
     $I->amOnPage('/node/add/stanford_publication');
-    $I->fillField('Title', 'A June 1st Pub');
+    $I->fillField('Title', $this->values['a_node_title']);
     $I->selectOption('su_publication_citation[actions][bundle]', 'Other');
     $I->click('Add Citation');
     $I->fillField('Year', 2020);
     $I->fillField('Month', 6);
     $I->fillField('Day', 1);
     $I->click('Save');
-    $I->canSee('A June 1st Pub', 'h1');
+    $I->canSee($this->values['a_node_title'], 'h1');
 
 
     $I->amOnPage('/node/add/stanford_publication');
-    $I->fillField('Title', 'B June 15th Pub');
+    $I->fillField('Title', $this->values['b_node_title']);
     $I->selectOption('su_publication_citation[actions][bundle]', 'Other');
     $I->click('Add Citation');
     $I->fillField('Year', 2020);
     $I->fillField('Month', 6);
     $I->fillField('Day', 15);
     $I->click('Save');
-    $I->canSee('B June 15th Pub', 'h1');
+    $I->canSee($this->values['b_node_title'], 'h1');
 
     $I->amOnPage('/node/add/stanford_publication');
-    $I->fillField('Title', 'C January Pub');
+    $I->fillField('Title', $this->values['c_node_title']);
     $I->selectOption('su_publication_citation[actions][bundle]', 'Other');
     $I->click('Add Citation');
     $I->fillField('Year', 2020);
     $I->fillField('Month', 1);
     $I->fillField('Day', 15);
     $I->click('Save');
-    $I->canSee('C January Pub', 'h1');
+    $I->canSee($this->values['c_node_title'], 'h1');
 
     $I->amOnPage('/publications');
     $titles = $I->grabMultiple('.csl-entry a');
@@ -144,19 +164,19 @@ class PublicationsCest {
       $title = preg_replace('/[^\da-z ]/i', '', $title);
     }
 
-    $a_pos = array_search('A June 1st Pub', $titles);
+    $a_pos = array_search($this->values['a_node_title'], $titles);
     $b_pos = array_search('B June 15th Pub', $titles);
-    $c_pos = array_search('C January Pub', $titles);
+    $c_pos = array_search($this->values['c_node_title'], $titles);
 
-    $I->assertGreaterThan($b_pos, $a_pos, '"A June 1st Pub" does not display after "B June 15th Pub"');
-    $I->assertGreaterThan($a_pos, $c_pos, '"C January Pub" does not display after "A June 1st Pub"');
-    $I->assertGreaterThan($b_pos, $c_pos, '"C January Pub" does not display after "B June 15th Pub"');
+    $I->assertGreaterThan($b_pos, $a_pos, sprintf('"%s" does not display after "%s"', $this->values['a_node_title'], $this->values['b_node_title']));
+    $I->assertGreaterThan($a_pos, $c_pos, sprintf('"%s" does not display after "%s"', $this->values['c_node_title'], $this->values['a_node_title']));
+    $I->assertGreaterThan($b_pos, $c_pos, sprintf('"%s" does not display after "%s"', $this->values['c_node_title'], $this->values['b_node_title']));
 
     // Ensure distinct results
     $titles_counts = array_count_values($titles);
-    $I->assertEquals(1, $titles_counts['A June 1st Pub']);
-    $I->assertEquals(1, $titles_counts['B June 15th Pub']);
-    $I->assertEquals(1, $titles_counts['C January Pub']);
+    $I->assertEquals(1, $titles_counts[$this->values['a_node_title']]);
+    $I->assertEquals(1, $titles_counts[$this->values['b_node_title']]);
+    $I->assertEquals(1, $titles_counts[$this->values['c_node_title']]);
   }
 
   /**
@@ -176,7 +196,7 @@ class PublicationsCest {
     $I->dontSee('Publications', 'h2');
     $publication = $I->createEntity([
       'type' => 'stanford_publication',
-      'title' => $this->faker->words(3, true),
+      'title' => $this->faker->words(3, TRUE),
       'su_publication_author_ref' => $author_node,
     ]);
     $I->logInWithRole('contributor');

--- a/tests/codeception/functional/BasicPage/BasicPageParagraphsCest.php
+++ b/tests/codeception/functional/BasicPage/BasicPageParagraphsCest.php
@@ -8,9 +8,33 @@ use Faker\Factory;
 class BasicPageParagraphsCest {
 
   /**
+   * Faker service.
+   *
+   * @var \Faker\Generator
+   */
+  protected $faker;
+
+  /**
+   * Test constructor.
+   */
+  public function __construct() {
+    $this->faker = Factory::create();
+  }
+
+  /**
    * Test the card component data is displayed correctly.
+   *
+   * @group aria-label
    */
   public function testCardParagraph(FunctionalTester $I) {
+    $card_values =[
+      'superhead' => $this->faker->words(3, true),
+      'headline' => $this->faker->words(3, true),
+      'uri' => $this->faker->url,
+      'title' => $this->faker->words(3, true),
+      'aria-label' => $this->faker->words(5, true),
+    ];
+
     $paragraph = $I->createEntity(['type' => 'stanford_card'], 'paragraph');
 
     $row = $I->createEntity([
@@ -23,28 +47,31 @@ class BasicPageParagraphsCest {
 
     $node = $I->createEntity([
       'type' => 'stanford_page',
-      'title' => 'Test Cards',
+      'title' => $this->faker->words(3, true),
       'su_page_components' => [
         'target_id' => $row->id(),
         'entity' => $row,
       ],
     ]);
     $I->logInWithRole('contributor');
-    $I->amOnPage("/node/{$node->id()}/edit");
+    $I->amOnPage($node->toUrl('edit-form')->toString());
     $I->waitForElementVisible('#row-0');
     $I->click('Edit', '#row-0');
     $I->waitForText('Superhead');
-    $I->fillField('Superhead', 'Superhead text');
-    $I->fillField('Headline', 'Headline');
-    $I->fillField('URL', '/about');
-    $I->fillField('Link text', 'Google Link');
+    $I->fillField('Superhead', $card_values['superhead']);
+    $I->fillField('Headline', $card_values['headline']);
+    $I->fillField('URL', $card_values['uri']);
+    $I->fillField('Link text', $card_values['title']);
+    $I->fillField('ARIA Label',$card_values['aria-label']);
     $I->click('Continue');
     $I->waitForElementNotVisible('.MuiDialog-scrollPaper');
     $I->wait(1);
     $I->click('Save', '#edit-actions');
-    $I->canSee('Superhead text');
-    $I->canSee('Headline');
-    $I->canSeeLink('Google Link', '/about');
+    $I->canSee($card_values['superhead']);
+    $I->canSee($card_values['headline']);
+    $I->canSeeLink($card_values['title'], $card_values['uri']);
+    $aria_label = $I->grabAttributeFrom("a[href='{$card_values['uri']}']", 'aria-label');
+    $I->assertEquals($card_values['aria-label'], $aria_label, sprintf('Attribute aria-label `%s` does not match expected value `%s`', $aria_label, $card_values['aria-label']));
   }
 
   /**

--- a/tests/codeception/functional/Paragraphs/BannerCest.php
+++ b/tests/codeception/functional/Paragraphs/BannerCest.php
@@ -11,20 +11,46 @@ use Faker\Factory;
 class BannerCest {
 
   /**
+   * Faker service.
+   *
+   * @var \Faker\Generator
+   */
+  protected $faker;
+
+  /**
+   * Test constructor.
+   */
+  public function __construct() {
+    $this->faker = Factory::create();
+  }
+
+  /**
    * The banner paragraph should display its fields.
+   *
+   * @group aria-label
    */
   public function testBannerBehaviors(FunctionalTester $I) {
-    $faker = Factory::create();
+    $field_values =[
+      'sup_header' => $this->faker->words(3, true),
+      'header' => $this->faker->words(3, true),
+      'body' => $this->faker->words(3, true),
+      'uri' => $this->faker->url,
+      'title' => $this->faker->words(3, true),
+      'aria-label' => $this->faker->words(5, true),
+    ];
 
     $paragraph = $I->createEntity([
       'type' => 'stanford_banner',
-      'su_banner_sup_header' => 'This is a super headline',
-      'su_banner_header' => 'Some Headline Here',
+      'su_banner_sup_header' => $field_values['sup_header'],
+      'su_banner_header' => $field_values['header'],
       'su_banner_button' => [
-        'uri' => 'http://google.com/',
-        'title' => 'Google Button',
+        'uri' => $field_values['uri'],
+        'title' => $field_values['title'],
+        'options' => [
+          'attributes' => ['aria-label' => $field_values['aria-label']]
+        ],
       ],
-      'su_banner_body' => 'Ipsum Lorem',
+      'su_banner_body' => $field_values['body'],
     ], 'paragraph');
 
     $row = $I->createEntity([
@@ -37,7 +63,7 @@ class BannerCest {
 
     $node = $I->createEntity([
       'type' => 'stanford_page',
-      'title' => $faker->text(30),
+      'title' => $this->faker->words(4, TRUE),
       'su_page_components' => [
         'target_id' => $row->id(),
         'entity' => $row,
@@ -45,10 +71,13 @@ class BannerCest {
     ]);
 
     $I->amOnPage($node->toUrl()->toString());
-    $I->canSee('This is a super headline');
-    $I->canSee('Some Headline Here');
-    $I->canSee('Ipsum Lorem');
-    $I->canSeeLink('Google Button', 'http://google.com/');
+    $I->canSee($field_values['sup_header']);
+    $I->canSee($field_values['header']);
+    $I->canSee($field_values['body']);
+    $I->canSeeLink($field_values['title'], $field_values['uri']);
+    $aria_label = $I->grabAttributeFrom("a[href='{$field_values['uri']}']", 'aria-label');
+    $I->assertEquals($field_values['aria-label'], $aria_label, sprintf('Attribute aria-label `%s` does not match expected value `%s`', $aria_label, $field_values['aria-label']));
+
     $I->cantSeeElement('.overlay-right');
 
     $I->logInWithRole('site_manager');
@@ -61,6 +90,7 @@ class BannerCest {
     $I->waitForText('Text Overlay Position');
 
     $I->clickWithLeftButton('#overlay_position');
+    $I->wait(1);
     $I->clickWithLeftButton('li[data-value="right"]');
 
     $I->click('Continue');

--- a/tests/codeception/functional/Paragraphs/EntityReferenceCest.php
+++ b/tests/codeception/functional/Paragraphs/EntityReferenceCest.php
@@ -8,6 +8,27 @@ use Faker\Factory;
 class EntityReferenceCest {
 
   /**
+   * Faker service.
+   *
+   * @var \Faker\Generator
+   */
+  protected $faker;
+
+  /**
+   * Keyed array of field values.
+   *
+   * @var array
+   */
+  protected $fieldValues = [];
+
+  /**
+   * Test constructor.
+   */
+  public function __construct() {
+    $this->faker = Factory::create();
+  }
+
+  /**
    * News items should display in the list paragraph.
    */
   public function testEntityReference(FunctionalTester $I) {
@@ -37,10 +58,11 @@ class EntityReferenceCest {
 
   /**
    * Publications can be referenced in teaser paragraph.
+   *
+   * @group aria-label
    */
   public function testPublicationTeasers(FunctionalTester $I) {
-    $faker = Factory::create();
-    $publication_title = $faker->text(20);
+    $publication_title = $this->faker->text(20);
     $I->logInWithRole('site_manager');
     $I->amOnPage('node/add/stanford_publication');
     $I->fillField('Title', $publication_title);
@@ -51,8 +73,12 @@ class EntityReferenceCest {
     $I->canSee($publication_title, 'h1');
 
     $node = $this->getNodeWithReferenceParagraph($I);
-    $I->amOnPage("/node/{$node->id()}/edit");
+    $I->amOnPage($node->toUrl()->toString());
+    $I->canSee($this->fieldValues['headliner']);
+    $I->canSee($this->fieldValues['description']);
+    $I->canSeeLink($this->fieldValues['title'], $this->fieldValues['uri']);
 
+    $I->amOnPage("/node/{$node->id()}/edit");
     $I->waitForElementVisible('#row-0');
     $I->click('Edit', '.inner-row-wrapper');
 
@@ -66,6 +92,9 @@ class EntityReferenceCest {
     $I->canSee('has been updated');
     $I->canSee($publication_title, 'h2');
     $I->canSee('Journal Article');
+
+    $aria_label = $I->grabAttributeFrom("a[href='{$this->fieldValues['uri']}']", 'aria-label');
+    $I->assertEquals($this->fieldValues['aria-label'], $aria_label, sprintf('Attribute aria-label `%s` does not match expected value `%s`', $aria_label, $this->fieldValues['aria-label']));
   }
 
   /**
@@ -77,16 +106,28 @@ class EntityReferenceCest {
    * @return bool|\Drupal\node\NodeInterface
    */
   protected function getNodeWithReferenceParagraph(FunctionalTester $I) {
-    $faker = Factory::create();
+    $this->fieldValues = [
+      'headliner' => $this->faker->words(3, TRUE),
+      'description' => $this->faker->words(3, TRUE),
+      'uri' => $this->faker->url,
+      'title' => $this->faker->words(3, TRUE),
+      'aria-label' => $this->faker->words(5, TRUE),
+    ];
 
     $paragraph = $I->createEntity([
       'type' => 'stanford_entity',
-      'su_list_headline' => 'Headliner',
-      'su_list_description' => [
+      'su_entity_headline' => $this->fieldValues['headliner'],
+      'su_entity_description' => [
         'format' => 'stanford_html',
-        'value' => '<p>Lorem Ipsum</p>',
+        'value' => $this->fieldValues['description'],
       ],
-      'su_list_button' => ['uri' => 'http://google.com', 'title' => 'Google'],
+      'su_entity_button' => [
+        'uri' => $this->fieldValues['uri'],
+        'title' => $this->fieldValues['title'],
+        'options' => [
+          'attributes' => ['aria-label' => $this->fieldValues['aria-label']],
+        ],
+      ],
     ], 'paragraph');
     $row = $I->createEntity([
       'type' => 'node_stanford_page_row',
@@ -98,7 +139,7 @@ class EntityReferenceCest {
 
     return $I->createEntity([
       'type' => 'stanford_page',
-      'title' => $faker->text(30),
+      'title' => $this->faker->text(30),
       'su_page_components' => [
         'target_id' => $row->id(),
         'entity' => $row,

--- a/tests/codeception/functional/Paragraphs/GalleryCest.php
+++ b/tests/codeception/functional/Paragraphs/GalleryCest.php
@@ -11,8 +11,6 @@ class GalleryCest {
 
   /**
    * Create a basic page with a gallery and check the colorbox actions.
-   *
-   * @group runthis
    */
   public function testGallery(FunctionalTester $I) {
     $faker = Factory::create();

--- a/tests/codeception/functional/Paragraphs/GalleryCest.php
+++ b/tests/codeception/functional/Paragraphs/GalleryCest.php
@@ -11,6 +11,8 @@ class GalleryCest {
 
   /**
    * Create a basic page with a gallery and check the colorbox actions.
+   *
+   * @group runthis
    */
   public function testGallery(FunctionalTester $I) {
     $faker = Factory::create();
@@ -30,7 +32,9 @@ class GalleryCest {
     $I->click('Upload and Continue');
 
     $I->waitForText('The media items have been created but have not yet been saved');
+    $I->clickWithLeftButton('input[name="media[0][fields][su_gallery_image][0][alt]"]');
     $I->fillField('media[0][fields][su_gallery_image][0][alt]', 'Logo');
+    $I->clickWithLeftButton('input[name="media[1][fields][su_gallery_image][0][alt]"]');
     $I->fillField('media[1][fields][su_gallery_image][0][alt]', 'Wordmark');
     $I->click('Save and insert', '.ui-dialog-buttonset');
 

--- a/tests/codeception/functional/Paragraphs/WYSIWYGCest.php
+++ b/tests/codeception/functional/Paragraphs/WYSIWYGCest.php
@@ -113,6 +113,7 @@ class WYSIWYGCest {
     $I->waitForElementVisible('.dropzone');
     $I->click('Video', '.media-library-menu-video');
     $I->waitForElementVisible('.media-library-add-form-oembed-url');
+    $I->clickWithLeftButton('input.media-library-add-form-oembed-url[name="url"]');
     $I->fillField('Add Video via URL', 'https://www.youtube.com/watch?v=ktCgVopf7D0');
 
     // If the youtube api fails, lets try again after a few seconds.


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Provide aria-label attribute for paragraph link fields.
- Allow aria-label in the wysiwyg

# Need Review By (Date)
- 7/30

# Urgency
- medium

# Steps to Test
1. checkout this branch and the matching branch in [react_paragraphs](https://github.com/SU-SWS/react_paragraphs/pull/114)
2. import configs or install fresh install
3. create a basic page
4. use the various paragraph types and populate the "ARIA Label" field
5. save the page and verify your aria-label is rendered on the link..

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
