### PR TITLE
D8CORE-8414 | Add body field to spotlight view

### DIFF
--- a/config/sync/layout_library.layout.news_spotlight.yml
+++ b/config/sync/layout_library.layout.news_spotlight.yml
@@ -167,7 +167,9 @@ layout:
               link: false
             third_party_settings:
               empty_fields:
-                handler: ''
+                handler: text
+                settings:
+                  empty_text: Spotlight
               field_formatter_class:
                 class: ''
               field_label:
@@ -185,32 +187,6 @@ layout:
       centered: centered-container
       columns: flex-12-of-12
     components:
-      074a19fc-39ac-40f6-95a7-b625dcc9e1b2:
-        uuid: 074a19fc-39ac-40f6-95a7-b625dcc9e1b2
-        region: main
-        configuration:
-          id: 'field_block:node:stanford_news:su_news_components'
-          label: Components
-          label_display: '0'
-          provider: layout_builder
-          context_mapping:
-            entity: layout_builder.entity
-            view_mode: view_mode
-          formatter:
-            type: layout_paragraphs
-            label: hidden
-            settings:
-              view_mode: default
-            third_party_settings:
-              empty_fields:
-                handler: ''
-              field_formatter_class:
-                class: su-news-components
-              field_label:
-                label_value: ''
-                label_tag: ''
-        weight: 1
-        additional: {  }
       5faf7033-e156-462c-a793-f543191db211:
         uuid: 5faf7033-e156-462c-a793-f543191db211
         region: main
@@ -237,5 +213,56 @@ layout:
                 label_value: ''
                 label_tag: ''
         weight: 0
+        additional: {  }
+      35a5e3ef-79bf-444c-8663-0f52e123108d:
+        uuid: 35a5e3ef-79bf-444c-8663-0f52e123108d
+        region: main
+        configuration:
+          id: 'field_block:node:stanford_news:body'
+          label: Body
+          label_display: '0'
+          provider: layout_builder
+          context_mapping:
+            entity: layout_builder.entity
+            view_mode: view_mode
+          formatter:
+            type: text_default
+            label: hidden
+            settings: {  }
+            third_party_settings:
+              empty_fields:
+                handler: ''
+              field_formatter_class:
+                class: ''
+              field_label:
+                label_value: ''
+                label_tag: ''
+        weight: 2
+        additional: {  }
+      074a19fc-39ac-40f6-95a7-b625dcc9e1b2:
+        uuid: 074a19fc-39ac-40f6-95a7-b625dcc9e1b2
+        region: main
+        configuration:
+          id: 'field_block:node:stanford_news:su_news_components'
+          label: Components
+          label_display: '0'
+          provider: layout_builder
+          context_mapping:
+            entity: layout_builder.entity
+            view_mode: view_mode
+          formatter:
+            type: layout_paragraphs
+            label: hidden
+            settings:
+              view_mode: default
+            third_party_settings:
+              empty_fields:
+                handler: ''
+              field_formatter_class:
+                class: su-news-components
+              field_label:
+                label_value: ''
+                label_tag: ''
+        weight: 3
         additional: {  }
     third_party_settings: {  }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- D8CORE-8414 | Add body field to spotlight view

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Create a News page
4. Select Spotlight variant and fill out fields
5. Save and verify that the body field appears above the paragraph types and below the date.
6. Review code

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? Yes


# Associated Issues and/or People
- D8CORE-8414 