### PR TITLE
D8CORE-5975 Allow resetting taxonomy term order to alphabetical with the button

### DIFF
--- a/modules/stanford_profile_helper/stanford_profile_helper.module
+++ b/modules/stanford_profile_helper/stanford_profile_helper.module
@@ -590,7 +590,20 @@ function stanford_profile_helper_xmlsitemap_link_alter(array &$link, array $cont
 function stanford_profile_helper_config_readonly_whitelist_patterns() {
   $default_theme = \Drupal::config('system.theme')->get('default');
   // Allow the theme settings to be changed in the UI.
-  return ["$default_theme.settings"];
+  $patterns = ["$default_theme.settings"];
+
+  // Allow the form to be submitted in the UI for specific routes that don't
+  // alter the configuration, such as resetting the order of taxonomy terms.
+  $routes_to_config = [
+    'entity.taxonomy_vocabulary.reset_form' => 'taxonomy.vocabulary.*',
+  ];
+  foreach ($routes_to_config as $route => $config_pattern) {
+    if (\Drupal::routeMatch()->getRouteName() == $route) {
+      $patterns[] = $config_pattern;
+    }
+  }
+
+  return $patterns;
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW


# Summary
- Allow users to "Reset to alphabetical" for taxonomy terms. Currently the config_readonly module prevents this action. This change conditionally adds the allowed config only for the given route since that route doesn't actually make any changes to the configuration.

# Review By (Date)
- :shrug: 

# Criticality
- low

# Urgency
- low

# Review Tasks

## Setup tasks and/or behavior to test

1. add `$settings['config_readonly'] = TRUE;` to the bottom of your local.settings.php file
2. Go to edit a taxonomy vocabulary
3. Ensure you are blocked and are unable to submit the form.
4. Go to a taxonomy vocabulary that has at least 2 terms.
5. verify when you click the "Reset to alphabetical" you aren't blocked.
