### PR TITLE
Tidy Up News Edit Form

### DIFF
--- a/config/sync/core.entity_form_display.node.stanford_news.default.yml
+++ b/config/sync/core.entity_form_display.node.stanford_news.default.yml
@@ -37,7 +37,6 @@ dependencies:
     - metatag
     - path
     - scheduler
-    - stanford_fields
     - stanford_intranet
     - text
 third_party_settings:
@@ -46,14 +45,16 @@ third_party_settings:
       children:
         - su_news_featured_media
         - group_banner
-      label: Media
+      label: 'Featured Images'
       region: content
       parent_name: ''
-      weight: 5
+      weight: 3
       format_type: fieldset
       format_settings:
         classes: ''
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         description: ''
         required_fields: true
     group_editorial_content:
@@ -67,7 +68,7 @@ third_party_settings:
       label: 'Editorial Content'
       region: content
       parent_name: ''
-      weight: 4
+      weight: 2
       format_type: fieldset
       format_settings:
         classes: ''
@@ -86,6 +87,24 @@ third_party_settings:
       format_settings:
         classes: ''
         id: ''
+        description: ''
+        required_fields: true
+    group_taxonomy:
+      children:
+        - su_news_topics
+        - su_news_spotlight_filters
+        - su_shared_tags
+      label: Taxonomy
+      region: content
+      parent_name: ''
+      weight: 6
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        open: false
         description: ''
         required_fields: true
 id: node.stanford_news.default
@@ -156,18 +175,18 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 13
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 15
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   scheduler_settings:
-    weight: 14
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -186,7 +205,7 @@ content:
     third_party_settings: {  }
   su_metatags:
     type: metatag_firehose
-    weight: 11
+    weight: 10
     region: content
     settings:
       sidebar: true
@@ -236,7 +255,7 @@ content:
             selector: ''
   su_news_components:
     type: layout_paragraphs
-    weight: 7
+    weight: 4
     region: content
     settings:
       view_mode: default
@@ -284,7 +303,7 @@ content:
     third_party_settings: {  }
   su_news_hide_social:
     type: boolean_checkbox
-    weight: 12
+    weight: 7
     region: content
     settings:
       display_label: true
@@ -310,7 +329,7 @@ content:
             selector: ''
   su_news_person:
     type: options_select
-    weight: 14
+    weight: 5
     region: content
     settings: {  }
     third_party_settings:
@@ -391,10 +410,17 @@ content:
       placeholder_title: ''
     third_party_settings: {  }
   su_news_spotlight_filters:
-    type: taxonomy_label_hierarchy
-    weight: 28
+    type: cshs
+    weight: 5
     region: content
-    settings: {  }
+    settings:
+      save_lineage: false
+      force_deepest: false
+      parent: ''
+      level_labels: ''
+      hierarchy_depth: 0
+      required_depth: 0
+      none_label: '- Please select -'
     third_party_settings:
       conditional_fields:
         ea6602ea-f047-48ee-af29-1ea7d973513c:
@@ -433,7 +459,7 @@ content:
             selector: ''
   su_news_topics:
     type: cshs
-    weight: 6
+    weight: 4
     region: content
     settings:
       save_lineage: false
@@ -486,7 +512,7 @@ content:
             selector: ''
   su_shared_tags:
     type: cshs
-    weight: 10
+    weight: 7
     region: content
     settings:
       save_lineage: false
@@ -518,7 +544,7 @@ content:
             selector: ''
   title:
     type: string_textfield
-    weight: 2
+    weight: 1
     region: content
     settings:
       size: 60

--- a/tests/codeception/functional/Content/StanfordNewsCest.php
+++ b/tests/codeception/functional/Content/StanfordNewsCest.php
@@ -49,6 +49,7 @@ class StanfordNewsCest {
 
     $I->amOnPage($node->toUrl('edit-form')->toString());
     $I->canSeeInField('Headline', $node->label());
+    $I->click('#edit-group-taxonomy summary');
 
     $I->waitForElementVisible('.form-item--su-news-topics-0-target-id select.simpler-select');
     $I->selectOption('.form-item--su-news-topics-0-target-id select.simpler-select', $first_term->id());
@@ -64,6 +65,7 @@ class StanfordNewsCest {
     $I->canSee($first_term->label() . ', ' . $second_term->label() . ', ' . $third_term->label());
 
     $I->amOnPage($node->toUrl('edit-form')->toString());
+    $I->click('#edit-group-taxonomy summary');
     $I->waitForElementVisible('.form-item--su-news-topics-2-target-id select.simpler-select');
     $I->selectOption('.form-item--su-news-topics-0-target-id select.simpler-select', $second_term->id());
     $I->selectOption('.form-item--su-news-topics-1-target-id select.simpler-select', $first_term->id());
@@ -74,6 +76,7 @@ class StanfordNewsCest {
     $I->canSee($second_term->label() . ', ' . $first_term->label() . ', ' . $third_term->label());
 
     $I->amOnPage($node->toUrl('edit-form')->toString());
+    $I->click('#edit-group-taxonomy summary');
     $I->waitForElementVisible('.form-item--su-news-topics-2-target-id select.simpler-select');
     $I->selectOption('.form-item--su-news-topics-0-target-id select.simpler-select', $third_term->id());
     $I->selectOption('.form-item--su-news-topics-1-target-id select.simpler-select', $second_term->id());
@@ -84,6 +87,7 @@ class StanfordNewsCest {
     $I->canSee($third_term->label() . ', ' . $second_term->label() . ', ' . $first_term->label());
 
     $I->amOnPage($node->toUrl('edit-form')->toString());
+    $I->click('#edit-group-taxonomy summary');
     $I->waitForElementVisible('.form-item--su-news-topics-2-target-id select.simpler-select');
     $I->selectOption('.form-item--su-news-topics-0-target-id select.simpler-select', $third_term->id());
     $I->selectOption('.form-item--su-news-topics-1-target-id select.simpler-select', $first_term->id());
@@ -95,7 +99,7 @@ class StanfordNewsCest {
   }
 
   /**
-   * Test that conditional fields work correctly for default and spotlight variants.
+   * Test that conditional fields work correctly for spotlight variants.
    */
   #[CodeceptionAttribute\Group('news_variant')]
   public function testNewsVariantConditionalFields(FunctionalTester $I) {
@@ -120,6 +124,8 @@ class StanfordNewsCest {
     // Test default news variant
     $I->amOnPage($default_news->toUrl('edit-form')->toString());
     $I->waitForElement('[name="layout_selection"]');
+    $I->click('#edit-group-taxonomy summary');
+
     $I->canSeeInField('Variant', 'News');
     $I->canSeeInField('Headline', $default_news->label());
     $I->canSeeInField('Dek', $default_news->get('su_news_dek')->value);
@@ -134,6 +140,8 @@ class StanfordNewsCest {
     // Test spotlight news variant
     $I->amOnPage($spotlight_news->toUrl('edit-form')->toString());
     $I->waitForElement('[name="layout_selection"]');
+    $I->click('#edit-group-taxonomy summary');
+
     $I->canSeeInField('Variant', 'Spotlight');
     $I->canSeeInField('Headline', $spotlight_news->label());
     $I->canSeeInField('Quote / Big Text', $spotlight_news->get('su_news_quote')->value);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
Updated field weights and labels in the entity form display configuration for 'stanford_news'. Added a new group for taxonomy fields.

# Review By (Date) 
Soonish?

# Criticality

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Check out the edit form
3. Am a bit torn about "body" in the editorial content, but leaving there now

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? YES

## Front End Validation
No front-end impact

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People


# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
