### PR TITLE
D8CORE-7753: removing aria:expanded

### DIFF
--- a/themes/stanford_basic/dist/js/behaviors.js
+++ b/themes/stanford_basic/dist/js/behaviors.js
@@ -146,7 +146,7 @@ window.Drupal.behaviors.stanford_basic = {
         $('summary', $details).each(function (sumIndex, summary) {
           var $summary = $(summary);
           var groupId = $summary.text().toLowerCase().replace(/[^\w]/g, '-').replace(/^-+/, '').replace(/-+$/, '').substring(0, 25);
-          $summary.attr('aria-expanded', 'false').attr('aria-controls', "".concat(groupId, "-panel")).attr('id', "".concat(groupId, "-button"));
+          $summary.attr('aria-controls', "".concat(groupId, "-panel")).attr('id', "".concat(groupId, "-button"));
           $summary.next().attr('id', "".concat(groupId, "-panel")).attr('aria-labelledby', "".concat(groupId, "-button"));
         });
         if ($details.length < 2 || $('.ptype-stanford-faq', faq).length) {
@@ -159,7 +159,7 @@ window.Drupal.behaviors.stanford_basic = {
           $('span', $button).text(expanded ? 'Collapse' : 'Expand');
           $details.each(function (i, detail) {
             $(detail).attr('open', expanded);
-            $('summary', detail).attr('aria-expanded', expanded).attr('aria-pressed', expanded);
+            $('summary', detail).attr('aria-pressed', expanded);
           });
         });
         var $headline = $('.su-faq-headline', faq);

--- a/themes/stanford_basic/dist/js/behaviors.js
+++ b/themes/stanford_basic/dist/js/behaviors.js
@@ -147,7 +147,7 @@ window.Drupal.behaviors.stanford_basic = {
           var $summary = $(summary);
           var groupId = $summary.text().toLowerCase().replace(/[^\w]/g, '-').replace(/^-+/, '').replace(/-+$/, '').substring(0, 25);
           $summary.attr('aria-controls', "".concat(groupId, "-panel")).attr('id', "".concat(groupId, "-button"));
-          $summary.next().attr('id', "".concat(groupId, "-panel")).attr('aria-labelledby', "".concat(groupId, "-button"));
+          $summary.next().attr('aria-pressed', expanded).attr('id', "".concat(groupId, "-panel")).attr('aria-labelledby', "".concat(groupId, "-button"));
         });
         if ($details.length < 2 || $('.ptype-stanford-faq', faq).length) {
           return;

--- a/themes/stanford_basic/src/js/stanford_basic.behavior.js
+++ b/themes/stanford_basic/src/js/stanford_basic.behavior.js
@@ -120,7 +120,7 @@ export default {
             .replace(/-+$/, '')
             .substring(0, 25);
 
-          $summary.attr('aria-expanded', 'false')
+          $summary
             .attr('aria-controls', `${groupId}-panel`)
             .attr('id', `${groupId}-button`);
           $summary.next().attr('id', `${groupId}-panel`)
@@ -144,7 +144,7 @@ export default {
           $('span', $button).text(expanded ? 'Collapse' : 'Expand');
           $details.each((i, detail) => {
             $(detail).attr('open', expanded);
-            $('summary', detail).attr('aria-expanded', expanded)
+            $('summary', detail)
               .attr('aria-pressed', expanded);
           });
         });

--- a/themes/stanford_basic/src/js/stanford_basic.behavior.js
+++ b/themes/stanford_basic/src/js/stanford_basic.behavior.js
@@ -123,6 +123,7 @@ export default {
           $summary
             .attr('aria-controls', `${groupId}-panel`)
             .attr('id', `${groupId}-button`);
+
           $summary.next().attr('id', `${groupId}-panel`)
             .attr('aria-labelledby', `${groupId}-button`);
         });
@@ -137,6 +138,7 @@ export default {
           '<span class="visually-hidden"> Items below.</span>' +
           '</button>',
         );
+
         $button.click(function () {
           $button.toggleClass('expand-all').toggleClass('collapse-all');
           const expanded = !$button.hasClass('expand-all');


### PR DESCRIPTION
# NOT READY FOR REVIEW
Here is what I'm having trouble with:
- Need assistance to remove the `aria-expanded` from the individual accordions.  It appears on click to the now shown `<summary>` 
- The button for expand all does not get the `aria-expanded` on click.

# Summary
- TL;DR - what's this PR for?

# Review By (Date)
- When does this need to be reviewed by?

# Criticality
- How critical is this PR on a 1-10 scale? Also see [Severity Assessment](https://stanfordits.atlassian.net/browse/D8CORE-1705).
- E.g., it affects one site, or every site and product?

# Urgency
- How urgent is this? (Normal, High)

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Navigate to...
4. Verify...

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory?

## Front End Validation
- [ ] Design is approved by @ user?
- [ ] HTML validation: Is the markup using the appropriate semantic tags and [passes validation](https://validator.w3.org/nu/)? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Cross-browser testing: Has been performed? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Automated accessibility: Scans performed? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Manual accessibility: Manually tested? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
[- D8CORE-7753](https://stanfordits.atlassian.net/browse/D8CORE-7753)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
