### PR TITLE
Modify directory permissions when copying the file during install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,7 @@
     ],
     "require": {
         "ext-imagick": "*",
-        "acquia/drupal-environment-detector": "^1.5",
+        "acquia/drupal-environment-detector": "^1.0",
         "citation-style-language/locales": "1.0.0",
         "citation-style-language/styles-distribution": "1.0.0",
         "ckeditor-plugin/a11ychecker": "^1.1.1",

--- a/composer.json
+++ b/composer.json
@@ -198,7 +198,7 @@
         "drupal/smart_trim": "^1.3",
         "drupal/taxonomy_entity_index": "^1.8",
         "drupal/taxonomy_menu": "^3.5",
-        "drupal/token_or": "dev-2.x",
+        "drupal/token_or": "^2.0",
         "drupal/transliterate_filenames": "^2.0",
         "drupal/ui_patterns": "^1.0",
         "drupal/view_unpublished": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -97,6 +97,7 @@
     ],
     "require": {
         "ext-imagick": "*",
+        "acquia/drupal-environment-detector": "^1.5",
         "citation-style-language/locales": "1.0.0",
         "citation-style-language/styles-distribution": "1.0.0",
         "ckeditor-plugin/a11ychecker": "^1.1.1",

--- a/src/EventSubscriber/EventSubscriber.php
+++ b/src/EventSubscriber/EventSubscriber.php
@@ -101,6 +101,7 @@ class EventSubscriber implements EventSubscriberInterface {
     $file_path = str_replace("$file_scheme://", '', $file_uri);
     $local_file = DRUPAL_ROOT . $this::FETCH_DIR . $file_path;
 
+    $this->logger->info('Using local file if available: %source', ['%source' => $local_file]);
     // @codeCoverageIgnoreStart
     if (file_exists($local_file)) {
       try {

--- a/src/EventSubscriber/EventSubscriber.php
+++ b/src/EventSubscriber/EventSubscriber.php
@@ -81,6 +81,7 @@ class EventSubscriber implements EventSubscriberInterface {
 
       if (!file_exists($file_uri)) {
         $this->getFile($file_uri);
+        $entity->save();
       }
     }
   }
@@ -98,12 +99,6 @@ class EventSubscriber implements EventSubscriberInterface {
     $file_scheme = StreamWrapperManager::getScheme($file_uri);
     $file_path = str_replace("$file_scheme://", '', $file_uri);
     $remote_url = $this::FETCH_DOMAIN . $this::FETCH_DIR . $file_path;
-
-
-    if (!AcquiaDrupalEnvironmentDetector::isAcsfEnv()) {
-      $this->downloadFile($remote_url, $file_uri);
-      return;
-    }
 
     $local_file = AcquiaDrupalEnvironmentDetector::getAhFilesRoot() . $this::FETCH_DIR . $file_path;
 

--- a/src/EventSubscriber/EventSubscriber.php
+++ b/src/EventSubscriber/EventSubscriber.php
@@ -101,7 +101,11 @@ class EventSubscriber implements EventSubscriberInterface {
     // @codeCoverageIgnoreStart
     if (file_exists($local_file)) {
       try {
-        $this->fileSystem->copy($local_file, $file_path, FileSystemInterface::EXISTS_REPLACE);
+        $this->fileSystem->copy($local_file, $file_uri, FileSystemInterface::EXISTS_REPLACE);
+        $real_path = $this->fileSystem->realpath($file_uri);
+        if (!file_exists($real_path)) {
+          throw new \Exception('File not found after copy attempt: ' . $real_path);
+        }
         return;
       }
       catch (\Exception $e) {

--- a/src/EventSubscriber/EventSubscriber.php
+++ b/src/EventSubscriber/EventSubscriber.php
@@ -81,7 +81,6 @@ class EventSubscriber implements EventSubscriberInterface {
 
       if (!file_exists($file_uri)) {
         $this->getFile($file_uri);
-        $entity->save();
       }
     }
   }
@@ -133,15 +132,18 @@ class EventSubscriber implements EventSubscriberInterface {
    * @param string $destination
    *   Local path with schema.
    *
+   * @return mixed
+   *   See system_retrieve_file().
+   *
    * @codeCoverageIgnore
    *   Ignore from unit tests.
    */
-  protected function downloadFile(string $source, string $destination): void {
+  protected function downloadFile(string $source, string $destination) {
     $this->logger->info('Downloading file %source to %destination', [
       '%source' => $source,
       '%destination' => $destination,
     ]);
-    system_retrieve_file($source, $destination, FALSE, FileSystemInterface::EXISTS_REPLACE);
+    return system_retrieve_file($source, $destination, FALSE, FileSystemInterface::EXISTS_REPLACE);
   }
 
 }

--- a/src/EventSubscriber/EventSubscriber.php
+++ b/src/EventSubscriber/EventSubscriber.php
@@ -79,6 +79,9 @@ class EventSubscriber implements EventSubscriberInterface {
       $file_uri = $entity->getFileUri();
 
       if (!file_exists($file_uri)) {
+        $this->logger->info('Fetching file from content import: %uri', [
+          '%uri' => $file_uri,
+        ]);
         $this->getFile($file_uri);
       }
     }

--- a/src/EventSubscriber/EventSubscriber.php
+++ b/src/EventSubscriber/EventSubscriber.php
@@ -91,8 +91,8 @@ class EventSubscriber implements EventSubscriberInterface {
    *   Local file path with schema.
    */
   protected function getFile($file_uri) {
-    $local_directory = substr($file_uri, 0, strrpos($file_uri, '/'));
-    $this->fileSystem->prepareDirectory($local_directory, FileSystemInterface::CREATE_DIRECTORY);
+    $local_directory = dirname($file_uri);
+    $this->fileSystem->prepareDirectory($local_directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS);
 
     $file_scheme = StreamWrapperManager::getScheme($file_uri);
     $file_path = str_replace("$file_scheme://", '', $file_uri);

--- a/src/EventSubscriber/EventSubscriber.php
+++ b/src/EventSubscriber/EventSubscriber.php
@@ -104,8 +104,14 @@ class EventSubscriber implements EventSubscriberInterface {
     // @codeCoverageIgnoreStart
     if (file_exists($local_file)) {
       try {
-        $this->fileSystem->copy($local_file, $file_uri, FileSystemInterface::EXISTS_REPLACE);
         $real_path = $this->fileSystem->realpath($file_uri);
+        $this->logger->info('Copying file from %source to %destination', [
+          '%source' => $local_file,
+          '%destination' => $real_path,
+        ]);
+
+        $this->fileSystem->copy($local_file, $real_path, FileSystemInterface::EXISTS_REPLACE);
+
         if (!file_exists($real_path)) {
           throw new \Exception('File not found after copy attempt: ' . $real_path);
         }
@@ -118,6 +124,11 @@ class EventSubscriber implements EventSubscriberInterface {
         ]);
       }
     }
+
+    $this->logger->info('Downloading %source to %destination', [
+      '%source' => $this::FETCH_DOMAIN . $this::FETCH_DIR . $file_path,
+      '%destination' => $file_uri,
+    ]);
     // @codeCoverageIgnoreEnd
     $this->downloadFile($this::FETCH_DOMAIN . $this::FETCH_DIR . $file_path, $file_uri);
   }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixed the local path for file download. The previous approach wasn't the correct path for the DRUPAL_ROOT somehow.

# Need Review By (Date)
- :man_shrugging: 

# Urgency
- medium

# Steps to Test
1. checkout this branch
2. Delete all files in `sites/default/files` directory
3. do a full site install
4. ensure the images were downloaded to your local.