### PR TITLE
D8CORE-8244: Fixes for Sidebar

### DIFF
--- a/config/sync/views.view.stanford_opportunities.yml
+++ b/config/sync/views.view.stanford_opportunities.yml
@@ -1552,51 +1552,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        su_opp_type_target_id:
-          id: su_opp_type_target_id
-          table: node__su_opp_type
-          field: su_opp_type_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: taxonomy_index_tid
-          operator: 'not empty'
-          value: {  }
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          vid: opportunity_type
-          type: textfield
-          hierarchy: false
-          limit: true
-          error_message: true
         su_opp_units_target_id:
           id: su_opp_units_target_id
           table: node__su_opp_units
@@ -1642,9 +1597,55 @@ display:
           hierarchy: false
           limit: true
           error_message: true
+        su_opp_type_target_id:
+          id: su_opp_type_target_id
+          table: node__su_opp_type
+          field: su_opp_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: 'not empty'
+          value: {  }
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: opportunity_type
+          type: textfield
+          hierarchy: false
+          limit: true
+          error_message: true
       filter_groups:
         operator: AND
-        groups: {  }
+        groups:
+          1: OR
       style:
         type: default
         options:

--- a/config/sync/views.view.stanford_opportunities.yml
+++ b/config/sync/views.view.stanford_opportunities.yml
@@ -1552,51 +1552,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        su_opp_units_target_id:
-          id: su_opp_units_target_id
-          table: node__su_opp_units
-          field: su_opp_units_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: taxonomy_index_tid
-          operator: 'not empty'
-          value: {  }
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          vid: opportunity_units
-          type: textfield
-          hierarchy: false
-          limit: true
-          error_message: true
         su_opp_type_target_id:
           id: su_opp_type_target_id
           table: node__su_opp_type
@@ -1642,10 +1597,54 @@ display:
           hierarchy: false
           limit: true
           error_message: true
+        su_opp_units_target_id:
+          id: su_opp_units_target_id
+          table: node__su_opp_units
+          field: su_opp_units_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: 'not empty'
+          value: {  }
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: opportunity_units
+          type: textfield
+          hierarchy: false
+          limit: true
+          error_message: true
       filter_groups:
-        operator: AND
-        groups:
-          1: OR
+        operator: OR
+        groups: {  }
       style:
         type: default
         options:


### PR DESCRIPTION
# NOT READY FOR REVIEW


# Summary
- Fixes the case where the Academic Info doesn't appear in the sidebar when one item is blank

# Review By (Date)
- As soon as possible

# Criticality
- High

# Urgency
- Hight

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Make some opportunities that have some academic info and/or opportunity type, but not all
4. Verify that you can see the info in the sidebar with incomplete info
5. Verify that with no info, you don't see a double line

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? YES

## Front End Validation


## Backend / Functional Validation
### Code

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
