### PR TITLE
Improve event sponsor field update hook

### DIFF
--- a/modules/stanford_events/stanford_events.install
+++ b/modules/stanford_events/stanford_events.install
@@ -5,6 +5,8 @@
  * Stanford_events.install.
  */
 
+use Drupal\field\Entity\FieldStorageConfig;
+
 /**
  * Update the length of the event sponsors field.
  */
@@ -25,4 +27,12 @@ function stanford_events_update_8001() {
   $field_schema['node_revision__su_event_sponsor']['fields']['su_event_sponsor_value']['length'] = 255;
   $storage_schema->set($storage_key, $field_schema);
 
+  // Update field configuration.
+  $config = \Drupal::configFactory()
+    ->getEditable('field.storage.node.su_event_sponsor');
+  $config->set('settings.max_length', 255);
+  $config->save(TRUE);
+
+  // Update field storage configuration.
+  FieldStorageConfig::loadByName('node', 'su_event_sponsor')->save();
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fix update hook. It breaks currently on ACSF deployment because the configuration in the database doesn't match the file config and so it breaks when trying to import configs.
- see https://evolvingweb.ca/blog/resizing-fields-drupal-8-without-losing-data

# Need Review By (Date)
- asap

# Urgency
- 

# Steps to Test

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
