### PR TITLE
Refactor how GA shared ID is added to the pages

### DIFF
--- a/themes/stanford_basic/stanford_basic.theme
+++ b/themes/stanford_basic/stanford_basic.theme
@@ -117,6 +117,58 @@ function stanford_basic_page_attachments_alter(array &$attachments) {
   }
   // Check if dropdown menus are activated
   $attachments['#attached']['drupalSettings']['stanford_basic']['nav_dropdown_enabled'] = (bool) theme_get_setting('nav_dropdown_enabled', 'stanford_basic');
+
+  // Only add Google Analytics for anonymous users or users without editing
+  // access while on Acquia environment. Being able to view the toolbar is a
+  // good indicator that they can edit some part of the site.
+  if (
+    isset($_ENV['AH_SITE_ENVIRONMENT']) &&
+    !\Drupal::currentUser()->hasPermission('access toolbar')
+  ) {
+    _stanford_basic_add_ga_tracking($attachments);
+  }
+}
+
+/**
+ * Add the necessary GA tracking for shared analytics.
+ *
+ * @param array $attachments
+ *   Page attachments from hook_page_attachments_alter().
+ */
+function _stanford_basic_add_ga_tracking(array &$attachments) {
+  $add_ga_file = FALSE;
+  // Look to see if there's already a Google Analytics tracking file included.
+  if (isset($attachments['#attached']['html_head'])) {
+    foreach ($attachments['#attached']['html_head'] as $html_head) {
+      if ($html_head[1] == 'google_analytics_tracking_file') {
+        $add_ga_file = TRUE;
+        break;
+      }
+    }
+  }
+
+  // No GA tracking file provided by GA module, we'll add our own.
+  if (!$add_ga_file) {
+    $attachments['#attached']['html_head'][] = [
+      [
+        '#tag' => 'script',
+        '#attributes' => [
+          'async' => TRUE,
+          'src' => '//www.googletagmanager.com/gtag/js?id=G-BECJQXLNCY',
+        ],
+      ],
+      'stanford_basic_analytics_tracking_file',
+    ];
+  }
+
+  // Add the shared GA tracking tag.
+  $attachments['#attached']['html_head'][] = [
+    [
+      '#tag' => 'script',
+      '#value' => 'gtag("config", "G-BECJQXLNCY");',
+    ],
+    'stanford_basic_analytics_tracking',
+  ];
 }
 
 /**
@@ -159,15 +211,6 @@ function stanford_basic_preprocess_html(&$variables) {
 
   // The base path.
   $variables['base_path'] = base_path();
-
-  // Add global google analytics tracker if the site is on Acquia.
-  if (isset($_ENV['AH_SITE_ENVIRONMENT'])) {
-    $variables['add_global_ga'] = TRUE;
-    if (\Drupal::moduleHandler()->moduleExists('google_analytics')) {
-      $variables['ga_module_enabled'] = !empty(\Drupal::config('google_analytics.settings')
-        ->get('account'));
-    }
-  }
 }
 
 /**

--- a/themes/stanford_basic/templates/html.html.twig
+++ b/themes/stanford_basic/templates/html.html.twig
@@ -61,24 +61,6 @@
     <title>{{ head_title|safe_join(' | ') }}</title>
     <css-placeholder token="{{ placeholder_token }}">
     <js-placeholder token="{{ placeholder_token }}">
-
-      {% if add_global_ga %}
-        {% if not ga_module_enabled %}
-        <!-- Global analytics tag (gtag.js) - Google Analytics -->
-        <script async src="//www.googletagmanager.com/gtag/js?id=G-BECJQXLNCY"></script>
-        <script>
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-
-          gtag('config', 'G-BECJQXLNCY');
-        </script>
-        {% else %}
-        <script>
-          gtag('config', 'G-BECJQXLNCY');
-        </script>
-        {% endif %}
-      {% endif %}
   </head>
   {% set classes = [is_front ? 'front', not is_front ? 'not-front'] %}
   {% for role in user.roles %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Refactor how the shared GA is added to the sites.

## Setup tasks and/or behavior to test

1. Check out this branch
2. comment out `$config['google_analytics.settings']['account'] = '';` in the `google_analytics.settings.php` file
3. clear your caches
4. view the site as anonymous in chrome
5. verify no console errors from GA.
6. verify the shared tracking code is loading.
7. Add a GA via site settings `/admin/config/system/basic-site-settings`
8. view the site as anonymous in chrome
9. verify no console errors from GA.
10. verify the shared tracking code and the one you entered is loaded on the page.

