### PR TITLE
D8CORE-2622, D8CORE-4494 | @jdwjdwjdw | Move brand bar and skip-links into header landmark banner

### DIFF
--- a/themes/stanford_basic/templates/html.html.twig
+++ b/themes/stanford_basic/templates/html.html.twig
@@ -89,15 +89,6 @@
     {% set classes = classes|merge(['role--' ~ role|clean_class]) %}
   {% endfor %}
   <body{{ attributes.addClass(classes) }}>
-    {% block block_skiplinks %}
-      <a href="#main-content" class="visually-hidden focusable su-skipnav su-skipnav--content">
-        {{ 'Skip to main content'|t }}
-      </a>
-      <a href="#secondary-navigation" class="visually-hidden focusable su-skipnav su-skipnav--secondary">
-        {{ 'Skip to secondary navigation'|t }}
-      </a>
-    {% endblock %}
-
     {{ page_top }}
     {{ page }}
     {{ page_bottom }}

--- a/themes/stanford_basic/templates/page.html.twig
+++ b/themes/stanford_basic/templates/page.html.twig
@@ -21,10 +21,6 @@
 {%- endif -%}
 {# End Template Paths. #}
 
-{# Brand Bar #}
-{%- block block_brandbar -%}
-  {%- include template_brand_bar with { modifier_class : brand_bar_variant } -%}
-{%- endblock -%}
 
 {# Help Section #}
 {%- block block_help -%}
@@ -35,6 +31,12 @@
 {%- block block_header -%}
   {%- if page.header or page.search or page.menu -%}
     <header class="su-masthead su-masthead--right">
+
+      {# Brand Bar #}
+      {%- block block_brandbar -%}
+        {%- include template_brand_bar with { modifier_class : brand_bar_variant } -%}
+      {%- endblock -%}
+      
       <section>
         {{ page.header }}
         {{ page.search }}

--- a/themes/stanford_basic/templates/page.html.twig
+++ b/themes/stanford_basic/templates/page.html.twig
@@ -32,6 +32,15 @@
   {%- if page.header or page.search or page.menu -%}
     <header class="su-masthead su-masthead--right">
 
+      {% block block_skiplinks %}
+        <a href="#main-content" class="visually-hidden focusable su-skipnav su-skipnav--content">
+          {{ 'Skip to main content'|t }}
+        </a>
+        <a href="#secondary-navigation" class="visually-hidden focusable su-skipnav su-skipnav--secondary">
+          {{ 'Skip to secondary navigation'|t }}
+        </a>
+      {% endblock %}
+
       {# Brand Bar #}
       {%- block block_brandbar -%}
         {%- include template_brand_bar with { modifier_class : brand_bar_variant } -%}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- [D8CORE-2622](https://stanfordits.atlassian.net/browse/D8CORE-2622): A11y: Put logo (Brand bar) into a landmark
- [D8CORE-4494](https://stanfordits.atlassian.net/browse/D8CORE-4494): A11y: Include skip links in ARIA landmark
  - Moving brand bar and skip-links into the header element, so that it is included in the header banner landmark, to fix SiteImprove A11y issue `Text not included in an ARIA landmark`

# Review By (Date)
- When convenient

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Navigate to any page and check that the `Text not included in an ARIA landmark` issue (using the SiteImprove Accessibility Checker) plugin() is gone for the brand bar and skip-links
3. Confirm that there are no visual issues with the rearranging done in this PR
4. Review code.

# Associated Issues and/or People
- [D8CORE-2622](https://stanfordits.atlassian.net/browse/D8CORE-2622): A11y: Put logo (Brand bar) into a landmark
- [D8CORE-4494](https://stanfordits.atlassian.net/browse/D8CORE-4494): A11y: Include skip links in ARIA landmark

[D8CORE-2622]: https://stanfordits.atlassian.net/browse/D8CORE-2622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D8CORE-4494]: https://stanfordits.atlassian.net/browse/D8CORE-4494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D8CORE-2622]: https://stanfordits.atlassian.net/browse/D8CORE-2622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D8CORE-4494]: https://stanfordits.atlassian.net/browse/D8CORE-4494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ