### PR TITLE
D8CORE-6726: Overrode the colorbox formatter template to remove aria-label

### DIFF
--- a/src/EventSubscriber/EventSubscriber.php
+++ b/src/EventSubscriber/EventSubscriber.php
@@ -121,7 +121,7 @@ class EventSubscriber implements EventSubscriberInterface {
 
     if (
       $event->getRequestType() == HttpKernelInterface::MAIN_REQUEST &&
-      (Settings::get('stanford_capture_ownership', FALSE) || getenv('GITHUB_ACTIONS')) &&
+      (Settings::get('stanford_capture_ownership', FALSE)) &&
       !str_starts_with($current_uri, '/admin/config/system/basic-site-settings') &&
       self::redirectUser()
     ) {

--- a/src/EventSubscriber/EventSubscriber.php
+++ b/src/EventSubscriber/EventSubscriber.php
@@ -10,6 +10,7 @@ use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\StreamWrapper\StreamWrapperManager;
 use Drupal\Core\Url;
+use Drupal\Core\Site\Settings;
 use Drupal\core_event_dispatcher\EntityHookEvents;
 use Drupal\core_event_dispatcher\Event\Entity\EntityDeleteEvent;
 use Drupal\core_event_dispatcher\Event\Entity\EntityInsertEvent;
@@ -24,6 +25,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
+
 
 /**
  * Class EventSubscriber.
@@ -120,7 +122,7 @@ class EventSubscriber implements EventSubscriberInterface {
 
     if (
       $event->getRequestType() == HttpKernelInterface::MAIN_REQUEST &&
-      !getenv('LANDO') &&
+      Settings::get('stanford_capture_ownership', FALSE) &&
       !str_starts_with($current_uri, '/admin/config/system/basic-site-settings') &&
       self::redirectUser()
     ) {

--- a/src/EventSubscriber/EventSubscriber.php
+++ b/src/EventSubscriber/EventSubscriber.php
@@ -8,9 +8,9 @@ use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Installer\InstallerKernel;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Site\Settings;
 use Drupal\Core\StreamWrapper\StreamWrapperManager;
 use Drupal\Core\Url;
-use Drupal\Core\Site\Settings;
 use Drupal\core_event_dispatcher\EntityHookEvents;
 use Drupal\core_event_dispatcher\Event\Entity\EntityDeleteEvent;
 use Drupal\core_event_dispatcher\Event\Entity\EntityInsertEvent;
@@ -121,7 +121,7 @@ class EventSubscriber implements EventSubscriberInterface {
 
     if (
       $event->getRequestType() == HttpKernelInterface::MAIN_REQUEST &&
-      Settings::get('stanford_capture_ownership', FALSE) &&
+      (Settings::get('stanford_capture_ownership', FALSE) || getenv('GITHUB_ACTIONS')) &&
       !str_starts_with($current_uri, '/admin/config/system/basic-site-settings') &&
       self::redirectUser()
     ) {
@@ -158,7 +158,6 @@ class EventSubscriber implements EventSubscriberInterface {
 
     // Check for config page edit access and ignore if the user is an
     // administrator. That way devs don't get forced into submitting the form.
-
     $site_manager = $current_user->hasPermission('edit stanford_basic_site_settings config page entity') && !in_array('administrator', $current_user->getRoles());
 
     // If the renewal date has passed, they should be redirected.

--- a/src/EventSubscriber/EventSubscriber.php
+++ b/src/EventSubscriber/EventSubscriber.php
@@ -26,7 +26,6 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-
 /**
  * Class EventSubscriber.
  *

--- a/src/EventSubscriber/EventSubscriber.php
+++ b/src/EventSubscriber/EventSubscriber.php
@@ -120,6 +120,7 @@ class EventSubscriber implements EventSubscriberInterface {
 
     if (
       $event->getRequestType() == HttpKernelInterface::MAIN_REQUEST &&
+      !getenv('LANDO') &&
       !str_starts_with($current_uri, '/admin/config/system/basic-site-settings') &&
       self::redirectUser()
     ) {

--- a/tests/codeception/functional/Paragraphs/GalleryCest.php
+++ b/tests/codeception/functional/Paragraphs/GalleryCest.php
@@ -63,6 +63,7 @@ class GalleryCest {
     $I->canSee($node->label(), 'h1');
     $I->canSeeNumberOfElements('.stanford-gallery-images img', 2);
     $I->canSeeNumberOfElements('.colorbox', 2);
+    $I->dontSeeElement('a.colorbox',['aria-label'] );
     $I->click('a.colorbox');
     $I->waitForElementVisible('#cboxLoadedContent');
     $I->canSeeNumberOfElements('#cboxContent img', 1);

--- a/tests/codeception/functional/Paragraphs/GalleryCest.php
+++ b/tests/codeception/functional/Paragraphs/GalleryCest.php
@@ -63,7 +63,7 @@ class GalleryCest {
     $I->canSee($node->label(), 'h1');
     $I->canSeeNumberOfElements('.stanford-gallery-images img', 2);
     $I->canSeeNumberOfElements('.colorbox', 2);
-    $I->dontSeeElement('a.colorbox',['aria-label'] );
+    $I->dontSeeElement('a.colorbox[aria-label]');
     $I->click('a.colorbox');
     $I->waitForElementVisible('#cboxLoadedContent');
     $I->canSeeNumberOfElements('#cboxContent img', 1);

--- a/tests/src/Kernel/EventSubscriber/EventSubscriberTest.php
+++ b/tests/src/Kernel/EventSubscriber/EventSubscriberTest.php
@@ -6,6 +6,7 @@ use Drupal\config_pages\ConfigPagesLoaderServiceInterface;
 use Drupal\consumers\Entity\Consumer;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\core_event_dispatcher\Event\Entity\EntityInsertEvent;
+use Drupal\Core\Site\Settings;
 use Drupal\default_content\Event\ImportEvent;
 use Drupal\file\Entity\File;
 use Drupal\KernelTests\KernelTestBase;
@@ -139,8 +140,12 @@ class EventSubscriberTest extends KernelTestBase {
     $ci = getenv('CI');
     putenv('CI');
 
-    $config_page_loader = $this->createMock(ConfigPagesLoaderServiceInterface::class);
+    $site_settings = [
+      'stanford_capture_ownership' => TRUE,
+    ];
+    new Settings($site_settings);
 
+    $config_page_loader = $this->createMock(ConfigPagesLoaderServiceInterface::class);
     \Drupal::getContainer()->set('config_pages.loader', $config_page_loader);
 
     $account = $this->createMock(AccountProxyInterface::class);

--- a/themes/stanford_basic/templates/contrib/colorbox-formatter.html.twig
+++ b/themes/stanford_basic/templates/contrib/colorbox-formatter.html.twig
@@ -1,0 +1,17 @@
+{#
+/**
+ * @file
+ * Stanford Basic theme implementation to display a formatted colorbox image field.
+ *
+ * Available variables:
+ * - image: A collection of image data.
+ * - url: An URL the image can be linked to.
+ * - attributes: Link attributes.
+ *
+ * @see template_preprocess_colorbox_formatter()
+ *
+ * @ingroup themeable
+ */
+#}
+
+<a href="{{ url }}" aria-controls="colorbox" role="button" {{ attributes }}>{{ image }}</a>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Per D8CORE-6726, we want to remove the `aria-label` from the `<a>` tag for colorbox gallery images.

# Review By (Date)
- next code freeze

# Criticality
- not critical

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Build a gallery with some images
4. Verify the images are using the overridden template, and there is no `aria-label` on the `<a>` link.

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? NO

## Front End Validation
- [ ] Design is approved by @ user?
- [ ] HTML validation: Is the markup using the appropriate semantic tags and [passes validation](https://validator.w3.org/nu/)? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Cross-browser testing: Has been performed? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Automated accessibility: Scans performed? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Manual accessibility: Manually tested? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
