### PR TITLE
D8CORE-8412 | replace spotlight text in layout with content block; show body field on Spotlight variant

### DIFF
--- a/config/sync/core.entity_form_display.node.stanford_news.default.yml
+++ b/config/sync/core.entity_form_display.node.stanford_news.default.yml
@@ -113,25 +113,7 @@ content:
         maxlength_js_summary: null
         maxlength_js_label_summary: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: false
-      conditional_fields:
-        a1b2c3d4-e5f6-7890-a1b2-c3d4e5f67890:
-          entity_type: node
-          bundle: stanford_news
-          dependee: layout_selection
-          settings:
-            state: '!visible'
-            reset: false
-            condition: value
-            grouping: AND
-            values_set: 1
-            value: ''
-            values: {  }
-            value_form:
-              -
-                target_id: news_spotlight
-            effect: show
-            effect_options: {  }
-            selector: ''
+      conditional_fields: {  }
   group_banner:
     weight: 26
     region: content

--- a/config/sync/layout_library.layout.news_spotlight.yml
+++ b/config/sync/layout_library.layout.news_spotlight.yml
@@ -70,7 +70,7 @@ layout:
               field_label:
                 label_value: ''
                 label_tag: ''
-        weight: 10
+        weight: 11
         additional: {  }
       a882d0a7-3cbf-49b9-a5e9-1907b4756679:
         uuid: a882d0a7-3cbf-49b9-a5e9-1907b4756679
@@ -96,7 +96,7 @@ layout:
               field_label:
                 label_value: ''
                 label_tag: ''
-        weight: 11
+        weight: 12
         additional: {  }
       732beb30-5e41-4c27-8b28-605b2cadbf06:
         uuid: 732beb30-5e41-4c27-8b28-605b2cadbf06
@@ -147,34 +147,21 @@ layout:
               field_label:
                 label_value: ''
                 label_tag: ''
-        weight: 9
+        weight: 10
         additional: {  }
-      b9778f05-c8e7-4f90-8456-3d0125d36538:
-        uuid: b9778f05-c8e7-4f90-8456-3d0125d36538
+      1067a8ed-6ab9-401a-a6df-fe6c069d4a08:
+        uuid: 1067a8ed-6ab9-401a-a6df-fe6c069d4a08
         region: left
         configuration:
-          id: 'field_block:node:stanford_news:layout_selection'
-          label: Layout
+          id: 'inline_block:stanford_component_block'
+          label: 'Spotlight Label'
           label_display: '0'
           provider: layout_builder
-          context_mapping:
-            entity: layout_builder.entity
-            view_mode: view_mode
-          formatter:
-            type: entity_reference_label
-            label: hidden
-            settings:
-              link: false
-            third_party_settings:
-              empty_fields:
-                handler: text
-                settings:
-                  empty_text: Spotlight
-              field_formatter_class:
-                class: ''
-              field_label:
-                label_value: ''
-                label_tag: ''
+          context_mapping: {  }
+          view_mode: full
+          block_id: null
+          block_revision_id: null
+          block_serialized: "O:40:\"Drupal\\block_content\\Entity\\BlockContent\":32:{s:15:\"\0*\0entityTypeId\";s:13:\"block_content\";s:15:\"\0*\0enforceIsNew\";b:1;s:12:\"\0*\0typedData\";N;s:17:\"\0*\0originalEntity\";N;s:16:\"\0*\0cacheContexts\";a:0:{}s:12:\"\0*\0cacheTags\";a:0:{}s:14:\"\0*\0cacheMaxAge\";i:-1;s:14:\"\0*\0_serviceIds\";a:0:{}s:18:\"\0*\0_entityStorages\";a:0:{}s:9:\"\0*\0values\";a:17:{s:8:\"langcode\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";s:2:\"en\";}}}s:11:\"revision_id\";a:1:{s:9:\"x-default\";a:0:{}}s:2:\"id\";a:1:{s:9:\"x-default\";a:0:{}}s:4:\"uuid\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";s:36:\"684382ac-2cf9-4b02-823d-50d5f1f443cb\";}}}s:4:\"type\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:9:\"target_id\";s:24:\"stanford_component_block\";}}}s:16:\"revision_created\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";i:1762900669;}}}s:13:\"revision_user\";a:1:{s:9:\"x-default\";a:0:{}}s:12:\"revision_log\";a:1:{s:9:\"x-default\";a:0:{}}s:6:\"status\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";b:1;}}}s:4:\"info\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";s:15:\"Spotlight Label\";}}}s:7:\"changed\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";i:1762900669;}}}s:8:\"reusable\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";b:0;}}}s:16:\"default_langcode\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";b:1;}}}s:16:\"revision_default\";a:1:{s:9:\"x-default\";a:0:{}}s:29:\"revision_translation_affected\";a:1:{s:9:\"x-default\";a:0:{}}s:7:\"metatag\";a:1:{s:9:\"x-default\";a:0:{}}s:12:\"su_component\";a:1:{s:9:\"x-default\";a:1:{i:0;a:5:{s:7:\"subform\";a:2:{s:6:\"status\";a:1:{s:5:\"value\";i:1;}s:15:\"su_wysiwyg_text\";a:1:{i:0;a:2:{s:5:\"value\";s:16:\"<p>Spotlight</p>\";s:6:\"format\";s:21:\"stanford_minimal_html\";}}}s:3:\"top\";a:1:{s:7:\"actions\";a:2:{s:7:\"actions\";a:1:{s:15:\"collapse_button\";O:48:\"Drupal\\Core\\StringTranslation\\TranslatableMarkup\":3:{s:9:\"\0*\0string\";s:8:\"Collapse\";s:12:\"\0*\0arguments\";a:0:{}s:10:\"\0*\0options\";a:0:{}}}s:16:\"dropdown_actions\";a:2:{s:16:\"duplicate_button\";O:48:\"Drupal\\Core\\StringTranslation\\TranslatableMarkup\":3:{s:9:\"\0*\0string\";s:9:\"Duplicate\";s:12:\"\0*\0arguments\";a:0:{}s:10:\"\0*\0options\";a:0:{}}s:13:\"remove_button\";O:48:\"Drupal\\Core\\StringTranslation\\TranslatableMarkup\":3:{s:9:\"\0*\0string\";s:6:\"Remove\";s:12:\"\0*\0arguments\";a:0:{}s:10:\"\0*\0options\";a:0:{}}}}}s:9:\"target_id\";N;s:18:\"target_revision_id\";N;s:6:\"entity\";O:34:\"Drupal\\paragraphs\\Entity\\Paragraph\":34:{s:15:\"\0*\0entityTypeId\";s:9:\"paragraph\";s:15:\"\0*\0enforceIsNew\";b:1;s:12:\"\0*\0typedData\";N;s:17:\"\0*\0originalEntity\";N;s:16:\"\0*\0cacheContexts\";a:0:{}s:12:\"\0*\0cacheTags\";a:0:{}s:14:\"\0*\0cacheMaxAge\";i:-1;s:14:\"\0*\0_serviceIds\";a:0:{}s:18:\"\0*\0_entityStorages\";a:0:{}s:9:\"\0*\0values\";a:15:{s:8:\"langcode\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";s:2:\"en\";}}}s:11:\"revision_id\";a:1:{s:9:\"x-default\";a:0:{}}s:2:\"id\";a:1:{s:9:\"x-default\";a:0:{}}s:4:\"uuid\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";s:36:\"bb692f93-0588-48a7-8008-c28867784632\";}}}s:4:\"type\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:9:\"target_id\";s:16:\"stanford_wysiwyg\";}}}s:6:\"status\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";i:1;}}}s:7:\"created\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";i:1762900669;}}}s:9:\"parent_id\";a:1:{s:9:\"x-default\";a:0:{}}s:11:\"parent_type\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";s:13:\"block_content\";}}}s:17:\"parent_field_name\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";s:12:\"su_component\";}}}s:17:\"behavior_settings\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";s:6:\"a:0:{}\";}}}s:16:\"default_langcode\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";b:1;}}}s:16:\"revision_default\";a:1:{s:9:\"x-default\";a:0:{}}s:29:\"revision_translation_affected\";a:1:{s:9:\"x-default\";a:0:{}}s:15:\"su_wysiwyg_text\";a:1:{s:9:\"x-default\";a:1:{i:0;a:2:{s:5:\"value\";s:16:\"<p>Spotlight</p>\";s:6:\"format\";s:21:\"stanford_minimal_html\";}}}}s:9:\"\0*\0fields\";a:0:{}s:19:\"\0*\0fieldDefinitions\";N;s:12:\"\0*\0languages\";N;s:14:\"\0*\0langcodeKey\";s:8:\"langcode\";s:21:\"\0*\0defaultLangcodeKey\";s:16:\"default_langcode\";s:17:\"\0*\0activeLangcode\";s:9:\"x-default\";s:28:\"\0*\0enforceDefaultTranslation\";N;s:18:\"\0*\0defaultLangcode\";s:2:\"en\";s:15:\"\0*\0translations\";a:1:{s:9:\"x-default\";a:1:{s:6:\"status\";i:2;}}s:24:\"\0*\0translationInitialize\";b:0;s:14:\"\0*\0newRevision\";b:1;s:20:\"\0*\0isDefaultRevision\";b:1;s:13:\"\0*\0entityKeys\";a:4:{s:6:\"bundle\";s:16:\"stanford_wysiwyg\";s:8:\"revision\";N;s:4:\"uuid\";s:36:\"bb692f93-0588-48a7-8008-c28867784632\";s:2:\"id\";N;}s:25:\"\0*\0translatableEntityKeys\";a:0:{}s:12:\"\0*\0validated\";b:1;s:21:\"\0*\0validationRequired\";b:0;s:19:\"\0*\0loadedRevisionId\";N;s:33:\"\0*\0revisionTranslationAffectedKey\";s:29:\"revision_translation_affected\";s:37:\"\0*\0enforceRevisionTranslationAffected\";a:0:{}s:12:\"\0*\0isSyncing\";b:0;s:31:\"\0*\0unserializedBehaviorSettings\";N;s:15:\"\0*\0summaryCount\";i:0;s:12:\"\0*\0needsSave\";b:1;s:20:\"\0*\0stringTranslation\";N;}}}}}s:9:\"\0*\0fields\";a:0:{}s:19:\"\0*\0fieldDefinitions\";N;s:12:\"\0*\0languages\";N;s:14:\"\0*\0langcodeKey\";s:8:\"langcode\";s:21:\"\0*\0defaultLangcodeKey\";s:16:\"default_langcode\";s:17:\"\0*\0activeLangcode\";s:9:\"x-default\";s:28:\"\0*\0enforceDefaultTranslation\";N;s:18:\"\0*\0defaultLangcode\";s:2:\"en\";s:15:\"\0*\0translations\";a:1:{s:9:\"x-default\";a:1:{s:6:\"status\";i:2;}}s:24:\"\0*\0translationInitialize\";b:0;s:14:\"\0*\0newRevision\";b:1;s:20:\"\0*\0isDefaultRevision\";b:1;s:13:\"\0*\0entityKeys\";a:3:{s:6:\"bundle\";s:24:\"stanford_component_block\";s:8:\"revision\";N;s:2:\"id\";N;}s:25:\"\0*\0translatableEntityKeys\";a:1:{s:8:\"langcode\";a:1:{s:9:\"x-default\";s:2:\"en\";}}s:12:\"\0*\0validated\";b:1;s:21:\"\0*\0validationRequired\";b:0;s:19:\"\0*\0loadedRevisionId\";N;s:33:\"\0*\0revisionTranslationAffectedKey\";s:29:\"revision_translation_affected\";s:37:\"\0*\0enforceRevisionTranslationAffected\";a:0:{}s:12:\"\0*\0isSyncing\";b:0;s:8:\"\0*\0theme\";N;s:19:\"\0*\0accessDependency\";N;}"
         weight: 8
         additional: {  }
     third_party_settings: {  }

--- a/config/sync/layout_library.layout.news_spotlight.yml
+++ b/config/sync/layout_library.layout.news_spotlight.yml
@@ -46,32 +46,6 @@ layout:
                 label_tag: ''
         weight: 0
         additional: {  }
-      59fa3d22-3c8f-403d-914b-590ada330bc3:
-        uuid: 59fa3d22-3c8f-403d-914b-590ada330bc3
-        region: left
-        configuration:
-          id: 'field_block:node:stanford_news:su_news_subtitle'
-          label: Subtitle
-          label_display: '0'
-          provider: layout_builder
-          context_mapping:
-            entity: layout_builder.entity
-            view_mode: view_mode
-          formatter:
-            type: string
-            label: hidden
-            settings:
-              link_to_entity: false
-            third_party_settings:
-              empty_fields:
-                handler: ''
-              field_formatter_class:
-                class: ''
-              field_label:
-                label_value: ''
-                label_tag: ''
-        weight: 11
-        additional: {  }
       a882d0a7-3cbf-49b9-a5e9-1907b4756679:
         uuid: a882d0a7-3cbf-49b9-a5e9-1907b4756679
         region: left
@@ -96,7 +70,7 @@ layout:
               field_label:
                 label_value: ''
                 label_tag: ''
-        weight: 12
+        weight: 11
         additional: {  }
       732beb30-5e41-4c27-8b28-605b2cadbf06:
         uuid: 732beb30-5e41-4c27-8b28-605b2cadbf06
@@ -149,19 +123,15 @@ layout:
                 label_tag: ''
         weight: 10
         additional: {  }
-      1067a8ed-6ab9-401a-a6df-fe6c069d4a08:
-        uuid: 1067a8ed-6ab9-401a-a6df-fe6c069d4a08
+      50cb47d0-dcb4-4d3e-95e8-7c04f42f10da:
+        uuid: 50cb47d0-dcb4-4d3e-95e8-7c04f42f10da
         region: left
         configuration:
-          id: 'inline_block:stanford_component_block'
-          label: 'Spotlight Label'
+          id: 'simple_block:su_spotlight_label'
+          label: 'Spotlight label'
           label_display: '0'
-          provider: layout_builder
+          provider: simple_block
           context_mapping: {  }
-          view_mode: full
-          block_id: null
-          block_revision_id: null
-          block_serialized: "O:40:\"Drupal\\block_content\\Entity\\BlockContent\":32:{s:15:\"\0*\0entityTypeId\";s:13:\"block_content\";s:15:\"\0*\0enforceIsNew\";b:1;s:12:\"\0*\0typedData\";N;s:17:\"\0*\0originalEntity\";N;s:16:\"\0*\0cacheContexts\";a:0:{}s:12:\"\0*\0cacheTags\";a:0:{}s:14:\"\0*\0cacheMaxAge\";i:-1;s:14:\"\0*\0_serviceIds\";a:0:{}s:18:\"\0*\0_entityStorages\";a:0:{}s:9:\"\0*\0values\";a:17:{s:8:\"langcode\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";s:2:\"en\";}}}s:11:\"revision_id\";a:1:{s:9:\"x-default\";a:0:{}}s:2:\"id\";a:1:{s:9:\"x-default\";a:0:{}}s:4:\"uuid\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";s:36:\"684382ac-2cf9-4b02-823d-50d5f1f443cb\";}}}s:4:\"type\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:9:\"target_id\";s:24:\"stanford_component_block\";}}}s:16:\"revision_created\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";i:1762900669;}}}s:13:\"revision_user\";a:1:{s:9:\"x-default\";a:0:{}}s:12:\"revision_log\";a:1:{s:9:\"x-default\";a:0:{}}s:6:\"status\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";b:1;}}}s:4:\"info\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";s:15:\"Spotlight Label\";}}}s:7:\"changed\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";i:1762900669;}}}s:8:\"reusable\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";b:0;}}}s:16:\"default_langcode\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";b:1;}}}s:16:\"revision_default\";a:1:{s:9:\"x-default\";a:0:{}}s:29:\"revision_translation_affected\";a:1:{s:9:\"x-default\";a:0:{}}s:7:\"metatag\";a:1:{s:9:\"x-default\";a:0:{}}s:12:\"su_component\";a:1:{s:9:\"x-default\";a:1:{i:0;a:5:{s:7:\"subform\";a:2:{s:6:\"status\";a:1:{s:5:\"value\";i:1;}s:15:\"su_wysiwyg_text\";a:1:{i:0;a:2:{s:5:\"value\";s:16:\"<p>Spotlight</p>\";s:6:\"format\";s:21:\"stanford_minimal_html\";}}}s:3:\"top\";a:1:{s:7:\"actions\";a:2:{s:7:\"actions\";a:1:{s:15:\"collapse_button\";O:48:\"Drupal\\Core\\StringTranslation\\TranslatableMarkup\":3:{s:9:\"\0*\0string\";s:8:\"Collapse\";s:12:\"\0*\0arguments\";a:0:{}s:10:\"\0*\0options\";a:0:{}}}s:16:\"dropdown_actions\";a:2:{s:16:\"duplicate_button\";O:48:\"Drupal\\Core\\StringTranslation\\TranslatableMarkup\":3:{s:9:\"\0*\0string\";s:9:\"Duplicate\";s:12:\"\0*\0arguments\";a:0:{}s:10:\"\0*\0options\";a:0:{}}s:13:\"remove_button\";O:48:\"Drupal\\Core\\StringTranslation\\TranslatableMarkup\":3:{s:9:\"\0*\0string\";s:6:\"Remove\";s:12:\"\0*\0arguments\";a:0:{}s:10:\"\0*\0options\";a:0:{}}}}}s:9:\"target_id\";N;s:18:\"target_revision_id\";N;s:6:\"entity\";O:34:\"Drupal\\paragraphs\\Entity\\Paragraph\":34:{s:15:\"\0*\0entityTypeId\";s:9:\"paragraph\";s:15:\"\0*\0enforceIsNew\";b:1;s:12:\"\0*\0typedData\";N;s:17:\"\0*\0originalEntity\";N;s:16:\"\0*\0cacheContexts\";a:0:{}s:12:\"\0*\0cacheTags\";a:0:{}s:14:\"\0*\0cacheMaxAge\";i:-1;s:14:\"\0*\0_serviceIds\";a:0:{}s:18:\"\0*\0_entityStorages\";a:0:{}s:9:\"\0*\0values\";a:15:{s:8:\"langcode\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";s:2:\"en\";}}}s:11:\"revision_id\";a:1:{s:9:\"x-default\";a:0:{}}s:2:\"id\";a:1:{s:9:\"x-default\";a:0:{}}s:4:\"uuid\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";s:36:\"bb692f93-0588-48a7-8008-c28867784632\";}}}s:4:\"type\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:9:\"target_id\";s:16:\"stanford_wysiwyg\";}}}s:6:\"status\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";i:1;}}}s:7:\"created\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";i:1762900669;}}}s:9:\"parent_id\";a:1:{s:9:\"x-default\";a:0:{}}s:11:\"parent_type\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";s:13:\"block_content\";}}}s:17:\"parent_field_name\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";s:12:\"su_component\";}}}s:17:\"behavior_settings\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";s:6:\"a:0:{}\";}}}s:16:\"default_langcode\";a:1:{s:9:\"x-default\";a:1:{i:0;a:1:{s:5:\"value\";b:1;}}}s:16:\"revision_default\";a:1:{s:9:\"x-default\";a:0:{}}s:29:\"revision_translation_affected\";a:1:{s:9:\"x-default\";a:0:{}}s:15:\"su_wysiwyg_text\";a:1:{s:9:\"x-default\";a:1:{i:0;a:2:{s:5:\"value\";s:16:\"<p>Spotlight</p>\";s:6:\"format\";s:21:\"stanford_minimal_html\";}}}}s:9:\"\0*\0fields\";a:0:{}s:19:\"\0*\0fieldDefinitions\";N;s:12:\"\0*\0languages\";N;s:14:\"\0*\0langcodeKey\";s:8:\"langcode\";s:21:\"\0*\0defaultLangcodeKey\";s:16:\"default_langcode\";s:17:\"\0*\0activeLangcode\";s:9:\"x-default\";s:28:\"\0*\0enforceDefaultTranslation\";N;s:18:\"\0*\0defaultLangcode\";s:2:\"en\";s:15:\"\0*\0translations\";a:1:{s:9:\"x-default\";a:1:{s:6:\"status\";i:2;}}s:24:\"\0*\0translationInitialize\";b:0;s:14:\"\0*\0newRevision\";b:1;s:20:\"\0*\0isDefaultRevision\";b:1;s:13:\"\0*\0entityKeys\";a:4:{s:6:\"bundle\";s:16:\"stanford_wysiwyg\";s:8:\"revision\";N;s:4:\"uuid\";s:36:\"bb692f93-0588-48a7-8008-c28867784632\";s:2:\"id\";N;}s:25:\"\0*\0translatableEntityKeys\";a:0:{}s:12:\"\0*\0validated\";b:1;s:21:\"\0*\0validationRequired\";b:0;s:19:\"\0*\0loadedRevisionId\";N;s:33:\"\0*\0revisionTranslationAffectedKey\";s:29:\"revision_translation_affected\";s:37:\"\0*\0enforceRevisionTranslationAffected\";a:0:{}s:12:\"\0*\0isSyncing\";b:0;s:31:\"\0*\0unserializedBehaviorSettings\";N;s:15:\"\0*\0summaryCount\";i:0;s:12:\"\0*\0needsSave\";b:1;s:20:\"\0*\0stringTranslation\";N;}}}}}s:9:\"\0*\0fields\";a:0:{}s:19:\"\0*\0fieldDefinitions\";N;s:12:\"\0*\0languages\";N;s:14:\"\0*\0langcodeKey\";s:8:\"langcode\";s:21:\"\0*\0defaultLangcodeKey\";s:16:\"default_langcode\";s:17:\"\0*\0activeLangcode\";s:9:\"x-default\";s:28:\"\0*\0enforceDefaultTranslation\";N;s:18:\"\0*\0defaultLangcode\";s:2:\"en\";s:15:\"\0*\0translations\";a:1:{s:9:\"x-default\";a:1:{s:6:\"status\";i:2;}}s:24:\"\0*\0translationInitialize\";b:0;s:14:\"\0*\0newRevision\";b:1;s:20:\"\0*\0isDefaultRevision\";b:1;s:13:\"\0*\0entityKeys\";a:3:{s:6:\"bundle\";s:24:\"stanford_component_block\";s:8:\"revision\";N;s:2:\"id\";N;}s:25:\"\0*\0translatableEntityKeys\";a:1:{s:8:\"langcode\";a:1:{s:9:\"x-default\";s:2:\"en\";}}s:12:\"\0*\0validated\";b:1;s:21:\"\0*\0validationRequired\";b:0;s:19:\"\0*\0loadedRevisionId\";N;s:33:\"\0*\0revisionTranslationAffectedKey\";s:29:\"revision_translation_affected\";s:37:\"\0*\0enforceRevisionTranslationAffected\";a:0:{}s:12:\"\0*\0isSyncing\";b:0;s:8:\"\0*\0theme\";N;s:19:\"\0*\0accessDependency\";N;}"
         weight: 8
         additional: {  }
     third_party_settings: {  }

--- a/config/sync/simple_block.simple_block.su_spotlight_label.yml
+++ b/config/sync/simple_block.simple_block.su_spotlight_label.yml
@@ -1,0 +1,11 @@
+uuid: 688335f7-5f54-4097-afb9-6388494c376e
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.stanford_minimal_html
+id: su_spotlight_label
+title: 'Spotlight label'
+content:
+  value: '<p>Spotlight</p>'
+  format: stanford_minimal_html

--- a/tests/codeception/acceptance/Content/NewsCest.php
+++ b/tests/codeception/acceptance/Content/NewsCest.php
@@ -435,4 +435,27 @@ class NewsCest {
     $I->seeNumberOfElements('.related-spotlights article', 3);
   }
 
+  /**
+   * Test spotlight label displayed correctly on the news spotlight variant page.
+   */
+
+  #[CodeceptionAttribute\Group('news_variant')]
+
+  #[CodeceptionAttribute\Group('spotlight_page')]
+  public function testSpotlightCreationAndDisplay(AcceptanceTester $I) {
+    // Create a spotlight node.
+    $spotlight = $I->createEntity([
+      'title' => $this->faker->words(3, TRUE),
+      'type' => 'stanford_news',
+      'layout_selection' => 'news_spotlight',
+      'status' => 1,
+    ]);
+
+    // Visit the spotlight page.
+    $I->amOnPage($spotlight->toUrl()->toString());
+
+    // Verify the spotlight label exists
+    $I->canSee('Spotlight', '.su-spotlight-label p');
+  }
+
 }

--- a/tests/codeception/functional/Content/StanfordNewsCest.php
+++ b/tests/codeception/functional/Content/StanfordNewsCest.php
@@ -137,9 +137,9 @@ class StanfordNewsCest {
     $I->canSeeInField('Variant', 'Spotlight');
     $I->canSeeInField('Headline', $spotlight_news->label());
     $I->canSeeInField('Quote / Big Text', $spotlight_news->get('su_news_quote')->value);
+    $I->canSee('Body');
 
-    // Body, Shared Tags, Social Share Icons, and Related Person should be hidden
-    $I->cantSee('Body');
+    // Shared Tags, Social Share Icons, and Related Person should be hidden
     $I->cantSee('Shared Tags');
     $I->cantSee('Hide Social Share Icons');
     $I->cantSee('Related Person');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- D8CORE-8412 | replace spotlight text in layout with content block; show body field on Spotlight variant

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Create a News spotlight variant. 
4. Verify that the body field appears in the Spotlight variant form
5. Fill out fields and save.
6. Navigate to that spotlight page in an incognito browser
7. Verify that the "Spotlight" text appears.
8. Review code

# Associated Issues and/or People
- D8CORE-8412