### PR TITLE
D8CORE-7622: Site Reviewer Role

### DIFF
--- a/config/sync/samlauth.authentication.yml
+++ b/config/sync/samlauth.authentication.yml
@@ -14,6 +14,7 @@ drupal_login_roles:
   stanford_faculty: '0'
   stanford_staff: '0'
   stanford_student: '0'
+  site_reviewer: '0'
   contributor: '0'
   site_manager: '0'
   site_editor: '0'
@@ -42,9 +43,10 @@ map_users_roles:
   administrator: administrator
   anonymous: anonymous
   contributor: contributor
-  opportunity_editor: opportunity_editor
+  site_reviewer: site_reviewer
   decoupled_site_users: decoupled_site_users
   layout_builder_user: layout_builder_user
+  opportunity_editor: opportunity_editor
   site_builder: site_builder
   site_developer: site_developer
   site_editor: site_editor

--- a/config/sync/system.action.user_add_role_action.site_reviewer.yml
+++ b/config/sync/system.action.user_add_role_action.site_reviewer.yml
@@ -1,0 +1,14 @@
+uuid: 3ef6e2d2-e2d5-49be-bc46-13b3b87b36d6
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.site_reviewer
+  module:
+    - user
+id: user_add_role_action.site_reviewer
+label: 'Add the Site Reviewer role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: site_reviewer

--- a/config/sync/system.action.user_remove_role_action.site_reviewer.yml
+++ b/config/sync/system.action.user_remove_role_action.site_reviewer.yml
@@ -1,0 +1,14 @@
+uuid: f44e56f0-fc8b-4742-96b6-bb76951f1165
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.site_reviewer
+  module:
+    - user
+id: user_remove_role_action.site_reviewer
+label: 'Remove the Site Reviewer role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: site_reviewer

--- a/config/sync/user.role.site_reviewer.yml
+++ b/config/sync/user.role.site_reviewer.yml
@@ -7,5 +7,4 @@ label: 'Site Reviewer'
 weight: 4
 is_admin: null
 permissions:
-  - 'access toolbar'
   - 'view any unpublished content'

--- a/config/sync/user.role.site_reviewer.yml
+++ b/config/sync/user.role.site_reviewer.yml
@@ -6,4 +6,6 @@ id: site_reviewer
 label: 'Site Reviewer'
 weight: 4
 is_admin: null
-permissions: {  }
+permissions:
+  - 'access toolbar'
+  - 'view any unpublished content'

--- a/config/sync/user.role.site_reviewer.yml
+++ b/config/sync/user.role.site_reviewer.yml
@@ -1,0 +1,9 @@
+uuid: 789e9ccb-b42b-44e2-9dc4-dea61e0c4ac4
+langcode: en
+status: true
+dependencies: {  }
+id: site_reviewer
+label: 'Site Reviewer'
+weight: 4
+is_admin: null
+permissions: {  }

--- a/tests/codeception/acceptance/Users/RolesCest.php
+++ b/tests/codeception/acceptance/Users/RolesCest.php
@@ -20,6 +20,7 @@ class RolesCest {
     $I->canSee('Site Developer');
     $I->canSee('Administrator');
     $I->canSee('Site Embedder');
+    $I->canSee('Site Reviewer');
   }
 
   /**
@@ -53,6 +54,17 @@ class RolesCest {
     // the admin toolbar.
     $I->amOnPage('/');
     $I->cantSeeElement('#toolbar-administration');
+  }
+
+  /**
+   * Site Reviewer role should be limited to viewing unpublished page.
+   */
+  public function testReviewerRole(AcceptanceTester $I) {
+    $I->logInWithRole('su_site_reviewer');
+    // D8CORE-7622
+    $I->amOnPage('/');
+    $I->canSeeElement('#toolbar-administration');
+    // would be nice to have a test of if they CAN see unpublished pages
   }
 
   /**

--- a/tests/codeception/acceptance/Users/RolesCest.php
+++ b/tests/codeception/acceptance/Users/RolesCest.php
@@ -60,11 +60,9 @@ class RolesCest {
    * Site Reviewer role should be limited to viewing unpublished page.
    */
   public function testReviewerRole(AcceptanceTester $I) {
-    $I->logInWithRole('su_site_reviewer');
+    $I->logInWithRole('site_reviewer');
     // D8CORE-7622
-    $I->amOnPage('/');
-    $I->canSeeElement('#toolbar-administration');
-    // would be nice to have a test of if they CAN see unpublished pages
+    // would be nice to have a test if they CAN see unpublished pages
   }
 
   /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adding a reviewer role that allows reviewers to see unpublished pages without seeing the editing interface.

# Review By (Date)
- Jan 30.

# Criticality
- Medium

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Make an unpublished page
3. Change role to Reviewer
4. Visit the unpublished page
5. Hopefully see it
6. Note that you can log out an that there is an indication that the page is unpublished

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? YES

## Front End Validation
No front-end impact

## Backend / Functional Validation
### Code
- [ YES] Are the naming conventions following our standards?
- [YES ] Does the code have sufficient inline comments?
- [NO ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ NO] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [Sort of? ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ N/A] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [NO ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [NO ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ YES] Is the approach to the problem appropriate?

# Affected Projects or Products
- Stanford Sites

# Associated Issues and/or People
- D8CORE-7622
