### PR TITLE
D8CORE-6731 | @jdwjdwjdw | Move help section to be below brand bar in header

### DIFF
--- a/themes/stanford_basic/templates/page.html.twig
+++ b/themes/stanford_basic/templates/page.html.twig
@@ -21,12 +21,6 @@
 {%- endif -%}
 {# End Template Paths. #}
 
-
-{# Help Section #}
-{%- block block_help -%}
-  {{ page.help }}
-{%- endblock -%}
-
 {# Masthead Section. #}
 {%- block block_header -%}
   {%- if page.header or page.search or page.menu -%}
@@ -44,6 +38,11 @@
       {# Brand Bar #}
       {%- block block_brandbar -%}
         {%- include template_brand_bar with { modifier_class : brand_bar_variant } -%}
+      {%- endblock -%}
+
+      {# Help Section #}
+      {%- block block_help -%}
+        {{ page.help }}
       {%- endblock -%}
       
       <section>
@@ -74,4 +73,3 @@
   <span class="fas fa-chevron-up"></span>
   Back to Top
 </button>
-


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- [D8CORE-6731](https://stanfordits.atlassian.net/browse/D8CORE-6731): DEV | Move help section into header section

# Review By (Date)
- When convenient

# Criticality
- Normal

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Add a global message and confirm that it is displayed below the brand bar within the header

# Associated Issues and/or People
- [D8CORE-6731](https://stanfordits.atlassian.net/browse/D8CORE-6731): DEV | Move help section into header section

[D8CORE-6731]: https://stanfordits.atlassian.net/browse/D8CORE-6731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D8CORE-6731]: https://stanfordits.atlassian.net/browse/D8CORE-6731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ