### PR TITLE
D8CORE-8196 | update card structure to match banner and fulfill a11y

### DIFF
--- a/config/sync/core.entity_view_display.paragraph.stanford_card.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.stanford_card.default.yml
@@ -11,6 +11,10 @@ dependencies:
     - paragraphs.paragraphs_type.stanford_card
   module:
     - ds
+    - element_class_formatter
+    - empty_fields
+    - field_formatter_class
+    - field_label
     - link
     - stanford_media
     - text
@@ -28,11 +32,10 @@ third_party_settings:
     regions:
       card_image:
         - su_card_media
-      card_super_headline:
-        - su_card_super_header
       card_headline:
         - su_card_header
       card_body:
+        - su_card_super_header
         - su_card_body
       card_link:
         - su_card_link
@@ -62,7 +65,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 2
+    weight: 1
     region: card_headline
   su_card_link:
     type: link
@@ -83,16 +86,29 @@ content:
       view_mode: default
       link: false
       image_style: card_2_1
+      remove_alt: false
     third_party_settings: {  }
     weight: 0
     region: card_image
   su_card_super_header:
-    type: string
+    type: wrapper_class
     label: hidden
     settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    weight: 1
-    region: card_super_headline
+      class: su-card__superhead
+      tag: div
+      link: false
+      link_class: ''
+      summary: false
+      trim: 200
+    third_party_settings:
+      empty_fields:
+        handler: ''
+      field_formatter_class:
+        class: ''
+      field_label:
+        label_value: ''
+        label_tag: ''
+    weight: 2
+    region: card_body
 hidden:
   search_api_excerpt: true


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- D8CORE-8196 | update card structure to match banner and fulfill a11y
- As mentioned in https://github.com/SU-SWS/stanford_profile_helper/pull/434 👍 

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Review code 

# Associated Issues and/or People
- D8CORE-8196 | update card structure to match banner and fulfill a11y
- https://github.com/SU-SWS/stanford_profile_helper/pull/434