### PR TITLE
D8CORE-7723: Allow unpublishing of taxonomy terms

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.basic_page_types.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.basic_page_types.default.yml
@@ -4,6 +4,9 @@ status: true
 dependencies:
   config:
     - taxonomy.vocabulary.basic_page_types
+  module:
+    - change_labels
+    - field_formatter_class
 id: taxonomy_term.basic_page_types.default
 targetEntityType: taxonomy_term
 bundle: basic_page_types
@@ -17,9 +20,19 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 1
+    region: content
+    settings:
+      display_label: true
+    third_party_settings:
+      field_formatter_class:
+        class: ''
+      change_labels:
+        field_label_overwrite: ''
 hidden:
   description: true
   path: true
   publish_on: true
-  status: true
   unpublish_on: true

--- a/config/sync/core.entity_form_display.taxonomy_term.basic_page_types.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.basic_page_types.default.yml
@@ -4,9 +4,6 @@ status: true
 dependencies:
   config:
     - taxonomy.vocabulary.basic_page_types
-  module:
-    - change_labels
-    - field_formatter_class
 id: taxonomy_term.basic_page_types.default
 targetEntityType: taxonomy_term
 bundle: basic_page_types
@@ -26,11 +23,7 @@ content:
     region: content
     settings:
       display_label: true
-    third_party_settings:
-      field_formatter_class:
-        class: ''
-      change_labels:
-        field_label_overwrite: ''
+    third_party_settings: {  }
 hidden:
   description: true
   path: true

--- a/config/sync/core.entity_form_display.taxonomy_term.stanford_event_types.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.stanford_event_types.default.yml
@@ -28,9 +28,15 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
 hidden:
   layout_builder__layout: true
   path: true
   publish_on: true
-  status: true
   unpublish_on: true

--- a/config/sync/core.entity_form_display.taxonomy_term.stanford_news_topics.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.stanford_news_topics.default.yml
@@ -28,9 +28,15 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
 hidden:
   layout_builder__layout: true
   path: true
   publish_on: true
-  status: true
   unpublish_on: true

--- a/config/sync/core.entity_form_display.taxonomy_term.stanford_person_types.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.stanford_person_types.default.yml
@@ -28,9 +28,15 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
 hidden:
   layout_builder__layout: true
   path: true
   publish_on: true
-  status: true
   unpublish_on: true

--- a/config/sync/core.entity_form_display.taxonomy_term.stanford_publication_topics.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.stanford_publication_topics.default.yml
@@ -28,9 +28,15 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
 hidden:
   layout_builder__layout: true
   path: true
   publish_on: true
-  status: true
   unpublish_on: true


### PR DESCRIPTION
# READY FOR REVIEW


# Summary
- Allow site editors to better control what taxonomy terms are displayed on the node, cards, and in the filter
- Basic Page Type, Event Type, News Type,  People Type, and Publication Type (Basic Page was included here only to provide parity, and so we don't forget this feature if we do create a filtered view.) Opportunity Type already had this functionality.

# Review By (Date)


# Criticality
Normal

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Go to a taxonomy like News
3. Unpublish a term
4. See it disappear from the filter on the News page
5. Try to use it to filter a list (it should still work!)


### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? YES

## Front End Validation
No front-end impact

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
