### PR TITLE
D8CORE-4495 | @jdwjdwjdw | Update past events text

### DIFF
--- a/config/sync/views.view.stanford_events.yml
+++ b/config/sync/views.view.stanford_events.yml
@@ -4604,7 +4604,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: '<div class="su-event--past-events-text">*This event has passed.</div>'
+            text: '<div class="su-event--past-events-text">*This event has already occurred.</div>'
             make_link: false
             path: ''
             absolute: false


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Updating past events text to `This event has already occurred.` on past event lists per instructions in https://stanfordits.atlassian.net/browse/D8CORE-4495. See [related PR](https://github.com/SU-SWS/stanford_profile_helper/pull/264) for updating past events text on events node page.

# Review By (Date)
- When convenient

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Add an event that has already occurred
3. Add a basic page with past events list or navigate to `/events/past` and confirm that the past events text has been updated.
4. Review code 🥪 

# Associated Issues and/or People
- [D8CORE-4495](https://stanfordits.atlassian.net/browse/D8CORE-4495): A11y|Past-Events: Line height is below minimum value for the subhead under date and time
- https://github.com/SU-SWS/stanford_profile_helper/pull/264

[D8CORE-4495]: https://stanfordits.atlassian.net/browse/D8CORE-4495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ