### PR TITLE
D8CORE-6237: Updated migration and created update hook to rebuild migration table

### DIFF
--- a/config/sync/migrate_plus.migration.stanford_courses.yml
+++ b/config/sync/migrate_plus.migration.stanford_courses.yml
@@ -62,6 +62,10 @@ source:
   ids:
     course_id:
       type: string
+    subject:
+      type: string
+    code:
+      type: string
   constants:
     status: 1
     type: stanford_course

--- a/modules/stanford_courses/stanford_courses.install.php
+++ b/modules/stanford_courses/stanford_courses.install.php
@@ -6,12 +6,14 @@
  */
 
 /**
- * Drop the migrate_map_stanford_courses table and allow it to be recreated upon the next import.
+ * Drop the migrate_map_stanford_courses table and allow it
+ * to be recreated upon the next import.
  */
 function stanford_courses_update_9001() {
   $database = \Drupal::database();
   if ($database->schema()->tableExists('migrate_map_stanford_courses')) {
-    // We need to remove previously imported courses and allow them to be recreated.
+    // We need to remove previously imported courses and
+    // allow them to be recreated.
     $query = $database->query("SELECT `destid1` FROM {migrate_map_stanford_courses}");
     $result = $query->fetchAll();
     foreach ($result as $obsolete_node_id) {

--- a/modules/stanford_courses/stanford_courses.install.php
+++ b/modules/stanford_courses/stanford_courses.install.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * Stanford_courses.install.
+ */
+
+/**
+ * Drop the migrate_map_stanford_courses table and allow it to be recreated upon the next import.
+ */
+function stanford_courses_update_9001() {
+  $database = \Drupal::database();
+  if ($database->schema()->tableExists('migrate_map_stanford_courses')) {
+    // We need to remove previously imported courses and allow them to be recreated.
+    $query = $database->query("SELECT `destid1` FROM {migrate_map_stanford_courses}");
+    $result = $query->fetchAll();
+    foreach ($result as $obsolete_node_id) {
+      $node = \Drupal::entityTypeManager()->getStorage('node')->load($obsolete_node_id->destid1);
+      if ($node) {
+        $node->delete();
+      }
+    }
+    $database->schema()->dropTable('migrate_map_stanford_courses');
+  }
+}

--- a/modules/stanford_courses/stanford_courses.install.php
+++ b/modules/stanford_courses/stanford_courses.install.php
@@ -6,14 +6,12 @@
  */
 
 /**
- * Drop the migrate_map_stanford_courses table and allow it
- * to be recreated upon the next import.
+ * Drop migrate_map_stanford_courses table and recreate upon next import.
  */
 function stanford_courses_update_9001() {
   $database = \Drupal::database();
   if ($database->schema()->tableExists('migrate_map_stanford_courses')) {
-    // We need to remove previously imported courses and
-    // allow them to be recreated.
+    // Remove previously imported courses and let them be recreated.
     $query = $database->query("SELECT `destid1` FROM {migrate_map_stanford_courses}");
     $result = $query->fetchAll();
     foreach ($result as $obsolete_node_id) {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- we need more than one key for courses in order to handle situations where multiple courses have the same id.  Here, we update the migration to use `course_id`, `subject` and `code` as a compound identifier.  We also remove the migration table and allow it to regenerate.

# Review By (Date)
- 10/13

# Criticality
- medium

# Urgency
- normal.

# Review Tasks

## Setup tasks and/or behavior to test

ExploreCourses Feed for testing: `https://explorecourses.stanford.edu/search?q=COMM&view=xml-20200810&page=0&academicYear=&filter-term-Autumn=on&filter-term-Winter=on&filter-term-Spring=on&collapse=&filter-catalognumber-COMM=on&filter-coursestatus-Active=on&filter-departmentcode-COMM=on`

That should have a list of 86 courses in it: 
![image](https://user-images.githubusercontent.com/1263892/193905439-7a29bf2b-a724-48af-b4ed-f6b842a4869a.png)


Pre-test: load the above URL into the Courses importer and let it run.  You should find that it completes, but gives you incorrect results: 
![image](https://user-images.githubusercontent.com/1263892/193905528-50da52f1-7866-4e02-a593-ac620b29904b.png)

1. Check out this branch
2. Do a `blt drupal:update` to make sure the config is imported and the update hook runs.
3. Verify that the incorrect course import that you did above has been removed, e.g, no courses should remain in the site.
4. Run the course importer again.  Verify it correctly imports 86 courses.

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? YES

## Front End Validation
- [ ] Design is approved by @ user?
- [ ] HTML validation: Is the markup using the appropriate semantic tags and [passes validation](https://validator.w3.org/nu/)? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Cross-browser testing: Has been performed? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Automated accessibility: Scans performed? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Manual accessibility: Manually tested? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
