### PR TITLE
D8CORE-6217 Allow configuring maximum main menu depth

### DIFF
--- a/config/sync/config_pages.type.stanford_basic_site_settings.yml
+++ b/config/sync/config_pages.type.stanford_basic_site_settings.yml
@@ -66,6 +66,14 @@ third_party_settings:
       config_item: page.404
       prefix: /node/
       suffix: ''
+    204f6874-bb28-482d-b8e2-3193dd2cb120:
+      field: su_site_menu_levels
+      delta: 0
+      column: value
+      config_name: block.block.stanford_basic_main_navigation
+      config_item: settings.depth
+      prefix: ''
+      suffix: ''
 id: stanford_basic_site_settings
 label: 'Site Settings'
 token: null

--- a/config/sync/core.entity_form_display.config_pages.stanford_basic_site_settings.default.yml
+++ b/config/sync/core.entity_form_display.config_pages.stanford_basic_site_settings.default.yml
@@ -11,9 +11,11 @@ dependencies:
     - field.field.config_pages.stanford_basic_site_settings.su_site_dropdowns
     - field.field.config_pages.stanford_basic_site_settings.su_site_email
     - field.field.config_pages.stanford_basic_site_settings.su_site_home
+    - field.field.config_pages.stanford_basic_site_settings.su_site_menu_levels
     - field.field.config_pages.stanford_basic_site_settings.su_site_name
     - field.field.config_pages.stanford_basic_site_settings.su_site_url
   module:
+    - conditional_fields
     - link
 id: config_pages.stanford_basic_site_settings.default
 targetEntityType: config_pages
@@ -30,20 +32,20 @@ content:
     third_party_settings: {  }
   su_hide_site_search:
     type: boolean_checkbox
-    weight: 5
+    weight: 6
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   su_site_403:
     type: options_select
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   su_site_404:
     type: options_select
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -64,10 +66,34 @@ content:
     third_party_settings: {  }
   su_site_home:
     type: options_select
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
+  su_site_menu_levels:
+    type: number
+    weight: 5
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings:
+      conditional_fields:
+        db3026f2-f6a1-483b-8d70-37940855f9a4:
+          entity_type: config_pages
+          bundle: stanford_basic_site_settings
+          dependee: su_site_dropdowns
+          settings:
+            state: visible
+            condition: checked
+            grouping: AND
+            values_set: 1
+            value: ''
+            values: {  }
+            value_form:
+              value: false
+            effect: show
+            effect_options: {  }
+            selector: ''
   su_site_name:
     type: string_textfield
     weight: 0

--- a/config/sync/core.entity_view_display.config_pages.stanford_basic_site_settings.default.yml
+++ b/config/sync/core.entity_view_display.config_pages.stanford_basic_site_settings.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.config_pages.stanford_basic_site_settings.su_site_dropdowns
     - field.field.config_pages.stanford_basic_site_settings.su_site_email
     - field.field.config_pages.stanford_basic_site_settings.su_site_home
+    - field.field.config_pages.stanford_basic_site_settings.su_site_menu_levels
     - field.field.config_pages.stanford_basic_site_settings.su_site_name
     - field.field.config_pages.stanford_basic_site_settings.su_site_url
   module:
@@ -78,6 +79,15 @@ content:
       link: true
     third_party_settings: {  }
     weight: 6
+    region: content
+  su_site_menu_levels:
+    type: number_integer
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    weight: 9
     region: content
   su_site_name:
     type: string

--- a/config/sync/field.field.config_pages.stanford_basic_site_settings.su_site_menu_levels.yml
+++ b/config/sync/field.field.config_pages.stanford_basic_site_settings.su_site_menu_levels.yml
@@ -1,0 +1,23 @@
+uuid: 05de11e4-d05f-410d-99f0-a54170d51006
+langcode: en
+status: true
+dependencies:
+  config:
+    - config_pages.type.stanford_basic_site_settings
+    - field.storage.config_pages.su_site_menu_levels
+id: config_pages.stanford_basic_site_settings.su_site_menu_levels
+field_name: su_site_menu_levels
+entity_type: config_pages
+bundle: stanford_basic_site_settings
+label: 'Maximum Menu Levels'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 2
+  max: 9
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.storage.config_pages.su_site_menu_levels.yml
+++ b/config/sync/field.storage.config_pages.su_site_menu_levels.yml
@@ -1,0 +1,20 @@
+uuid: 74e762a1-1301-431e-83ce-ad257c2d98a2
+langcode: en
+status: true
+dependencies:
+  module:
+    - config_pages
+id: config_pages.su_site_menu_levels
+field_name: su_site_menu_levels
+entity_type: config_pages
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/stanford_profile_helper/src/Config/ConfigOverrides.php
+++ b/modules/stanford_profile_helper/src/Config/ConfigOverrides.php
@@ -111,7 +111,7 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
       return;
     }
 
-    // Override the lockup settings
+    // Override the lockup settings.
     if ($lockup_overrides = $this->getLockupTextOverrides()) {
       $overrides[$default_theme . '.settings'] = $lockup_overrides;
     }

--- a/modules/stanford_profile_helper/src/Config/ConfigOverrides.php
+++ b/modules/stanford_profile_helper/src/Config/ConfigOverrides.php
@@ -123,12 +123,7 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
   }
 
   /**
-   * Set the lockup text overrides.
-   *
-   * @param array $overrides
-   *   The array of overrides.
-   * @param string $theme_name
-   *   The name of the default theme.
+   * Get the lockup text overrides.
    */
   protected function getLockupTextOverrides() {
     $overrides = [
@@ -205,12 +200,11 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
    */
   protected function setMainMenuOverrides(array $names, array &$overrides) {
     foreach ($names as $name) {
-      if (strpos($name, 'block.block') === 0) {
+      if (str_starts_with($name, 'block.block.')) {
         $block_plugin = $this->configFactory->getEditable($name)
           ->getOriginal('plugin', FALSE);
         $region = $this->configFactory->getEditable($name)
           ->getOriginal('region', FALSE);
-
 
         if ($block_plugin == 'system_menu_block:main' && $region == 'menu') {
           $menu_depth = (int) $this->configPagesLoader->getValue('stanford_basic_site_settings', 'su_site_menu_levels', 0, 'value');

--- a/modules/stanford_profile_helper/src/Config/ConfigOverrides.php
+++ b/modules/stanford_profile_helper/src/Config/ConfigOverrides.php
@@ -9,7 +9,6 @@ use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\config_pages\ConfigPagesLoaderServiceInterface;
-use Drupal\config_pages\ConfigPagesInterface;
 use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
 
 /**
@@ -68,13 +67,7 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
    * @param \Drupal\Core\StreamWrapper\StreamWrapperManagerInterface $stream_wrapper_manager
    *   Stream wrapper manager interface.
    */
-  public function __construct(
-    StateInterface                    $state,
-    ConfigPagesLoaderServiceInterface $config_pages_loader,
-    ConfigFactoryInterface            $config_factory,
-    EntityTypeManagerInterface        $entity_type_manager,
-    StreamWrapperManagerInterface     $stream_wrapper_manager
-  ) {
+  public function __construct(StateInterface $state, ConfigPagesLoaderServiceInterface $config_pages_loader, ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager, StreamWrapperManagerInterface $stream_wrapper_manager) {
     $this->state = $state;
     $this->configPagesLoader = $config_pages_loader;
     $this->configFactory = $config_factory;
@@ -105,34 +98,28 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
    *   Keyed array of config overrides.
    */
   protected function setLockupOverrides(array $names, array &$overrides) {
-
-    // Avoid circular loops.
-    if (!$this->configFactory || in_array('system.theme', $names)) {
-      return;
-    }
-
     // Validate we are working with the info we need.
-    $theme_info = $this->configFactory->get('system.theme');
-    if (!$this->configPagesLoader || !$theme_info || !in_array($theme_info->get('default') . '.settings', $names)) {
+    $default_theme = $this->configFactory->getEditable('system.theme')
+      ->getOriginal('default', FALSE);
+
+    if (!in_array("$default_theme.settings", $names)) {
       return;
     }
 
-    // Get the default theme from the config.
-    $theme_name = $theme_info->get('default');
-    $config_page = $this->configPagesLoader->load('lockup_settings');
-
-    // Failed to load the config page or not enabled.
-    if (!$config_page || $config_page->get('su_lockup_enabled')
-        ->getString() == "1") {
+    // The lockup isn't enabled, so bail out.
+    if (!$this->configPagesLoader->getValue('lockup_settings', 'su_lockup_enabled', 0, 'value')) {
       return;
     }
 
-    // Do the overrides.
-    $this->setLockupTextOverrides($overrides, $theme_name, $config_page);
+    // Override the lockup settings
+    if ($lockup_overrides = $this->getLockupTextOverrides()) {
+      $overrides[$default_theme . '.settings'] = $lockup_overrides;
+    }
 
     // Get and set a file path that is relative to the site base dir.
-    $this->setLockupFileOverrides($overrides, $theme_name, $config_page);
-
+    if ($logo = $this->getLogoUrl()) {
+      $overrides[$default_theme . '.settings']['logo']['path'] = $logo;
+    }
   }
 
   /**
@@ -142,54 +129,44 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
    *   The array of overrides.
    * @param string $theme_name
    *   The name of the default theme.
-   * @param \Drupal\config_pages\ConfigPagesInterface $config_page
-   *   A config page object.
    */
-  protected function setLockupTextOverrides(array &$overrides, $theme_name, ConfigPagesInterface $config_page) {
-    $overrides[$theme_name . '.settings'] = [
+  protected function getLockupTextOverrides() {
+    $overrides = [
       'lockup' => [
-        'option' => $config_page->get('su_lockup_options')->getString(),
-        'line1' => $config_page->get('su_line_1')->getString(),
-        'line2' => $config_page->get('su_line_2')->getString(),
-        'line3' => $config_page->get('su_line_3')->getString(),
-        'line4' => $config_page->get('su_line_4')->getString(),
-        'line5' => $config_page->get('su_line_5')->getString(),
+        'option' => $this->configPagesLoader->getValue('lockup_settings', 'su_lockup_options', 0, 'value'),
+        'line1' => $this->configPagesLoader->getValue('lockup_settings', 'su_line_1', 0, 'value'),
+        'line2' => $this->configPagesLoader->getValue('lockup_settings', 'su_line_2', 0, 'value'),
+        'line3' => $this->configPagesLoader->getValue('lockup_settings', 'su_line_3', 0, 'value'),
+        'line4' => $this->configPagesLoader->getValue('lockup_settings', 'su_line_4', 0, 'value'),
+        'line5' => $this->configPagesLoader->getValue('lockup_settings', 'su_line_5', 0, 'value'),
       ],
       'logo' => [
-        'use_default' => ($config_page->get('su_use_theme_logo')
-            ->getString() == "1") ? TRUE : FALSE,
+        'use_default' => (bool) $this->configPagesLoader->getValue('lockup_settings', 'su_use_theme_logo', 0, 'value'),
       ],
     ];
+    $overrides['lockup'] = array_filter($overrides['lockup']);
+    $overrides['logo'] = array_filter($overrides['logo']);
+    return array_filter($overrides);
   }
 
   /**
-   * Set the lockup file/logo overrides.
-   *
-   * @param array $overrides
-   *   The array of overrides.
-   * @param string $theme_name
-   *   The name of the default theme.
-   * @param \Drupal\config_pages\ConfigPagesInterface $config_page
-   *   A config page object.
+   * Get the lockup file/logo overrides.
    */
-  protected function setLockupFileOverrides(array &$overrides, $theme_name, ConfigPagesInterface $config_page) {
+  protected function getLogoUrl(): ?string {
 
-    $file_field = $config_page->get('su_upload_logo_image')->getValue();
-    if (empty($file_field[0]['target_id'])) {
-      return;
+    $file_id = $this->configPagesLoader->getValue('lockup_settings', 'su_upload_logo_image', 0, 'target_id');
+    if (!$file_id) {
+      return NULL;
     }
 
-    $file = $this->entityTypeManager->getStorage('file')
-      ->load($file_field[0]['target_id']);
+    $file = $this->entityTypeManager->getStorage('file')->load($file_id);
     if (!$file) {
-      return;
+      return NULL;
     }
 
     $file_uri = $file->getFileUri();
     $wrapper = $this->streamWrapperManager->getViaUri($file_uri);
-    $file_path = $wrapper->getExternalUrl();
-
-    $overrides[$theme_name . '.settings']['logo']['path'] = $file_path;
+    return $wrapper->getExternalUrl();
   }
 
   /**
@@ -233,6 +210,7 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
           ->getOriginal('plugin', FALSE);
         $region = $this->configFactory->getEditable($name)
           ->getOriginal('region', FALSE);
+
 
         if ($block_plugin == 'system_menu_block:main' && $region == 'menu') {
           $menu_depth = (int) $this->configPagesLoader->getValue('stanford_basic_site_settings', 'su_site_menu_levels', 0, 'value');

--- a/modules/stanford_profile_helper/src/Config/ConfigOverrides.php
+++ b/modules/stanford_profile_helper/src/Config/ConfigOverrides.php
@@ -107,18 +107,13 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
     }
 
     // The lockup isn't enabled, so bail out.
-    if (!$this->configPagesLoader->getValue('lockup_settings', 'su_lockup_enabled', 0, 'value')) {
+    if ($this->configPagesLoader->getValue('lockup_settings', 'su_lockup_enabled', 0, 'value')) {
       return;
     }
 
     // Override the lockup settings.
     if ($lockup_overrides = $this->getLockupTextOverrides()) {
       $overrides[$default_theme . '.settings'] = $lockup_overrides;
-    }
-
-    // Get and set a file path that is relative to the site base dir.
-    if ($logo = $this->getLogoUrl()) {
-      $overrides[$default_theme . '.settings']['logo']['path'] = $logo;
     }
   }
 
@@ -136,11 +131,15 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
         'line5' => $this->configPagesLoader->getValue('lockup_settings', 'su_line_5', 0, 'value'),
       ],
       'logo' => [
-        'use_default' => (bool) $this->configPagesLoader->getValue('lockup_settings', 'su_use_theme_logo', 0, 'value'),
+        'path' => $this->getLogoUrl(),
       ],
     ];
     $overrides['lockup'] = array_filter($overrides['lockup']);
     $overrides['logo'] = array_filter($overrides['logo']);
+
+    if (!empty($overrides['lockup']) && !$this->configPagesLoader->getValue('lockup_settings', 'su_use_theme_logo', 0, 'value')) {
+      $overrides['logo']['use_default'] = FALSE;
+    }
     return array_filter($overrides);
   }
 

--- a/modules/stanford_profile_helper/tests/src/Unit/Config/ConfigOverridesTest.php
+++ b/modules/stanford_profile_helper/tests/src/Unit/Config/ConfigOverridesTest.php
@@ -24,6 +24,8 @@ class ConfigOverridesTest extends UnitTestCase {
 
   protected $logoFile;
 
+  protected $configPageValues = [];
+
   /**
    * Custom roles can be assigned by the site managers.
    */
@@ -43,14 +45,15 @@ class ConfigOverridesTest extends UnitTestCase {
     $overridder = $this->getOverrideService();
     $this->assertEmpty($overridder->loadOverrides(['barfoo.settings']));
     $this->assertEmpty($overridder->loadOverrides(['foobar.settings']));
+
     $this->configPageValues['lockup_settings'] = [
-      'su_lockup_enabled' => 1,
+      'su_lockup_enabled' => 0,
       'su_lockup_options' => 'a',
       'su_line_1' => 'Line 1',
       'su_line_2' => 'Line 2',
       'su_line_4' => 'Line 4',
       'su_line_5' => 'Line 5',
-      'su_use_theme_logo' => 1,
+      'su_use_theme_logo' => 0,
       'su_upload_logo_image' => NULL,
     ];
 
@@ -65,17 +68,18 @@ class ConfigOverridesTest extends UnitTestCase {
             'line5' => 'Line 5',
           ],
           'logo' => [
-            'use_default' => TRUE,
+            'use_default' => FALSE,
           ],
         ],
     ];
+
     $this->assertEquals($expected, $overridder->loadOverrides(['foobar.settings']));
 
     $this->configPageValues['lockup_settings']['su_upload_logo_image'] = 1;
     $this->assertEquals($expected, $overridder->loadOverrides(['foobar.settings']));
 
     $this->logoFile = $this->createMock(FileInterface::class);
-    $this->logoFile->method('getFileuri')->wilLReturn('public://foobar.jpg');
+    $this->logoFile->method('getFileUri')->wilLReturn('public://foobar.jpg');
 
     $expected['foobar.settings']['logo']['path'] = '/sites/default/files/logo.jpg';
     $this->assertEquals($expected, $overridder->loadOverrides(['foobar.settings']));

--- a/modules/stanford_profile_helper/tests/src/Unit/Config/ConfigOverridesTest.php
+++ b/modules/stanford_profile_helper/tests/src/Unit/Config/ConfigOverridesTest.php
@@ -2,18 +2,15 @@
 
 namespace Drupal\Tests\stanford_profile_helper\Unit\Config;
 
+use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Cache\CacheableMetadata;
-use Drupal\Core\Config\Config;
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\State\StateInterface;
+use Drupal\file\FileInterface;
 use Drupal\stanford_profile_helper\Config\ConfigOverrides;
 use Drupal\Tests\UnitTestCase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\config_pages\ConfigPagesLoaderServiceInterface;
-use Drupal\config_pages\Entity\ConfigPages;
 use Drupal\Core\Entity\EntityStorageInterface;
-use Drupal\file\Entity\File;
-use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
 use Drupal\Core\StreamWrapper\StreamWrapperInterface;
 
@@ -25,41 +22,96 @@ use Drupal\Core\StreamWrapper\StreamWrapperInterface;
  */
 class ConfigOverridesTest extends UnitTestCase {
 
-  /**
-   * @var \Drupal\stanford_profile_helper\Config\ConfigOverrides
-   */
-  protected $overrideService;
-
-  /**
-   * {@inheritDoc}
-   */
-  protected function setUp(): void {
-    parent::setUp();
-    $state = $this->createMock(StateInterface::class);
-    $state->method('get')->will($this->returnCallback([
-      $this,
-      'getStateCallback',
-    ]));
-
-    $config_pages = $this->createMock(ConfigPagesLoaderServiceInterface::class);
-    $config_factory = $this->createMock(ConfigFactoryInterface::class);
-    $entity_manager = $this->createMock(EntityTypeManagerInterface::class);
-    $stream_wrapper_manager = $this->createMock(StreamWrapperManagerInterface::class);
-
-    $config_factory->method('getEditable')
-      ->will($this->returnCallback([$this, 'getConfigCallback']));
-
-    $this->overrideService = new ConfigOverrides($state, $config_pages, $config_factory, $entity_manager, $stream_wrapper_manager);
-  }
+  protected $logoFile;
 
   /**
    * Custom roles can be assigned by the site managers.
    */
   public function testConfigRolesOverrides() {
-    $overrides = $this->overrideService->loadOverrides(['user.role.site_manager']);
+    $overridder = $this->getOverrideService();
+    $overrides = $overridder->loadOverrides(['user.role.site_manager']);
     $expected['user.role.site_manager']['permissions'][500] = 'assign custm_foo_bar role';
     $expected['user.role.site_manager']['permissions'][501] = 'assign custm_bar_foo role';
     $this->assertEquals($expected, $overrides);
+  }
+
+  /**
+   * Lockup custom overrides through config form.
+   */
+  public function testConfigLockupOverrides() {
+
+    $overridder = $this->getOverrideService();
+    $this->assertEmpty($overridder->loadOverrides(['barfoo.settings']));
+    $this->assertEmpty($overridder->loadOverrides(['foobar.settings']));
+    $this->configPageValues['lockup_settings'] = [
+      'su_lockup_enabled' => 1,
+      'su_lockup_options' => 'a',
+      'su_line_1' => 'Line 1',
+      'su_line_2' => 'Line 2',
+      'su_line_4' => 'Line 4',
+      'su_line_5' => 'Line 5',
+      'su_use_theme_logo' => 1,
+      'su_upload_logo_image' => NULL,
+    ];
+
+    $expected = [
+      'foobar.settings' =>
+        [
+          'lockup' => [
+            'option' => 'a',
+            'line1' => 'Line 1',
+            'line2' => 'Line 2',
+            'line4' => 'Line 4',
+            'line5' => 'Line 5',
+          ],
+          'logo' => [
+            'use_default' => TRUE,
+          ],
+        ],
+    ];
+    $this->assertEquals($expected, $overridder->loadOverrides(['foobar.settings']));
+
+    $this->configPageValues['lockup_settings']['su_upload_logo_image'] = 1;
+    $this->assertEquals($expected, $overridder->loadOverrides(['foobar.settings']));
+
+    $this->logoFile = $this->createMock(FileInterface::class);
+    $this->logoFile->method('getFileuri')->wilLReturn('public://foobar.jpg');
+
+    $expected['foobar.settings']['logo']['path'] = '/sites/default/files/logo.jpg';
+    $this->assertEquals($expected, $overridder->loadOverrides(['foobar.settings']));
+  }
+
+  public function testMainMenuOverrides() {
+    $configs = [
+      'block.block.foobar_main_menu' => [
+        'plugin' => 'system_menu_block:main',
+        'region' => 'menu',
+      ],
+    ];
+    $overridder = $this->getOverrideService($configs);
+
+    $expected = [];
+    $this->assertEquals($expected, $overridder->loadOverrides(['block.block.foobar_main_menu']));
+
+    $this->configPageValues['stanford_basic_site_settings'] = ['su_site_menu_levels' => 2];
+    $expected['block.block.foobar_main_menu'] = ['settings' => ['depth' => 2]];
+    $this->assertEquals($expected, $overridder->loadOverrides(['block.block.foobar_main_menu']));
+  }
+
+  public function getConfigPageValue($config_name, $field, $delta = [], $key = NULL) {
+    return $this->configPageValues[$config_name][$field] ?? NULL;
+  }
+
+  /**
+   * [testCreateConfigObject description]
+   *
+   * @return [type] [description]
+   */
+  public function testDefaultFunctions() {
+    $overridder = $this->getOverrideService();
+    $this->assertNull($overridder->createConfigObject('name'));
+    $this->assertEquals($overridder->getCacheSuffix(), 'StanfordProfileHelperConfigOverride');
+    $this->assertInstanceOf(CacheableMetadata::class, $overridder->getCacheableMetadata('name'));
   }
 
   /**
@@ -78,194 +130,89 @@ class ConfigOverridesTest extends UnitTestCase {
     return $default_value;
   }
 
-  /**
-   * Lockup custom overrides through config form.
-   */
-  public function testConfigLockupOverrides() {
+  protected function getOverrideService(array $configs = []) {
+    if (!isset($configs['system.theme']['default'])) {
+      $configs['system.theme']['default'] = 'foobar';
+    }
     $state = $this->createMock(StateInterface::class);
+    $state->method('get')->will($this->returnCallback([
+      $this,
+      'getStateCallback',
+    ]));
 
     $config_pages = $this->createMock(ConfigPagesLoaderServiceInterface::class);
-    $config_factory = $this->createMock(ConfigFactoryInterface::class);
+    $config_pages->method('getValue')->will(
+      $this->returnCallback([$this, 'getConfigPageValue'])
+    );
+
+    $file_storage = $this->createMock(EntityStorageInterface::class);
+    $file_storage->method('load')->willReturnReference($this->logoFile);
+
     $entity_manager = $this->createMock(EntityTypeManagerInterface::class);
-    $file = $this->createMock(File::class);
-    $entity_storage = $this->createMock(EntityStorageInterface::class);
-    $stream_wrapper_manager = $this->createMock(StreamWrapperManagerInterface::class);
+    $entity_manager->method('getStorage')->wilLReturn($file_storage);
+
     $stream_wrapper = $this->createMock(StreamWrapperInterface::class);
-
-    $config_factory->method('getEditable')->will(
-      $this->returnCallback([$this, 'getConfigCallback'])
-    );
-
-    $config_factory->method('get')->will(
-      $this->returnCallback([$this, 'getConfigCallback'])
-    );
-
-    $config_pages->method('load')->will(
-      $this->returnCallback([$this, 'getConfigPageLockup'])
-    );
-
-    $file->method('getFileUri')->willReturn('public://logo.jpg');
-    $entity_storage->method('load')->willReturn($file);
-    $entity_manager->method('getStorage')->willReturn($entity_storage);
-
     $stream_wrapper->method('getExternalUrl')
       ->willReturn('/sites/default/files/logo.jpg');
+
+    $stream_wrapper_manager = $this->createMock(StreamWrapperManagerInterface::class);
     $stream_wrapper_manager->method('getViaUri')->willReturn($stream_wrapper);
 
-    $overrideService = new ConfigOverrides($state, $config_pages, $config_factory, $entity_manager, $stream_wrapper_manager);
-
-    $overrides = $overrideService->loadOverrides(['stanford_basic.settings']);
-    $expected = [
-      'stanford_basic.settings' =>
-        [
-          'lockup' => [
-            'option' => 'a',
-            'line1' => 'Line 1',
-            'line2' => 'Line 2',
-            'line3' => 'Line 3',
-            'line4' => 'Line 4',
-            'line5' => 'Line 5',
-          ],
-          'logo' => [
-            'path' => '/sites/default/files/logo.jpg',
-            'use_default' => TRUE,
-          ],
-        ],
-    ];
-    $this->assertEquals($expected, $overrides);
-
-    // TEST SOME FAILURES FOR MORE COVERAGE.
-    // -------------------------------------------------------------------------
-
-    // Test to avoid circular ref.
-    $overrides = $overrideService->loadOverrides(['system.theme']);
-
-    // Test a failed get image from config page.
-    $config_page = $this->createMock(ConfigPages::class);
-    $config_page->method('get')->willReturn(FALSE);
-    $config_pages->method('load')->willReturn($config_page);
-    $overrideService = new ConfigOverrides($state, $config_pages, $config_factory, $entity_manager, $stream_wrapper_manager);
-    $overrides = $overrideService->loadOverrides(['stanford_basic.settings']);
-    $this->assertTrue(is_array($overrides));
-
-    // Test a failed get image fid.
-    $obj = $this->createMock(FieldItemListInterface::class);
-    $obj->method('getValue')->willReturn(FALSE);
-    $obj->method('first')->will(
-      $this->returnSelf()
-    );
-    $config_page = $this->createMock(ConfigPages::class);
-    $config_page->method('get')->willReturn($obj);
-    $config_pages->method('load')->willReturn($config_page);
-    $overrideService = new ConfigOverrides($state, $config_pages, $config_factory, $entity_manager, $stream_wrapper_manager);
-    $overrides = $overrideService->loadOverrides(['stanford_basic.settings']);
-    $this->assertTrue(is_array($overrides));
-
-    // Test a failed config page load.
-    $config_pages->method('load')->willReturn(FALSE);
-    $overrideService = new ConfigOverrides($state, $config_pages, $config_factory, $entity_manager, $stream_wrapper_manager);
-    $overrides = $overrideService->loadOverrides(['stanford_basic.settings']);
-    $this->assertTrue(is_array($overrides));
-
+    $this->configFactory = $this->getConfigFactoryStub([
+      'system.them' => ['stanford_basic' => 0],
+    ]);
+    return new ConfigOverrides($state, $config_pages, $this->getConfigFactoryStub($configs), $entity_manager, $stream_wrapper_manager);
   }
 
-  /**
-   * [getConfigCallback description]
-   *
-   * @param  [type] $name [description]
-   *
-   * @return [type]       [description]
-   */
-  public function getConfigCallback($name) {
-    $config = $this->createMock(Config::class);
-    $setting = [];
-    switch ($name) {
-      case 'core.extension':
-        $setting = ['stable' => 0, 'seven' => 0];
-        break;
+  public function getConfigFactoryStub(array $configs = []) {
+    $config_get_map = [];
+    $config_editable_map = [];
+    // Construct the desired configuration object stubs, each with its own
+    // desired return map.
+    foreach ($configs as $config_name => $config_values) {
+      // Define a closure over the $config_values, which will be used as a
+      // returnCallback below. This function will mimic
+      // \Drupal\Core\Config\Config::get and allow using dotted keys.
+      $config_get = function ($key = '') use ($config_values) {
+        // Allow to pass in no argument.
+        if (empty($key)) {
+          return $config_values;
+        }
+        // See if we have the key as is.
+        if (isset($config_values[$key])) {
+          return $config_values[$key];
+        }
+        $parts = explode('.', $key);
+        $value = NestedArray::getValue($config_values, $parts, $key_exists);
+        return $key_exists ? $value : NULL;
+      };
 
-      case 'system.theme':
-        $setting = ['default' => 'stanford_basic'];
-        break;
+      $immutable_config_object = $this->getMockBuilder('Drupal\Core\Config\ImmutableConfig')
+        ->disableOriginalConstructor()
+        ->getMock();
+      $immutable_config_object->expects($this->any())
+        ->method('get')
+        ->willReturnCallback($config_get);
+      $config_get_map[] = [$config_name, $immutable_config_object];
+
+      $mutable_config_object = $this->getMockBuilder('Drupal\Core\Config\Config')
+        ->disableOriginalConstructor()
+        ->getMock();
+      $mutable_config_object->expects($this->any())
+        ->method('getOriginal')
+        ->willReturnCallback($config_get);
+      $config_editable_map[] = [$config_name, $mutable_config_object];
     }
-
-    $config->method('getOriginal')->willReturn($setting);
-    $config->method('get')->with('default')->willReturn('stanford_basic');
-    return $config;
-  }
-
-  /**
-   * [getConfigPageLockup description]
-   *
-   * @return [type] [description]
-   */
-  function getConfigPageLockup($name) {
-    $config_page = $this->createMock(ConfigPages::class);
-
-    $config_page->method('get')->will(
-      $this->returnCallback([$this, 'getFieldValue'])
-    );
-
-    return $config_page;
-  }
-
-  /**
-   * [getFieldValue description]
-   *
-   * @param  [type] $name [description]
-   *
-   * @return [type]       [description]
-   */
-  public function getFieldValue($name) {
-    $obj = $this->createMock(FieldItemListInterface::class);
-
-    switch ($name) {
-      case 'su_lockup_options':
-        $obj->method('getString')->willReturn('a');
-        break;
-
-      case 'su_line_1':
-        $obj->method('getString')->willReturn('Line 1');
-        break;
-
-      case 'su_line_2':
-        $obj->method('getString')->willReturn('Line 2');
-        break;
-
-      case 'su_line_3':
-        $obj->method('getString')->willReturn('Line 3');
-        break;
-
-      case 'su_line_4':
-        $obj->method('getString')->willReturn('Line 4');
-        break;
-
-      case 'su_line_5':
-        $obj->method('getString')->willReturn('Line 5');
-        break;
-
-      case 'su_use_theme_logo':
-        $obj->method('getString')->willReturn('1');
-        break;
-
-      case 'su_upload_logo_image':
-        $obj->method('getValue')->willReturn([['target_id' => 1]]);
-        break;
-    }
-
-    return $obj;
-  }
-
-  /**
-   * [testCreateConfigObject description]
-   *
-   * @return [type] [description]
-   */
-  function testDefaultFunctions() {
-    $this->assertNull($this->overrideService->createConfigObject('name'));
-    $this->assertEquals($this->overrideService->getCacheSuffix(), 'StanfordProfileHelperConfigOverride');
-    $obj = new CacheableMetadata();
-    $this->assertEquals(get_class($obj), get_class($this->overrideService->getCacheableMetadata('name')));
+    // Construct a config factory with the array of configuration object stubs
+    // as its return map.
+    $config_factory = $this->createMock('Drupal\Core\Config\ConfigFactoryInterface');
+    $config_factory->expects($this->any())
+      ->method('get')
+      ->willReturnMap($config_get_map);
+    $config_factory->expects($this->any())
+      ->method('getEditable')
+      ->willReturnMap($config_editable_map);
+    return $config_factory;
   }
 
 }

--- a/tests/codeception/acceptance/LockupSettings/LockupSettingsCest.php
+++ b/tests/codeception/acceptance/LockupSettings/LockupSettingsCest.php
@@ -4,6 +4,8 @@ require_once __DIR__ . '/../TestFilesTrait.php';
 
 /**
  * Test for the lockup settings.
+ *
+ * @group lockup
  */
 class LockupSettingsCest {
 
@@ -50,9 +52,9 @@ class LockupSettingsCest {
     $I->logInWithRole('administrator');
     $I->amOnPage('/admin/config/system/lockup-settings');
     $I->canSeeResponseCodeIs(200);
-    $I->uncheckOption('#edit-su-lockup-enabled-value');
-    $I->selectOption('#edit-su-lockup-options', 'a');
-    $I->checkOption('#edit-su-use-theme-logo-value');
+    $I->uncheckOption('Use Default Lockup');
+    $I->selectOption('Lockup Options', 'a');
+    $I->checkOption('Use the logo supplied by the theme');
     $I->fillField('Line 1', 'Site title line');
     $I->fillField('Line 2', 'Secondary title line');
     $I->fillField('Line 3', 'Tertiary title line');
@@ -71,9 +73,9 @@ class LockupSettingsCest {
     $I->logInWithRole('administrator');
     $I->amOnPage('/admin/config/system/lockup-settings');
     $I->canSeeResponseCodeIs(200);
-    $I->uncheckOption('#edit-su-lockup-enabled-value');
-    $I->selectOption("#edit-su-lockup-options", "b");
-    $I->checkOption('#edit-su-use-theme-logo-value');
+    $I->uncheckOption('Use Default Lockup');
+    $I->selectOption("Lockup Options", "b");
+    $I->checkOption('Use the logo supplied by the theme');
     $I->fillField('Line 1', 'Site title line');
     $I->fillField('Line 2', 'Secondary title line');
     $I->fillField('Line 3', 'Tertiary title line');
@@ -92,9 +94,9 @@ class LockupSettingsCest {
     $I->logInWithRole('administrator');
     $I->amOnPage('/admin/config/system/lockup-settings');
     $I->canSeeResponseCodeIs(200);
-    $I->uncheckOption('#edit-su-lockup-enabled-value');
-    $I->selectOption("#edit-su-lockup-options", "d");
-    $I->checkOption('#edit-su-use-theme-logo-value');
+    $I->uncheckOption('Use Default Lockup');
+    $I->selectOption("Lockup Options", "d");
+    $I->checkOption('Use the logo supplied by the theme');
     $I->fillField('Line 1', 'Site title line');
     $I->fillField('Line 2', 'Secondary title line');
     $I->fillField('Line 3', 'Tertiary title line');
@@ -113,9 +115,9 @@ class LockupSettingsCest {
     $I->logInWithRole('administrator');
     $I->amOnPage('/admin/config/system/lockup-settings');
     $I->canSeeResponseCodeIs(200);
-    $I->uncheckOption('#edit-su-lockup-enabled-value');
-    $I->selectOption("#edit-su-lockup-options", "e");
-    $I->checkOption('#edit-su-use-theme-logo-value');
+    $I->uncheckOption('Use Default Lockup');
+    $I->selectOption("Lockup Options", "e");
+    $I->checkOption('Use the logo supplied by the theme');
     $I->fillField('Line 1', 'Site title line');
     $I->fillField('Line 2', 'Secondary title line');
     $I->fillField('Line 3', 'Tertiary title line');
@@ -135,9 +137,9 @@ class LockupSettingsCest {
     $I->logInWithRole('administrator');
     $I->amOnPage('/admin/config/system/lockup-settings');
     $I->canSeeResponseCodeIs(200);
-    $I->uncheckOption('#edit-su-lockup-enabled-value');
-    $I->selectOption("#edit-su-lockup-options", "h");
-    $I->checkOption('#edit-su-use-theme-logo-value');
+    $I->uncheckOption('Use Default Lockup');
+    $I->selectOption("Lockup Options", "h");
+    $I->checkOption('Use the logo supplied by the theme');
     $I->fillField('Line 1', 'Site title line');
     $I->fillField('Line 2', 'Secondary title line');
     $I->fillField('Line 3', 'Tertiary title line');
@@ -157,9 +159,9 @@ class LockupSettingsCest {
     $I->logInWithRole('administrator');
     $I->amOnPage('/admin/config/system/lockup-settings');
     $I->canSeeResponseCodeIs(200);
-    $I->uncheckOption('#edit-su-lockup-enabled-value');
-    $I->selectOption("#edit-su-lockup-options", "i");
-    $I->checkOption('#edit-su-use-theme-logo-value');
+    $I->uncheckOption('Use Default Lockup');
+    $I->selectOption("Lockup Options", "i");
+    $I->checkOption('Use the logo supplied by the theme');
     $I->fillField('Line 1', 'Site title line');
     $I->fillField('Line 2', 'Secondary title line');
     $I->fillField('Line 3', 'Tertiary title line');
@@ -179,9 +181,9 @@ class LockupSettingsCest {
     $I->logInWithRole('administrator');
     $I->amOnPage('/admin/config/system/lockup-settings');
     $I->canSeeResponseCodeIs(200);
-    $I->uncheckOption('#edit-su-lockup-enabled-value');
-    $I->selectOption("#edit-su-lockup-options", "m");
-    $I->checkOption('#edit-su-use-theme-logo-value');
+    $I->uncheckOption('Use Default Lockup');
+    $I->selectOption("Lockup Options", "m");
+    $I->checkOption('Use the logo supplied by the theme');
     $I->fillField('Line 1', 'Site title line');
     $I->fillField('Line 2', 'Secondary title line');
     $I->fillField('Line 3', 'Tertiary title line');
@@ -200,9 +202,9 @@ class LockupSettingsCest {
     $I->logInWithRole('administrator');
     $I->amOnPage('/admin/config/system/lockup-settings');
     $I->canSeeResponseCodeIs(200);
-    $I->uncheckOption('#edit-su-lockup-enabled-value');
-    $I->selectOption("#edit-su-lockup-options", "o");
-    $I->checkOption('#edit-su-use-theme-logo-value');
+    $I->uncheckOption('Use Default Lockup');
+    $I->selectOption("Lockup Options", "o");
+    $I->checkOption('Use the logo supplied by the theme');
     $I->fillField('Line 1', 'Site title line');
     $I->fillField('Line 2', 'Secondary title line');
     $I->fillField('Line 3', 'Tertiary title line');
@@ -220,9 +222,9 @@ class LockupSettingsCest {
     $I->logInWithRole('administrator');
     $I->amOnPage('/admin/config/system/lockup-settings');
     $I->canSeeResponseCodeIs(200);
-    $I->uncheckOption('#edit-su-lockup-enabled-value');
-    $I->selectOption("#edit-su-lockup-options", "p");
-    $I->checkOption('#edit-su-use-theme-logo-value');
+    $I->uncheckOption('Use Default Lockup');
+    $I->selectOption("Lockup Options", "p");
+    $I->checkOption('Use the logo supplied by the theme');
     $I->fillField('Line 1', 'Site title line');
     $I->fillField('Line 2', 'Secondary title line');
     $I->fillField('Line 3', 'Tertiary title line');
@@ -241,9 +243,9 @@ class LockupSettingsCest {
     $I->logInWithRole('administrator');
     $I->amOnPage('/admin/config/system/lockup-settings');
     $I->canSeeResponseCodeIs(200);
-    $I->uncheckOption('#edit-su-lockup-enabled-value');
-    $I->selectOption("#edit-su-lockup-options", "r");
-    $I->checkOption('#edit-su-use-theme-logo-value');
+    $I->uncheckOption('Use Default Lockup');
+    $I->selectOption("Lockup Options", "r");
+    $I->checkOption('Use the logo supplied by the theme');
     $I->fillField('Line 1', 'Site title line');
     $I->fillField('Line 2', 'Secondary title line');
     $I->fillField('Line 3', 'Tertiary title line');
@@ -261,9 +263,9 @@ class LockupSettingsCest {
     $I->logInWithRole('administrator');
     $I->amOnPage('/admin/config/system/lockup-settings');
     $I->canSeeResponseCodeIs(200);
-    $I->uncheckOption('#edit-su-lockup-enabled-value');
-    $I->selectOption("#edit-su-lockup-options", "s");
-    $I->checkOption('#edit-su-use-theme-logo-value');
+    $I->uncheckOption('Use Default Lockup');
+    $I->selectOption("Lockup Options", "s");
+    $I->checkOption('Use the logo supplied by the theme');
     $I->fillField('Line 1', 'Site title line');
     $I->fillField('Line 2', 'Secondary title line');
     $I->fillField('Line 3', 'Tertiary title line');
@@ -283,9 +285,9 @@ class LockupSettingsCest {
     $I->logInWithRole('administrator');
     $I->amOnPage('/admin/config/system/lockup-settings');
     $I->canSeeResponseCodeIs(200);
-    $I->uncheckOption('#edit-su-lockup-enabled-value');
-    $I->selectOption("#edit-su-lockup-options", "t");
-    $I->checkOption('#edit-su-use-theme-logo-value');
+    $I->uncheckOption('Use Default Lockup');
+    $I->selectOption("Lockup Options", "t");
+    $I->checkOption('Use the logo supplied by the theme');
     $I->fillField('Line 1', 'Site title line');
     $I->fillField('Line 2', 'Secondary title line');
     $I->fillField('Line 3', 'Tertiary title line');
@@ -306,8 +308,8 @@ class LockupSettingsCest {
     $I->logInWithRole('administrator');
     $I->amOnPage('/admin/config/system/lockup-settings');
     $I->canSeeResponseCodeIs(200);
-    $I->uncheckOption('#edit-su-lockup-enabled-value');
-    $I->selectOption('#edit-su-lockup-options', 'a');
+    $I->uncheckOption('Use Default Lockup');
+    $I->selectOption('Lockup Options', 'a');
     $I->fillField('Line 1', 'Site title line');
     $I->fillField('Line 2', 'Secondary title line');
     $I->fillField('Line 3', 'Tertiary title line');
@@ -315,7 +317,7 @@ class LockupSettingsCest {
     $I->fillField('Line 5', 'Last line full width option');
 
     // Add custom logo.
-    $I->uncheckOption('#edit-su-use-theme-logo-value');
+    $I->uncheckOption('Use the logo supplied by the theme');
 
     // In case there was an image already.
     if ($I->grabMultiple('input[value="Remove"]')) {
@@ -339,8 +341,8 @@ class LockupSettingsCest {
     $I->logInWithRole('administrator');
     $I->amOnPage('/admin/config/system/lockup-settings');
     $I->canSeeResponseCodeIs(200);
-    $I->uncheckOption('#edit-su-lockup-enabled-value');
-    $I->selectOption('#edit-su-lockup-options', 'none');
+    $I->uncheckOption('Use Default Lockup');
+    $I->selectOption('Lockup Options', 'none');
     $I->fillField('Line 1', 'Site title line');
     $I->fillField('Line 2', 'Secondary title line');
     $I->fillField('Line 3', 'Tertiary title line');
@@ -348,7 +350,7 @@ class LockupSettingsCest {
     $I->fillField('Line 5', 'Last line full width option');
 
     // Add custom logo.
-    $I->uncheckOption('#edit-su-use-theme-logo-value');
+    $I->uncheckOption('Use the logo supplied by the theme');
 
     // In case there was an image already.
     if ($I->grabMultiple('input[value="Remove"]')) {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Allow site managers the ability to turn on the main menu drop down & choose how many levels to display

# Need Review By (Date)
- :shrug: 

# Urgency
- low

# Steps to Test
1. Checkout this branch
2. import configs & clear caches
3. Create several levels of menu items. (at least 4 levels)
4. turn on the drop down menu at `/admin/config/system/basic-site-settings`
5. observe the drop down menu shows all levels
6. set the "Maximum Menu Levels" so some value at `/admin/config/system/basic-site-settings`
7. observe the drop down shows only that many levels.
