### PR TITLE
D8CORE-5825 Add taxonomy field to media types for categorization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -193,6 +193,7 @@
         "drupal/shs": "^2.0@RC",
         "drupal/smart_date": "^3.5",
         "drupal/smart_trim": "^1.3",
+        "drupal/taxonomy_entity_index": "^1.8",
         "drupal/taxonomy_menu": "^3.5",
         "drupal/transliterate_filenames": "^2.0",
         "drupal/ui_patterns": "^1.0",

--- a/config/sync/core.entity_form_display.media.file.default.yml
+++ b/config/sync/core.entity_form_display.media.file.default.yml
@@ -4,9 +4,11 @@ status: true
 dependencies:
   config:
     - field.field.media.file.field_media_file
+    - field.field.media.file.su_media_category
     - media.type.file
   module:
     - file
+    - shs
 _core:
   default_config_hash: IZZZH3ZmZ5xpeUW2scF9RPSnKb3qnEKu-cBMQQOuHQk
 id: media.file.default
@@ -28,6 +30,16 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  su_media_category:
+    type: options_shs
+    weight: 27
+    region: content
+    settings:
+      display_node_count: false
+      create_new_items: false
+      create_new_levels: false
+      force_deepest: false
     third_party_settings: {  }
 hidden:
   created: true

--- a/config/sync/core.entity_form_display.media.file.media_library.yml
+++ b/config/sync/core.entity_form_display.media.file.media_library.yml
@@ -5,12 +5,23 @@ dependencies:
   config:
     - core.entity_form_mode.media.media_library
     - field.field.media.file.field_media_file
+    - field.field.media.file.su_media_category
     - media.type.file
+  module:
+    - file
+    - shs
 id: media.file.media_library
 targetEntityType: media
 bundle: file
 mode: media_library
 content:
+  field_media_file:
+    type: file_generic
+    weight: 8
+    region: content
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 0
@@ -19,9 +30,18 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  su_media_category:
+    type: options_shs
+    weight: 1
+    region: content
+    settings:
+      display_node_count: false
+      create_new_items: false
+      create_new_levels: false
+      force_deepest: false
+    third_party_settings: {  }
 hidden:
   created: true
-  field_media_file: true
   path: true
   publish_on: true
   status: true

--- a/config/sync/core.entity_form_display.media.image.default.yml
+++ b/config/sync/core.entity_form_display.media.image.default.yml
@@ -4,10 +4,12 @@ status: true
 dependencies:
   config:
     - field.field.media.image.field_media_image
+    - field.field.media.image.su_media_category
     - image.style.thumbnail
     - media.type.image
   module:
     - focal_point
+    - shs
 _core:
   default_config_hash: VlvGpKQnaptFys0SJOZOeTnEs8B561SwPjIy-uFSiJE
 id: media.image.default
@@ -21,9 +23,9 @@ content:
     region: content
     settings:
       progress_indicator: throbber
+      preview_image_style: thumbnail
       preview_link: false
       offsets: '50,50'
-      'preview:image_style': medium
     third_party_settings: {  }
   name:
     type: string_textfield
@@ -32,6 +34,16 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  su_media_category:
+    type: options_shs
+    weight: 27
+    region: content
+    settings:
+      display_node_count: false
+      create_new_items: false
+      create_new_levels: false
+      force_deepest: false
     third_party_settings: {  }
 hidden:
   created: true

--- a/config/sync/core.entity_form_display.media.image.media_library.yml
+++ b/config/sync/core.entity_form_display.media.image.media_library.yml
@@ -5,10 +5,12 @@ dependencies:
   config:
     - core.entity_form_mode.media.media_library
     - field.field.media.image.field_media_image
+    - field.field.media.image.su_media_category
     - image.style.thumbnail
     - media.type.image
   module:
     - focal_point
+    - shs
 _core:
   default_config_hash: BMLrK4zKp8-FFnMseBdT_6h6YipUsKRfbDf_3WUB5HA
 id: media.image.media_library
@@ -33,6 +35,16 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  su_media_category:
+    type: options_shs
+    weight: 2
+    region: content
+    settings:
+      display_node_count: false
+      create_new_items: false
+      create_new_levels: false
+      force_deepest: false
     third_party_settings: {  }
 hidden:
   created: true

--- a/config/sync/core.entity_form_display.media.stanford_gallery_images.default.yml
+++ b/config/sync/core.entity_form_display.media.stanford_gallery_images.default.yml
@@ -5,10 +5,12 @@ dependencies:
   config:
     - field.field.media.stanford_gallery_images.su_gallery_caption
     - field.field.media.stanford_gallery_images.su_gallery_image
+    - field.field.media.stanford_gallery_images.su_media_category
     - image.style.thumbnail
     - media.type.stanford_gallery_images
   module:
     - focal_point
+    - shs
 id: media.stanford_gallery_images.default
 targetEntityType: media
 bundle: stanford_gallery_images
@@ -39,6 +41,16 @@ content:
       preview_image_style: thumbnail
       preview_link: true
       offsets: '50,50'
+    third_party_settings: {  }
+  su_media_category:
+    type: options_shs
+    weight: 27
+    region: content
+    settings:
+      display_node_count: false
+      create_new_items: false
+      create_new_levels: false
+      force_deepest: false
     third_party_settings: {  }
 hidden:
   created: true

--- a/config/sync/core.entity_form_display.media.stanford_gallery_images.media_library.yml
+++ b/config/sync/core.entity_form_display.media.stanford_gallery_images.media_library.yml
@@ -6,10 +6,12 @@ dependencies:
     - core.entity_form_mode.media.media_library
     - field.field.media.stanford_gallery_images.su_gallery_caption
     - field.field.media.stanford_gallery_images.su_gallery_image
+    - field.field.media.stanford_gallery_images.su_media_category
     - image.style.thumbnail
     - media.type.stanford_gallery_images
   module:
     - focal_point
+    - shs
 id: media.stanford_gallery_images.media_library
 targetEntityType: media
 bundle: stanford_gallery_images
@@ -40,6 +42,16 @@ content:
       preview_image_style: thumbnail
       preview_link: true
       offsets: '50,50'
+    third_party_settings: {  }
+  su_media_category:
+    type: options_shs
+    weight: 3
+    region: content
+    settings:
+      display_node_count: false
+      create_new_items: false
+      create_new_levels: false
+      force_deepest: false
     third_party_settings: {  }
 hidden:
   created: true

--- a/config/sync/core.entity_form_display.media.video.default.yml
+++ b/config/sync/core.entity_form_display.media.video.default.yml
@@ -4,7 +4,10 @@ status: true
 dependencies:
   config:
     - field.field.media.video.field_media_oembed_video
+    - field.field.media.video.su_media_category
     - media.type.video
+  module:
+    - shs
 _core:
   default_config_hash: 7asQaGZMyJ5EtC9GHpp-bYEGCmfCKgCZhEcDl4wsU6w
 id: media.video.default
@@ -27,6 +30,16 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  su_media_category:
+    type: options_shs
+    weight: 26
+    region: content
+    settings:
+      display_node_count: false
+      create_new_items: false
+      create_new_levels: false
+      force_deepest: false
     third_party_settings: {  }
 hidden:
   created: true

--- a/config/sync/core.entity_form_display.media.video.media_library.yml
+++ b/config/sync/core.entity_form_display.media.video.media_library.yml
@@ -5,7 +5,10 @@ dependencies:
   config:
     - core.entity_form_mode.media.media_library
     - field.field.media.video.field_media_oembed_video
+    - field.field.media.video.su_media_category
     - media.type.video
+  module:
+    - shs
 id: media.video.media_library
 targetEntityType: media
 bundle: video
@@ -13,7 +16,7 @@ mode: media_library
 content:
   field_media_oembed_video:
     type: string_textfield
-    weight: 26
+    weight: 1
     region: content
     settings:
       size: 60
@@ -26,6 +29,16 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  su_media_category:
+    type: options_shs
+    weight: 2
+    region: content
+    settings:
+      display_node_count: false
+      create_new_items: false
+      create_new_levels: false
+      force_deepest: false
     third_party_settings: {  }
 hidden:
   created: true

--- a/config/sync/core.entity_view_display.media.file.default.yml
+++ b/config/sync/core.entity_view_display.media.file.default.yml
@@ -25,5 +25,6 @@ hidden:
   created: true
   name: true
   search_api_excerpt: true
+  su_media_category: true
   thumbnail: true
   uid: true

--- a/config/sync/core.entity_view_display.media.file.media_library.yml
+++ b/config/sync/core.entity_view_display.media.file.media_library.yml
@@ -30,4 +30,5 @@ hidden:
   field_media_file: true
   name: true
   search_api_excerpt: true
+  su_media_category: true
   uid: true

--- a/config/sync/core.entity_view_display.media.image.default.yml
+++ b/config/sync/core.entity_view_display.media.image.default.yml
@@ -28,5 +28,6 @@ hidden:
   created: true
   name: true
   search_api_excerpt: true
+  su_media_category: true
   thumbnail: true
   uid: true

--- a/config/sync/core.entity_view_display.media.image.media_library.yml
+++ b/config/sync/core.entity_view_display.media.image.media_library.yml
@@ -35,4 +35,5 @@ hidden:
   field_media_image: true
   name: true
   search_api_excerpt: true
+  su_media_category: true
   uid: true

--- a/config/sync/core.entity_view_display.media.image.stanford_image_large.yml
+++ b/config/sync/core.entity_view_display.media.image.stanford_image_large.yml
@@ -29,5 +29,6 @@ hidden:
   created: true
   name: true
   search_api_excerpt: true
+  su_media_category: true
   thumbnail: true
   uid: true

--- a/config/sync/core.entity_view_display.media.image.stanford_image_large_square.yml
+++ b/config/sync/core.entity_view_display.media.image.stanford_image_large_square.yml
@@ -39,5 +39,6 @@ hidden:
   created: true
   name: true
   search_api_excerpt: true
+  su_media_category: true
   thumbnail: true
   uid: true

--- a/config/sync/core.entity_view_display.media.image.stanford_image_medium.yml
+++ b/config/sync/core.entity_view_display.media.image.stanford_image_medium.yml
@@ -29,5 +29,6 @@ hidden:
   created: true
   name: true
   search_api_excerpt: true
+  su_media_category: true
   thumbnail: true
   uid: true

--- a/config/sync/core.entity_view_display.media.image.stanford_image_medium_square.yml
+++ b/config/sync/core.entity_view_display.media.image.stanford_image_medium_square.yml
@@ -39,5 +39,6 @@ hidden:
   created: true
   name: true
   search_api_excerpt: true
+  su_media_category: true
   thumbnail: true
   uid: true

--- a/config/sync/core.entity_view_display.media.image.stanford_image_stanford_circle.yml
+++ b/config/sync/core.entity_view_display.media.image.stanford_image_stanford_circle.yml
@@ -29,5 +29,6 @@ hidden:
   created: true
   name: true
   search_api_excerpt: true
+  su_media_category: true
   thumbnail: true
   uid: true

--- a/config/sync/core.entity_view_display.media.image.stanford_image_thumb_square.yml
+++ b/config/sync/core.entity_view_display.media.image.stanford_image_thumb_square.yml
@@ -39,5 +39,6 @@ hidden:
   created: true
   name: true
   search_api_excerpt: true
+  su_media_category: true
   thumbnail: true
   uid: true

--- a/config/sync/core.entity_view_display.media.image.thumbnail.yml
+++ b/config/sync/core.entity_view_display.media.image.thumbnail.yml
@@ -31,5 +31,6 @@ hidden:
   created: true
   name: true
   search_api_excerpt: true
+  su_media_category: true
   thumbnail: true
   uid: true

--- a/config/sync/core.entity_view_display.media.stanford_gallery_images.default.yml
+++ b/config/sync/core.entity_view_display.media.stanford_gallery_images.default.yml
@@ -44,5 +44,6 @@ hidden:
   created: true
   name: true
   search_api_excerpt: true
+  su_media_category: true
   thumbnail: true
   uid: true

--- a/config/sync/core.entity_view_display.media.stanford_gallery_images.media_library.yml
+++ b/config/sync/core.entity_view_display.media.stanford_gallery_images.media_library.yml
@@ -40,4 +40,5 @@ hidden:
   search_api_excerpt: true
   su_gallery_caption: true
   su_gallery_image: true
+  su_media_category: true
   uid: true

--- a/config/sync/core.entity_view_display.media.video.default.yml
+++ b/config/sync/core.entity_view_display.media.video.default.yml
@@ -27,5 +27,6 @@ hidden:
   created: true
   name: true
   search_api_excerpt: true
+  su_media_category: true
   thumbnail: true
   uid: true

--- a/config/sync/core.entity_view_display.media.video.full.yml
+++ b/config/sync/core.entity_view_display.media.video.full.yml
@@ -28,5 +28,6 @@ hidden:
   created: true
   name: true
   search_api_excerpt: true
+  su_media_category: true
   thumbnail: true
   uid: true

--- a/config/sync/core.entity_view_display.media.video.media_library.yml
+++ b/config/sync/core.entity_view_display.media.video.media_library.yml
@@ -30,4 +30,5 @@ hidden:
   field_media_oembed_video: true
   name: true
   search_api_excerpt: true
+  su_media_category: true
   uid: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -191,6 +191,7 @@ module:
   syslog: 0
   system: 0
   taxonomy: 0
+  taxonomy_entity_index: 0
   taxonomy_menu: 0
   telephone: 0
   text: 0

--- a/config/sync/field.field.media.file.su_media_category.yml
+++ b/config/sync/field.field.media.file.su_media_category.yml
@@ -1,0 +1,29 @@
+uuid: eb9cd582-b361-4741-87ac-2dc9dba7929d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.su_media_category
+    - media.type.file
+    - taxonomy.vocabulary.media_tags
+id: media.file.su_media_category
+field_name: su_media_category
+entity_type: media
+bundle: file
+label: Category
+description: 'Categorize the media to help find the media at a later time.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      media_tags: media_tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.media.image.su_media_category.yml
+++ b/config/sync/field.field.media.image.su_media_category.yml
@@ -1,0 +1,29 @@
+uuid: e3e7f718-fa5a-44dc-8586-1c0bbc640bd7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.su_media_category
+    - media.type.image
+    - taxonomy.vocabulary.media_tags
+id: media.image.su_media_category
+field_name: su_media_category
+entity_type: media
+bundle: image
+label: Category
+description: 'Categorize the media to help find the media at a later time.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      media_tags: media_tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.media.stanford_gallery_images.su_media_category.yml
+++ b/config/sync/field.field.media.stanford_gallery_images.su_media_category.yml
@@ -1,0 +1,29 @@
+uuid: 3109e4ac-64db-4305-850d-ec8c07620453
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.su_media_category
+    - media.type.stanford_gallery_images
+    - taxonomy.vocabulary.media_tags
+id: media.stanford_gallery_images.su_media_category
+field_name: su_media_category
+entity_type: media
+bundle: stanford_gallery_images
+label: Category
+description: 'Categorize the media to help find the media at a later time.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      media_tags: media_tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.media.video.su_media_category.yml
+++ b/config/sync/field.field.media.video.su_media_category.yml
@@ -1,0 +1,29 @@
+uuid: c450fc4a-c3ac-4035-b6ae-918de4be32a6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.su_media_category
+    - media.type.video
+    - taxonomy.vocabulary.media_tags
+id: media.video.su_media_category
+field_name: su_media_category
+entity_type: media
+bundle: video
+label: Category
+description: 'Categorize the media to help find the media at a later time.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      media_tags: media_tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.media.su_media_category.yml
+++ b/config/sync/field.storage.media.su_media_category.yml
@@ -1,0 +1,20 @@
+uuid: 694fc518-bdaa-4af5-a79e-b34b44e7fe0a
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - taxonomy
+id: media.su_media_category
+field_name: su_media_category
+entity_type: media
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/rabbit_hole.behavior_settings.taxonomy_vocabulary_media_tags.yml
+++ b/config/sync/rabbit_hole.behavior_settings.taxonomy_vocabulary_media_tags.yml
@@ -1,0 +1,14 @@
+uuid: fcd87dd6-a0e0-4b3b-b571-9dc4fffcb284
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.media_tags
+id: taxonomy_vocabulary_media_tags
+entity_type_id: taxonomy_vocabulary
+entity_id: media_tags
+action: display_page
+allow_override: 1
+redirect: ''
+redirect_code: 301
+redirect_fallback_action: access_denied

--- a/config/sync/taxonomy.vocabulary.media_tags.yml
+++ b/config/sync/taxonomy.vocabulary.media_tags.yml
@@ -1,0 +1,24 @@
+uuid: d1142a72-56ca-4641-baf8-94ea8c120661
+langcode: en
+status: true
+dependencies:
+  module:
+    - scheduler
+third_party_settings:
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    show_message_after_update: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
+name: 'Media Tags'
+vid: media_tags
+description: ''
+weight: 0

--- a/config/sync/taxonomy_entity_index.settings.yml
+++ b/config/sync/taxonomy_entity_index.settings.yml
@@ -1,0 +1,6 @@
+_core:
+  default_config_hash: ybFcPjZje3mJVpuKZAJmoX9OXSZmM0NWrppkk8gaToo
+types:
+  media: media
+index_revisions: false
+index_per_field: false

--- a/config/sync/views.settings.yml
+++ b/config/sync/views.settings.yml
@@ -9,7 +9,7 @@ ui:
     performance_statistics: false
     preview_information: true
     sql_query:
-      enabled: false
+      enabled: true
       where: above
     display_embed: false
   always_live_preview: false

--- a/config/sync/views.view.media.yml
+++ b/config/sync/views.view.media.yml
@@ -4,9 +4,11 @@ status: true
 dependencies:
   config:
     - image.style.thumbnail
+    - taxonomy.vocabulary.media_tags
   module:
     - image
     - media
+    - taxonomy_entity_index
     - user
 id: media
 label: Media
@@ -532,7 +534,7 @@ display:
         type: basic
         options:
           submit_button: Filter
-          reset_button: false
+          reset_button: true
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'
           expose_sort_order: true
@@ -661,54 +663,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        status:
-          id: status
-          table: media_field_data
-          field: status
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: media
-          entity_field: status
-          plugin_id: boolean
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: 'True'
-            description: null
-            use_operator: false
-            operator: status_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: status
-            required: true
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: true
-          group_info:
-            label: 'Published status'
-            description: ''
-            identifier: status
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items:
-              1:
-                title: Published
-                operator: '='
-                value: '1'
-              2:
-                title: Unpublished
-                operator: '='
-                value: '0'
         status_extra:
           id: status_extra
           table: media_field_data
@@ -748,36 +702,45 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        langcode:
-          id: langcode
-          table: media_field_data
-          field: langcode
+        taxonomy_entity_index_tid_depth:
+          id: taxonomy_entity_index_tid_depth
+          table: media
+          field: taxonomy_entity_index_tid_depth
           relationship: none
           group_type: group
           admin_label: ''
           entity_type: media
-          entity_field: langcode
-          plugin_id: language
-          operator: in
+          plugin_id: taxonomy_entity_index_tid_depth
+          operator: or
           value: {  }
           group: 1
           exposed: true
           expose:
-            operator_id: langcode_op
-            label: Language
+            operator_id: taxonomy_entity_index_tid_depth_op
+            label: Category
             description: ''
             use_operator: false
-            operator: langcode_op
+            operator: taxonomy_entity_index_tid_depth_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: langcode
+            identifier: category
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-              anonymous: '0'
               administrator: '0'
+              anonymous: '0'
+              stanford_faculty: '0'
+              stanford_staff: '0'
+              stanford_student: '0'
+              contributor: '0'
+              site_manager: '0'
+              site_editor: '0'
+              site_builder: '0'
+              site_developer: '0'
+              layout_builder_user: '0'
+              decoupled_site_users: '0'
             reduce: false
           is_grouped: false
           group_info:
@@ -791,6 +754,13 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          reduce_duplicates: false
+          vid: media_tags
+          type: select
+          hierarchy: true
+          limit: true
+          error_message: true
+          depth: 10
       style:
         type: table
         options:
@@ -863,7 +833,9 @@ display:
           disable_sql_rewrite: false
           distinct: false
           replica: false
-          query_tags: {  }
+          query_tags:
+            - term_children
+          contextual_filters_or: false
       relationships: {  }
       header: {  }
       footer: {  }

--- a/config/sync/views.view.media_library.yml
+++ b/config/sync/views.view.media_library.yml
@@ -5,10 +5,12 @@ dependencies:
   config:
     - core.entity_view_mode.media.media_library
     - image.style.media_library
+    - taxonomy.vocabulary.media_tags
   module:
     - image
     - media
     - media_library
+    - taxonomy_entity_index
     - user
   enforced:
     module:
@@ -403,36 +405,45 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        langcode:
-          id: langcode
-          table: media_field_data
-          field: langcode
+        taxonomy_entity_index_tid_depth:
+          id: taxonomy_entity_index_tid_depth
+          table: media
+          field: taxonomy_entity_index_tid_depth
           relationship: none
           group_type: group
           admin_label: ''
           entity_type: media
-          entity_field: langcode
-          plugin_id: language
-          operator: in
+          plugin_id: taxonomy_entity_index_tid_depth
+          operator: or
           value: {  }
           group: 1
           exposed: true
           expose:
-            operator_id: langcode_op
-            label: Language
+            operator_id: taxonomy_entity_index_tid_depth_op
+            label: Category
             description: ''
             use_operator: false
-            operator: langcode_op
+            operator: taxonomy_entity_index_tid_depth_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: langcode
+            identifier: category
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-              anonymous: '0'
               administrator: '0'
+              anonymous: '0'
+              stanford_faculty: '0'
+              stanford_staff: '0'
+              stanford_student: '0'
+              contributor: '0'
+              site_manager: '0'
+              site_editor: '0'
+              site_builder: '0'
+              site_developer: '0'
+              layout_builder_user: '0'
+              decoupled_site_users: '0'
             reduce: false
           is_grouped: false
           group_info:
@@ -446,6 +457,13 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+          reduce_duplicates: false
+          vid: media_tags
+          type: select
+          hierarchy: true
+          limit: true
+          error_message: true
+          depth: 10
       style:
         type: default
         options:
@@ -466,7 +484,9 @@ display:
           disable_sql_rewrite: false
           distinct: false
           replica: false
-          query_tags: {  }
+          query_tags:
+            - term_children
+          contextual_filters_or: false
       relationships: {  }
       css_class: ''
       use_ajax: true
@@ -482,7 +502,27 @@ display:
         - 'url.query_args:sort_by'
         - user
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:core.entity_view_display.media.embeddable.default'
+        - 'config:core.entity_view_display.media.embeddable.media_library'
+        - 'config:core.entity_view_display.media.file.default'
+        - 'config:core.entity_view_display.media.file.media_library'
+        - 'config:core.entity_view_display.media.google_form.default'
+        - 'config:core.entity_view_display.media.google_form.media_library'
+        - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.media_library'
+        - 'config:core.entity_view_display.media.image.stanford_image_large'
+        - 'config:core.entity_view_display.media.image.stanford_image_large_square'
+        - 'config:core.entity_view_display.media.image.stanford_image_medium'
+        - 'config:core.entity_view_display.media.image.stanford_image_medium_square'
+        - 'config:core.entity_view_display.media.image.stanford_image_stanford_circle'
+        - 'config:core.entity_view_display.media.image.stanford_image_thumb_square'
+        - 'config:core.entity_view_display.media.image.thumbnail'
+        - 'config:core.entity_view_display.media.stanford_gallery_images.default'
+        - 'config:core.entity_view_display.media.stanford_gallery_images.media_library'
+        - 'config:core.entity_view_display.media.video.default'
+        - 'config:core.entity_view_display.media.video.full'
+        - 'config:core.entity_view_display.media.video.media_library'
   page:
     id: page
     display_title: Page
@@ -779,7 +819,27 @@ display:
         - 'url.query_args:sort_by'
         - user
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:core.entity_view_display.media.embeddable.default'
+        - 'config:core.entity_view_display.media.embeddable.media_library'
+        - 'config:core.entity_view_display.media.file.default'
+        - 'config:core.entity_view_display.media.file.media_library'
+        - 'config:core.entity_view_display.media.google_form.default'
+        - 'config:core.entity_view_display.media.google_form.media_library'
+        - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.media_library'
+        - 'config:core.entity_view_display.media.image.stanford_image_large'
+        - 'config:core.entity_view_display.media.image.stanford_image_large_square'
+        - 'config:core.entity_view_display.media.image.stanford_image_medium'
+        - 'config:core.entity_view_display.media.image.stanford_image_medium_square'
+        - 'config:core.entity_view_display.media.image.stanford_image_stanford_circle'
+        - 'config:core.entity_view_display.media.image.stanford_image_thumb_square'
+        - 'config:core.entity_view_display.media.image.thumbnail'
+        - 'config:core.entity_view_display.media.stanford_gallery_images.default'
+        - 'config:core.entity_view_display.media.stanford_gallery_images.media_library'
+        - 'config:core.entity_view_display.media.video.default'
+        - 'config:core.entity_view_display.media.video.full'
+        - 'config:core.entity_view_display.media.video.media_library'
   widget:
     id: widget
     display_title: Widget
@@ -1057,6 +1117,65 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        taxonomy_entity_index_tid_depth:
+          id: taxonomy_entity_index_tid_depth
+          table: media
+          field: taxonomy_entity_index_tid_depth
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          plugin_id: taxonomy_entity_index_tid_depth
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: taxonomy_entity_index_tid_depth_op
+            label: Category
+            description: ''
+            use_operator: false
+            operator: taxonomy_entity_index_tid_depth_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: category
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              administrator: '0'
+              anonymous: '0'
+              stanford_faculty: '0'
+              stanford_staff: '0'
+              stanford_student: '0'
+              contributor: '0'
+              site_manager: '0'
+              site_editor: '0'
+              site_builder: '0'
+              site_developer: '0'
+              layout_builder_user: '0'
+              decoupled_site_users: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: media_tags
+          type: select
+          hierarchy: true
+          limit: true
+          error_message: true
+          depth: 10
       filter_groups:
         operator: AND
         groups:
@@ -1098,8 +1217,29 @@ display:
         - url
         - url.query_args
         - 'url.query_args:sort_by'
+        - user
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:core.entity_view_display.media.embeddable.default'
+        - 'config:core.entity_view_display.media.embeddable.media_library'
+        - 'config:core.entity_view_display.media.file.default'
+        - 'config:core.entity_view_display.media.file.media_library'
+        - 'config:core.entity_view_display.media.google_form.default'
+        - 'config:core.entity_view_display.media.google_form.media_library'
+        - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.media_library'
+        - 'config:core.entity_view_display.media.image.stanford_image_large'
+        - 'config:core.entity_view_display.media.image.stanford_image_large_square'
+        - 'config:core.entity_view_display.media.image.stanford_image_medium'
+        - 'config:core.entity_view_display.media.image.stanford_image_medium_square'
+        - 'config:core.entity_view_display.media.image.stanford_image_stanford_circle'
+        - 'config:core.entity_view_display.media.image.stanford_image_thumb_square'
+        - 'config:core.entity_view_display.media.image.thumbnail'
+        - 'config:core.entity_view_display.media.stanford_gallery_images.default'
+        - 'config:core.entity_view_display.media.stanford_gallery_images.media_library'
+        - 'config:core.entity_view_display.media.video.default'
+        - 'config:core.entity_view_display.media.video.full'
+        - 'config:core.entity_view_display.media.video.media_library'
   widget_table:
     id: widget_table
     display_title: 'Widget (table)'
@@ -1339,6 +1479,65 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        taxonomy_entity_index_tid_depth:
+          id: taxonomy_entity_index_tid_depth
+          table: media
+          field: taxonomy_entity_index_tid_depth
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          plugin_id: taxonomy_entity_index_tid_depth
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: taxonomy_entity_index_tid_depth_op
+            label: Category
+            description: ''
+            use_operator: false
+            operator: taxonomy_entity_index_tid_depth_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: category
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              administrator: '0'
+              anonymous: '0'
+              stanford_faculty: '0'
+              stanford_staff: '0'
+              stanford_student: '0'
+              contributor: '0'
+              site_manager: '0'
+              site_editor: '0'
+              site_builder: '0'
+              site_developer: '0'
+              layout_builder_user: '0'
+              decoupled_site_users: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: media_tags
+          type: select
+          hierarchy: true
+          limit: true
+          error_message: true
+          depth: 10
       filter_groups:
         operator: AND
         groups:
@@ -1388,5 +1587,6 @@ display:
         - url
         - url.query_args
         - 'url.query_args:sort_by'
+        - user
         - user.permissions
       tags: {  }

--- a/modules/stanford_profile_helper/src/EventSubscriber/ViewsEventSubscriber.php
+++ b/modules/stanford_profile_helper/src/EventSubscriber/ViewsEventSubscriber.php
@@ -30,6 +30,11 @@ class ViewsEventSubscriber implements EventSubscriberInterface {
     $view = $event->getView();
     $display_options = &$view->getDisplay()->options;
 
+    // When viewing the "default" view display, just escape out.
+    if (!isset($view->getDisplay()->default_display)) {
+      return;
+    }
+
     $default_options = &$view->getDisplay()->default_display->options;
     $filters = !empty($display_options['filters']) ? $display_options['filters'] : $default_options['filters'];
 
@@ -37,11 +42,13 @@ class ViewsEventSubscriber implements EventSubscriberInterface {
     // using the node type filters that exist on the view.
     // @see \Drupal\Core\Entity\EntityBase::getListCacheTagsToInvalidate().
     if (!empty($filters['type']['entity_type']) && $filters['type']['entity_type'] == 'node') {
+
       $tags = [];
       foreach ($filters['type']['value'] as $node_type) {
         $tags[] = 'node_list:' . $node_type;
       }
-      // If no node type tags are available, fall back to the general `node_list`.
+
+      // If no node type tags are available, fall back to general `node_list`.
       $tags = empty($tags) ? ['node_list'] : $tags;
       $cache = [
         'type' => 'custom_tag',

--- a/modules/stanford_profile_helper/src/EventSubscriber/ViewsEventSubscriber.php
+++ b/modules/stanford_profile_helper/src/EventSubscriber/ViewsEventSubscriber.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\stanford_profile_helper\EventSubscriber;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\views_event_dispatcher\Event\Views\ViewsPreViewEvent;
+use Drupal\views_event_dispatcher\Event\Views\ViewsQueryAlterEvent;
+use Drupal\views_event_dispatcher\ViewsHookEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ViewsEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function getSubscribedEvents() {
+    $events = [];
+    $events[ViewsHookEvents::VIEWS_PRE_VIEW] = 'viewsPreView';
+    return $events;
+  }
+
+  /**
+   * Modify the cache tags on views.
+   *
+   * @param \Drupal\views_event_dispatcher\Event\Views\ViewsPreViewEvent $event
+   *   Pre view hook event.
+   */
+  public function viewsPreView(ViewsPreViewEvent $event) {
+    $view = $event->getView();
+    $display_options = &$view->getDisplay()->options;
+
+    $default_options = &$view->getDisplay()->default_display->options;
+    $filters = !empty($display_options['filters']) ? $display_options['filters'] : $default_options['filters'];
+
+    // Change the default cache mechanism to use custom tags that we generate
+    // using the node type filters that exist on the view.
+    // @see \Drupal\Core\Entity\EntityBase::getListCacheTagsToInvalidate().
+    if (!empty($filters['type']['entity_type']) && $filters['type']['entity_type'] == 'node') {
+      $tags = [];
+      foreach ($filters['type']['value'] as $node_type) {
+        $tags[] = 'node_list:' . $node_type;
+      }
+      // If no node type tags are available, fall back to the general `node_list`.
+      $tags = empty($tags) ? ['node_list'] : $tags;
+      $cache = [
+        'type' => 'custom_tag',
+        'options' => ['custom_tag' => implode(' ', $tags)],
+      ];
+      $display_options['cache'] = $cache;
+      $default_options['cache'] = $cache;
+    }
+  }
+
+}

--- a/modules/stanford_profile_helper/src/EventSubscriber/ViewsEventSubscriber.php
+++ b/modules/stanford_profile_helper/src/EventSubscriber/ViewsEventSubscriber.php
@@ -2,12 +2,13 @@
 
 namespace Drupal\stanford_profile_helper\EventSubscriber;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\views_event_dispatcher\Event\Views\ViewsPreViewEvent;
-use Drupal\views_event_dispatcher\Event\Views\ViewsQueryAlterEvent;
 use Drupal\views_event_dispatcher\ViewsHookEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
+/**
+ * Views hook event subscriber.
+ */
 class ViewsEventSubscriber implements EventSubscriberInterface {
 
   /**

--- a/modules/stanford_profile_helper/stanford_profile_helper.info.yml
+++ b/modules/stanford_profile_helper/stanford_profile_helper.info.yml
@@ -18,6 +18,7 @@ dependencies:
   - drupal:help
   - drupal:media
   - drupal:media_library
+  - hook_event_dispatcher:views_event_dispatcher
   - pdb:pdb
   - rabbit_hole:rabbit_hole
   - xmlsitemap:xmlsitemap

--- a/modules/stanford_profile_helper/stanford_profile_helper.module
+++ b/modules/stanford_profile_helper/stanford_profile_helper.module
@@ -26,7 +26,6 @@ use Drupal\search_api\IndexInterface;
 use Drupal\stanford_profile_helper\StanfordProfileHelper;
 use Drupal\taxonomy\TermInterface;
 use Drupal\taxonomy_menu\Plugin\Menu\TaxonomyMenuMenuLink;
-use Drupal\views\ViewExecutable;
 use Drupal\Core\Render\Element;
 
 /**
@@ -860,33 +859,6 @@ function _stanford_profile_helper_extension_enabled(Extension $extension) {
     $path = implode('/', $path);
   }
   return FALSE;
-}
-
-/**
- * Implements hook_views_pre_view().
- */
-function stanford_profile_helper_views_pre_view(ViewExecutable $view, $display_id, array &$args) {
-  $display_options = &$view->getDisplay()->options;
-  $default_options = &$view->getDisplay()->default_display->options;
-  $filters = !empty($display_options['filters']) ? $display_options['filters'] : $default_options['filters'];
-
-  // Change the default cache mechanism to use custom tags that we generate
-  // using the node type filters that exist on the view.
-  // @see \Drupal\Core\Entity\EntityBase::getListCacheTagsToInvalidate().
-  if (!empty($filters['type']['entity_type']) && $filters['type']['entity_type'] == 'node') {
-    $tags = [];
-    foreach ($filters['type']['value'] as $node_type) {
-      $tags[] = 'node_list:' . $node_type;
-    }
-    // If no node type tags are available, fall back to the general `node_list`.
-    $tags = empty($tags) ? ['node_list'] : $tags;
-    $cache = [
-      'type' => 'custom_tag',
-      'options' => ['custom_tag' => implode(' ', $tags)],
-    ];
-    $display_options['cache'] = $cache;
-    $default_options['cache'] = $cache;
-  }
 }
 
 /**

--- a/modules/stanford_profile_helper/stanford_profile_helper.services.yml
+++ b/modules/stanford_profile_helper/stanford_profile_helper.services.yml
@@ -2,6 +2,11 @@ services:
   stanford_profile_helper.default_content:
     class: Drupal\stanford_profile_helper\StanfordDefaultContent
     arguments: ['@entity_type.manager', '@config.factory', '@extension.path.resolver']
+  stanford_profile_helper.event_subscriber.views:
+    class: Drupal\stanford_profile_helper\EventSubscriber\ViewsEventSubscriber
+    arguments: [ ]
+    tags:
+      - { name: 'event_subscriber' }
   stanford_profile_helper.event_subscriber.entity:
     class: Drupal\stanford_profile_helper\EventSubscriber\EntityEventSubscriber
     arguments: ['@stanford_profile_helper.default_content', '@state', '@entity_type.manager']

--- a/modules/stanford_profile_helper/tests/src/Kernel/EventSubscriber/EntityEventSubscriberTest.php
+++ b/modules/stanford_profile_helper/tests/src/Kernel/EventSubscriber/EntityEventSubscriberTest.php
@@ -6,14 +6,11 @@ use Drupal\config_pages\Entity\ConfigPages;
 use Drupal\config_pages\Entity\ConfigPagesType;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
-use Drupal\KernelTests\KernelTestBase;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\Entity\Node;
-use Drupal\node\Entity\NodeType;
-use Drupal\node\NodeInterface;
 use Drupal\path_alias\Entity\PathAlias;
 use Drupal\redirect\Entity\Redirect;
-use Drupal\stanford_profile_helper\StanfordDefaultContentInterface;
+use Drupal\Tests\stanford_profile_helper\Kernel\SuProfileHelperKernelTestBase;
 use Drupal\user\Entity\Role;
 
 /**
@@ -21,63 +18,7 @@ use Drupal\user\Entity\Role;
  *
  * @coversDefaultClass \Drupal\stanford_profile_helper\EventSubscriber\EntityEventSubscriber
  */
-class EntityEventSubscriberTest extends KernelTestBase {
-
-  /**
-   * {@inheritDoc}
-   */
-  protected static $modules = [
-    'config_pages',
-    'core_event_dispatcher',
-    'hook_event_dispatcher',
-    'preprocess_event_dispatcher',
-    'default_content',
-    'hal',
-    'node',
-    'serialization',
-    'stanford_profile_helper',
-    'system',
-    'user',
-    'path_alias',
-    'rabbit_hole',
-    'rh_node',
-    'menu_link_content',
-    'link',
-    'redirect',
-    'text',
-    'field',
-    'config_pages',
-    'link',
-  ];
-
-  /**
-   * {@inheritDoc}
-   */
-  protected function setUp() {
-    parent::setUp();
-    $this->installEntitySchema('node');
-    $this->installEntitySchema('user');
-    $this->installEntitySchema('path_alias');
-    $this->installEntitySchema('menu_link_content');
-    $this->installEntitySchema('redirect');
-    $this->installEntitySchema('field_storage_config');
-    $this->installEntitySchema('config_pages');
-    $this->installConfig('system');
-    $this->setInstallProfile('test_stanford_profile_helper');
-
-    NodeType::create(['type' => 'stanford_event', 'name' => 'Event'])->save();
-
-    $entity = $this->createMock(NodeInterface::class);
-    $entity->method('label')->willReturn('Foo Bar');
-
-    $default_content_mock = $this->createMock(StanfordDefaultContentInterface::class);
-    $default_content_mock->method('createDefaultContent')
-      ->willReturnReference($entity);
-
-    $container = \Drupal::getContainer();
-    $container->set('stanford_profile_helper.default_content', $default_content_mock);
-    \Drupal::setContainer($container);
-  }
+class EntityEventSubscriberTest extends SuProfileHelperKernelTestBase {
 
   /**
    * Entity Pre-save event listener.

--- a/modules/stanford_profile_helper/tests/src/Kernel/EventSubscriber/ViewsEventSubscriberTest.php
+++ b/modules/stanford_profile_helper/tests/src/Kernel/EventSubscriber/ViewsEventSubscriberTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\Tests\stanford_profile_helper\Kernel\EventSubscriber;
+
+use Drupal\Tests\stanford_profile_helper\Kernel\SuProfileHelperKernelTestBase;
+use Drupal\views\Entity\View;
+use Drupal\views\Views;
+
+/**
+ * Test the event subscriber.
+ *
+ * @coversDefaultClass \Drupal\stanford_profile_helper\EventSubscriber\ViewsEventSubscriber
+ */
+class ViewsEventSubscriberTest extends SuProfileHelperKernelTestBase {
+
+  protected function setUp() {
+    parent::setUp();
+    \Drupal::service('module_installer')->install([
+      'views',
+      'views_event_dispatcher',
+      'views_custom_cache_tag',
+    ]);
+  }
+
+  public function testCacheTags() {
+    $view_id = $this->randomMachineName();
+    $view = View::create([
+      'id' => $view_id,
+      'base_table' => 'node_field_data',
+      'display' => [
+        'default' => [
+          'display_plugin' => 'default',
+          'id' => 'default',
+          'display_options' => [
+            'fields' => [
+              'nid' => [
+                'table' => 'node_field_data',
+                'field' => 'nid',
+                'id' => 'nid',
+                'plugin_id' => 'field',
+              ],
+            ],
+          ],
+        ],
+        'test_block' => [
+          'display_plugin' => 'block',
+          'id' => 'test_block',
+          'display_options' => [
+            'filters' => [
+              'type' => [
+                'table' => 'node_field_data',
+                'field' => 'type',
+                'id' => 'type',
+                'entity_type' => 'node',
+                'entity_field' => 'type',
+                'plugin_id' => 'bundle',
+                'value' => [
+                  'stanford_event' => 'stanford_event',
+                ],
+              ],
+            ],
+          ],
+        ],
+      ],
+    ]);
+    $view->save();
+
+    $executable = Views::getView($view_id);
+    $build = $executable->preview();
+    $this->assertEquals('tag', $build['#view']->getDisplay()->options['cache']['type']);
+
+    $executable = Views::getView($view_id);
+    $build = $executable->preview('test_block');
+    $this->assertEquals('custom_tag', $build['#view']->getDisplay()->options['cache']['type']);
+    $this->assertContains('node_list:stanford_event', $build['#view']->getDisplay()->options['cache']['options']);
+  }
+
+}

--- a/modules/stanford_profile_helper/tests/src/Kernel/SuProfileHelperKernelTestBase.php
+++ b/modules/stanford_profile_helper/tests/src/Kernel/SuProfileHelperKernelTestBase.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\Tests\stanford_profile_helper\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\NodeType;
+use Drupal\node\NodeInterface;
+use Drupal\stanford_profile_helper\StanfordDefaultContentInterface;
+
+/**
+ * Test the event subscriber.
+ *
+ * @coversDefaultClass \Drupal\stanford_profile_helper\EventSubscriber\EntityEventSubscriber
+ */
+abstract class SuProfileHelperKernelTestBase extends KernelTestBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  protected static $modules = [
+    'config_pages',
+    'core_event_dispatcher',
+    'hook_event_dispatcher',
+    'preprocess_event_dispatcher',
+    'default_content',
+    'hal',
+    'node',
+    'serialization',
+    'stanford_profile_helper',
+    'system',
+    'user',
+    'path_alias',
+    'rabbit_hole',
+    'rh_node',
+    'menu_link_content',
+    'link',
+    'redirect',
+    'text',
+    'field',
+    'config_pages',
+    'link',
+  ];
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('path_alias');
+    $this->installEntitySchema('menu_link_content');
+    $this->installEntitySchema('redirect');
+    $this->installEntitySchema('field_storage_config');
+    $this->installEntitySchema('config_pages');
+    $this->installConfig('system');
+    $this->setInstallProfile('test_stanford_profile_helper');
+
+    NodeType::create(['type' => 'stanford_event', 'name' => 'Event'])->save();
+
+    $entity = $this->createMock(NodeInterface::class);
+    $entity->method('label')->willReturn('Foo Bar');
+
+    $default_content_mock = $this->createMock(StanfordDefaultContentInterface::class);
+    $default_content_mock->method('createDefaultContent')
+      ->willReturnReference($entity);
+
+    $container = \Drupal::getContainer();
+    $container->set('stanford_profile_helper.default_content', $default_content_mock);
+    \Drupal::setContainer($container);
+  }
+
+}

--- a/tests/codeception/acceptance/Media/MediaCest.php
+++ b/tests/codeception/acceptance/Media/MediaCest.php
@@ -118,8 +118,8 @@ class MediaCest {
   public function testAllowedEmbedCodes(AcceptanceTester $I) {
     $I->logInWithRole('site_manager');
     $I->amOnPage('/media/add/embeddable');
-    $I->fillField('Name', $this->faker->words(3, true));
-    $I->fillField('Embed Code', '<iframe src="' . $this->faker->url. '"></iframe>');
+    $I->fillField('Name', $this->faker->words(3, TRUE));
+    $I->fillField('Embed Code', '<iframe src="' . $this->faker->url . '"></iframe>');
     $I->click('Save');
     $I->canSee('The given embeddable code is not permitted');
 
@@ -226,6 +226,63 @@ class MediaCest {
     $I->fillField('oEmbed URL', 'https://purl.stanford.edu/fr477qg2469');
     $I->click('Save');
     $I->canSee('has been created.');
+  }
+
+  /**
+   * Test media category taxonomy field.
+   */
+  public function testCategoryField(AcceptanceTester $I) {
+    /** @var \Drupal\Core\File\FileSystemInterface $file_system */
+    $file_system = \Drupal::service('file_system');
+    $image_path = $file_system->copy(__DIR__ . '/../assets/logo.jpg', 'public://' . $this->faker->word . '.jpg');
+    $file = $I->createEntity(['uri' => $image_path], 'file');
+
+    $unrelated_term = $I->createEntity([
+      'vid' => 'media_tags',
+      'name' => $this->faker->word,
+    ], 'taxonomy_term');
+
+    $parent_term = $I->createEntity([
+      'vid' => 'media_tags',
+      'name' => $this->faker->word,
+    ], 'taxonomy_term');
+    $child_term = $I->createEntity([
+      'vid' => 'media_tags',
+      'name' => $this->faker->word,
+      'parent' => $parent_term->id(),
+    ], 'taxonomy_term');
+
+    $media = $I->createEntity([
+      'bundle' => 'image',
+      'field_media_image' => $file->id(),
+      'name' => $this->faker->words(3, TRUE),
+      'su_media_category' => $child_term,
+    ], 'media');
+
+    $I->logInWithRole('site_manager');
+
+    $I->amOnPage($media->toUrl('edit-form')->toString());
+    $I->canSeeInField('Category', '-' . $child_term->label());
+    $I->click('Save');
+
+    $I->amOnPage('/admin/content/media');
+    $I->canSee($media->label());
+
+    $I->selectOption('Category', $unrelated_term->label());
+    $I->click('Filter');
+    $I->cantSee($media->label());
+
+    $I->selectOption('Category', $parent_term->label());
+    $I->click('Filter');
+    $I->canSee($media->label());
+
+    $I->selectOption('Category', $unrelated_term->label());
+    $I->click('Filter');
+    $I->cantSee($media->label());
+
+    $I->selectOption('Category', '-' . $child_term->label());
+    $I->click('Filter');
+    $I->canSee($media->label());
   }
 
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added a taxonomy field on media entities for categorizing.

# Need Review By (Date)
- :shrug: 

# Urgency
- low

# Steps to Test
1. `composer require su-sws/stanford_profile:dev-D8CORE-5825`
2. install new site or import configs `drush cim -y`
3. create some media tags: `/admin/structure/taxonomy/manage/media_tags/overview` (using devel_generate can make that fast)
4. Create some media items via the node forms or `/media/add`
5. categorize the media you're creating
6. view the `/admin/content/media` and use the filters to find your media
7. create a basic page with a WYISYWG.
8. use the filters to find your media item when embedding something into the wysiwyg
