### PR TITLE
D8CORE-7622: Reviewer role

### DIFF
--- a/config/sync/user.role.site_reviewer.yml
+++ b/config/sync/user.role.site_reviewer.yml
@@ -5,7 +5,7 @@ dependencies:
   module:
     - toolbar
     - view_unpublished
-id: su_site_reviewer
+id: site_reviewer
 label: 'Site Reviewer'
 weight: 3
 is_admin: null

--- a/config/sync/user.role.site_reviewer.yml
+++ b/config/sync/user.role.site_reviewer.yml
@@ -1,4 +1,4 @@
-uuid: 48173aba-4532-4e16-ba93-6911f1b949ef
+uuid: 06847d41-1e2c-4dd7-b1f8-c4d4f382f643
 langcode: en
 status: true
 dependencies:

--- a/config/sync/user.role.su_site_reviewer.yml
+++ b/config/sync/user.role.su_site_reviewer.yml
@@ -1,4 +1,4 @@
-uuid: 53eb3228-4f2a-48f1-b1b0-dd3768976ea2
+uuid: 48173aba-4532-4e16-ba93-6911f1b949ef
 langcode: en
 status: true
 dependencies:

--- a/config/sync/user.role.su_site_reviewer.yml
+++ b/config/sync/user.role.su_site_reviewer.yml
@@ -1,4 +1,4 @@
-uuid: 48173aba-4532-4e16-ba93-6911f1b949ef
+uuid: 53eb3228-4f2a-48f1-b1b0-dd3768976ea2
 langcode: en
 status: true
 dependencies:

--- a/config/sync/user.role.su_site_reviewer.yml
+++ b/config/sync/user.role.su_site_reviewer.yml
@@ -1,0 +1,14 @@
+uuid: 48173aba-4532-4e16-ba93-6911f1b949ef
+langcode: en
+status: true
+dependencies:
+  module:
+    - toolbar
+    - view_unpublished
+id: su_site_reviewer
+label: 'Site Reviewer'
+weight: 3
+is_admin: null
+permissions:
+  - 'access toolbar'
+  - 'view any unpublished content'

--- a/config/sync/views.view.search.yml
+++ b/config/sync/views.view.search.yml
@@ -347,6 +347,7 @@ display:
               layout_builder_user: '0'
               su_site_embedder: '0'
               decoupled_site_users: '0'
+              su_site_reviewer: '0'
             expose_fields: false
             placeholder: 'Search This Site'
             searched_fields_id: search_api_fulltext_searched_fields

--- a/config/sync/views.view.search.yml
+++ b/config/sync/views.view.search.yml
@@ -347,7 +347,7 @@ display:
               layout_builder_user: '0'
               su_site_embedder: '0'
               decoupled_site_users: '0'
-              su_site_reviewer: '0'
+              site_reviewer: '0'
             expose_fields: false
             placeholder: 'Search This Site'
             searched_fields_id: search_api_fulltext_searched_fields

--- a/tests/codeception/acceptance/Users/RolesCest.php
+++ b/tests/codeception/acceptance/Users/RolesCest.php
@@ -20,6 +20,7 @@ class RolesCest {
     $I->canSee('Site Developer');
     $I->canSee('Administrator');
     $I->canSee('Site Embedder');
+    $I->canSee('Site Reviewer');
   }
 
   /**
@@ -53,6 +54,17 @@ class RolesCest {
     // the admin toolbar.
     $I->amOnPage('/');
     $I->cantSeeElement('#toolbar-administration');
+  }
+
+  /**
+   * Site Reviewer role should be limited to viewing unpublished page.
+   */
+  public function testReviewerRole(AcceptanceTester $I) {
+    $I->logInWithRole('su_site_reviewer');
+    // D8CORE-7622
+    $I->amOnPage('/');
+    $I->canSeeElement('#toolbar-administration');
+    // would be nice to have a test of if they CAN see unpublished pages
   }
 
   /**


### PR DESCRIPTION
# NOT READY FOR REVIEW

# Summary
- Adding a reviewer role that allows reviewers to see unpublished pages without seeing the editing interface.

# Review By (Date)
- Jan 30.

# Criticality
- Medium

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Make an unpublished page
3. Change role to Reviewer
4. Visit the unpublished page
5. Hopefully see it
6. Note that you can log out an that there is an indication that the page is unpublished

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? YES

## Front End Validation
No front-end impact

## Backend / Functional Validation
### Code
- [ YES] Are the naming conventions following our standards?
- [YES ] Does the code have sufficient inline comments?
- [NO ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ NO] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [NOT YET ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ N/A] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [NO ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [NO ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ YES] Is the approach to the problem appropriate?

# Affected Projects or Products
- Stanford Sites

# Associated Issues and/or People
- D8CORE-7622
