### PR TITLE
D8CORE-8090: Sponsor and Learn More link editable

### DIFF
--- a/config/sync/core.entity_form_display.node.stanford_opportunity.default.yml
+++ b/config/sync/core.entity_form_display.node.stanford_opportunity.default.yml
@@ -31,6 +31,7 @@ dependencies:
     - node.type.stanford_opportunity
   module:
     - change_labels
+    - cshs
     - datetime
     - field_formatter_class
     - field_group
@@ -358,10 +359,17 @@ content:
       change_labels:
         field_label_overwrite: ''
   su_opp_sponsor:
-    type: options_select
+    type: cshs
     weight: 0
     region: content
-    settings: {  }
+    settings:
+      save_lineage: false
+      force_deepest: false
+      parent: ''
+      level_labels: ''
+      hierarchy_depth: 0
+      required_depth: 0
+      none_label: '- Please select -'
     third_party_settings: {  }
   su_opp_summary:
     type: text_textarea
@@ -391,16 +399,30 @@ content:
         hide_add_another: 0
         force_single_cardinality: 0
   su_opp_type:
-    type: options_select
+    type: cshs
     weight: 9
     region: content
-    settings: {  }
+    settings:
+      save_lineage: false
+      force_deepest: false
+      parent: ''
+      level_labels: ''
+      hierarchy_depth: 0
+      required_depth: 0
+      none_label: '- Please select -'
     third_party_settings: {  }
   su_opp_units:
-    type: options_select
+    type: cshs
     weight: 12
     region: content
-    settings: {  }
+    settings:
+      save_lineage: false
+      force_deepest: false
+      parent: ''
+      level_labels: ''
+      hierarchy_depth: 0
+      required_depth: 0
+      none_label: '- Please select -'
     third_party_settings: {  }
   title:
     type: string_textfield

--- a/config/sync/core.entity_form_display.node.stanford_opportunity.default.yml
+++ b/config/sync/core.entity_form_display.node.stanford_opportunity.default.yml
@@ -67,11 +67,11 @@ third_party_settings:
     group_taxonomy:
       children:
         - su_opp_type
+        - group_academic_info
         - su_opp_application_deadline
         - su_opp_tags
         - group_contact_information
         - su_opp_cta_url
-        - group_academic_info
       label: Sidebar
       region: content
       parent_name: ''
@@ -107,10 +107,12 @@ third_party_settings:
         required_fields: true
     group_page_content:
       children:
+        - su_opp_sponsor
         - su_opp_eligibility
         - su_opp_prerequisites
         - body
         - su_opp_components
+        - su_opp_learn_more
       label: 'Page Content'
       region: content
       parent_name: ''
@@ -129,7 +131,7 @@ third_party_settings:
         - su_opp_course_code
         - su_opp_units
       label: 'Academic Info'
-      region: hidden
+      region: content
       parent_name: group_taxonomy
       weight: 10
       format_type: details
@@ -148,7 +150,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 18
+    weight: 3
     region: content
     settings:
       rows: 4
@@ -201,7 +203,7 @@ content:
     third_party_settings: {  }
   su_opp_components:
     type: layout_paragraphs
-    weight: 20
+    weight: 4
     region: content
     settings:
       view_mode: default
@@ -271,7 +273,7 @@ content:
     third_party_settings: {  }
   su_opp_eligibility:
     type: text_textarea
-    weight: 16
+    weight: 1
     region: content
     settings:
       rows: 1
@@ -315,9 +317,17 @@ content:
     settings:
       media_types: {  }
     third_party_settings: {  }
+  su_opp_learn_more:
+    type: link_default
+    weight: 5
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
   su_opp_prerequisites:
     type: text_textarea
-    weight: 17
+    weight: 2
     region: content
     settings:
       rows: 1
@@ -347,6 +357,12 @@ content:
         maxlength_js_enforce: false
       change_labels:
         field_label_overwrite: ''
+  su_opp_sponsor:
+    type: options_select
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   su_opp_summary:
     type: text_textarea
     weight: 4
@@ -401,9 +417,7 @@ hidden:
   publish_on: true
   scheduler_settings: true
   sticky: true
-  su_opp_learn_more: true
   su_opp_open_date: true
-  su_opp_sponsor: true
   su_opp_start_date: true
   su_opp_status: true
   uid: true

--- a/config/sync/field.field.node.stanford_opportunity.su_opp_sponsor.yml
+++ b/config/sync/field.field.node.stanford_opportunity.su_opp_sponsor.yml
@@ -11,7 +11,7 @@ field_name: su_opp_sponsor
 entity_type: node
 bundle: stanford_opportunity
 label: Sponsor
-description: 'Who sponsors this opportunity.'
+description: 'What organization sponsors this opportunity? To create a list of options, go to the Sponsor taxonomy.'
 required: false
 translatable: false
 default_value: {  }


### PR DESCRIPTION
# NOT READY FOR REVIEW


# Summary
- Adding Sponsor and Learn More link to edit form to support Cardinal Service Migration (D8CORE-8090)
- Updating widgets for Sponsor, Opportunity Type to support easier use (D8CORE-8034)

# Review By (Date)
- No rush!

# Criticality
- 5

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Add a few terms to the Sponsor taxonomy
4. Navigate to add an Opportunity
5. Verify you can enter content in the Sponsor and Learn More field on the edit form
6. Verify that the widget has changed for selecting Opportunity Type
7. Verify that they do not yet display

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? YES

## Front End Validation
No front-end impact

## Backend / Functional Validation
### Code
N/A

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
