### PR TITLE
D8CORE-8457 | add style classes to spotlight teaser large and small images, and teaser news

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -202,7 +202,7 @@
         "su-sws/stanford_actions": "^8.2",
         "su-sws/stanford_media": "^11.0",
         "su-sws/stanford_migrate": "^9.0",
-        "su-sws/stanford_profile_helper": "10.x-dev",
+        "su-sws/stanford_profile_helper": "D8CORE-8453-dev",
         "su-sws/stanford_samlauth": "^2.0"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -101,6 +101,7 @@
         "drupal/editoria11y": "^2.0",
         "drupal/element_class_formatter": "^2.0@beta",
         "drupal/encrypt": "^3.0",
+        "drupal/entity_reference_display": "^2.0",
         "drupal/environment_indicator": "^4.0",
         "drupal/extlink": "^2.0",
         "drupal/fast_404_generator": "^1.0",

--- a/config/sync/core.entity_form_display.paragraph.stanford_entity.default.yml
+++ b/config/sync/core.entity_form_display.paragraph.stanford_entity.default.yml
@@ -7,10 +7,32 @@ dependencies:
     - field.field.paragraph.stanford_entity.su_entity_description
     - field.field.paragraph.stanford_entity.su_entity_headline
     - field.field.paragraph.stanford_entity.su_entity_item
+    - field.field.paragraph.stanford_entity.su_entity_news
+    - field.field.paragraph.stanford_entity.su_entity_news_display
     - paragraphs.paragraphs_type.stanford_entity
   module:
+    - field_group
     - link
     - text
+third_party_settings:
+  field_group:
+    group_news:
+      children:
+        - su_entity_news
+        - su_entity_news_display
+      label: News
+      region: content
+      parent_name: ''
+      weight: 1
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        open: false
+        description: ''
+        required_fields: true
 id: paragraph.stanford_entity.default
 targetEntityType: paragraph
 bundle: stanford_entity
@@ -18,14 +40,14 @@ mode: default
 content:
   status:
     type: boolean_checkbox
-    weight: 4
+    weight: 5
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   su_entity_button:
     type: link_default
-    weight: 3
+    weight: 4
     region: content
     settings:
       placeholder_url: ''
@@ -33,7 +55,7 @@ content:
     third_party_settings: {  }
   su_entity_description:
     type: text_textarea
-    weight: 2
+    weight: 3
     region: content
     settings:
       rows: 5
@@ -41,7 +63,7 @@ content:
     third_party_settings: {  }
   su_entity_headline:
     type: string_textfield
-    weight: 1
+    weight: 2
     region: content
     settings:
       size: 60
@@ -56,6 +78,22 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  su_entity_news:
+    type: entity_reference_autocomplete
+    weight: 6
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  su_entity_news_display:
+    type: options_select
+    weight: 7
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden:
   created: true

--- a/config/sync/core.entity_view_display.node.stanford_news.spotlight_teaser_large_image.yml
+++ b/config/sync/core.entity_view_display.node.stanford_news.spotlight_teaser_large_image.yml
@@ -66,7 +66,7 @@ third_party_settings:
         formatter: default
         settings:
           link: true
-          'link class': 'su-link su-card__link'
+          'link class': 'su-link su-card__link su-link--action'
           link_target: ''
           wrapper: h3
           class: ''

--- a/config/sync/core.entity_view_display.node.stanford_news.spotlight_teaser_large_image.yml
+++ b/config/sync/core.entity_view_display.node.stanford_news.spotlight_teaser_large_image.yml
@@ -1,0 +1,179 @@
+uuid: 1221dfea-9b09-49ba-863a-5cc5f6d4fc36
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.spotlight_teaser_large_image
+    - field.field.node.stanford_news.body
+    - field.field.node.stanford_news.layout_builder__layout
+    - field.field.node.stanford_news.layout_selection
+    - field.field.node.stanford_news.stanford_intranet__access
+    - field.field.node.stanford_news.su_metatags
+    - field.field.node.stanford_news.su_news_banner
+    - field.field.node.stanford_news.su_news_banner_media_caption
+    - field.field.node.stanford_news.su_news_byline
+    - field.field.node.stanford_news.su_news_components
+    - field.field.node.stanford_news.su_news_dek
+    - field.field.node.stanford_news.su_news_featured_media
+    - field.field.node.stanford_news.su_news_hide_social
+    - field.field.node.stanford_news.su_news_person
+    - field.field.node.stanford_news.su_news_publishing_date
+    - field.field.node.stanford_news.su_news_quote
+    - field.field.node.stanford_news.su_news_source
+    - field.field.node.stanford_news.su_news_spotlight_filters
+    - field.field.node.stanford_news.su_news_topics
+    - field.field.node.stanford_news.su_shared_tags
+    - node.type.stanford_news
+  module:
+    - datetime
+    - ds
+    - element_class_formatter
+    - empty_fields
+    - field_formatter_class
+    - field_formatter_range
+    - field_label
+    - layout_builder
+    - smart_trim
+    - stanford_media
+    - user
+third_party_settings:
+  ds:
+    layout:
+      id: pattern_spotlight-teaser
+      library: null
+      disable_css: false
+      entity_classes: all_classes
+      settings:
+        pattern:
+          field_templates: only_content
+          variant: large_image
+    regions:
+      spotlight_teaser_headline:
+        - node_title
+      spotlight_teaser_quote:
+        - su_news_quote
+      spotlight_teaser_media:
+        - su_news_featured_media
+      spotlight_filters:
+        - su_news_spotlight_filters
+      date:
+        - su_news_publishing_date
+    fields:
+      node_title:
+        plugin_id: node_title
+        weight: 0
+        label: hidden
+        formatter: default
+        settings:
+          link: true
+          'link class': 'su-link su-card__link'
+          link_target: ''
+          wrapper: h3
+          class: ''
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: node.stanford_news.spotlight_teaser_large_image
+targetEntityType: node
+bundle: stanford_news
+mode: spotlight_teaser_large_image
+content:
+  su_news_featured_media:
+    type: media_image_formatter
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+      image_style: large_square
+      remove_alt: false
+    third_party_settings:
+      empty_fields:
+        handler: ''
+      field_formatter_class:
+        class: ''
+      field_label:
+        label_value: ''
+        label_tag: ''
+    weight: 2
+    region: spotlight_teaser_media
+  su_news_publishing_date:
+    type: datetime_custom
+    label: hidden
+    settings:
+      timezone_override: ''
+      date_format: 'F d, Y'
+    third_party_settings: {  }
+    weight: 4
+    region: date
+  su_news_quote:
+    type: smart_trim
+    label: hidden
+    settings:
+      trim_length: 100
+      trim_type: chars
+      trim_suffix: \u2026
+      wrap_output: false
+      wrap_class: trimmed
+      more:
+        display_link: false
+        target_blank: false
+        link_trim_only: false
+        class: more-link
+        text: More
+        aria_label: 'Read more about [node:title]'
+      summary_handler: full
+      trim_options:
+        text: true
+        trim_zero: false
+        replace_tokens: false
+    third_party_settings:
+      empty_fields:
+        handler: ''
+      field_formatter_class:
+        class: ''
+      field_label:
+        label_value: ''
+        label_tag: ''
+    weight: 1
+    region: spotlight_teaser_quote
+  su_news_spotlight_filters:
+    type: entity_reference_list_label_class
+    label: hidden
+    settings:
+      link: false
+      class: su-list-unstyled
+      list_type: ul
+    third_party_settings:
+      empty_fields:
+        handler: ''
+      field_formatter_class:
+        class: ''
+      field_formatter_range:
+        order: 0
+        limit: 0
+        offset: 0
+      field_label:
+        label_value: ''
+        label_tag: ''
+      ds:
+        ds_limit: '3'
+    weight: 3
+    region: spotlight_filters
+hidden:
+  body: true
+  layout_builder__layout: true
+  layout_selection: true
+  links: true
+  search_api_excerpt: true
+  stanford_intranet__access: true
+  su_metatags: true
+  su_news_banner: true
+  su_news_banner_media_caption: true
+  su_news_byline: true
+  su_news_components: true
+  su_news_dek: true
+  su_news_hide_social: true
+  su_news_person: true
+  su_news_source: true
+  su_news_topics: true
+  su_shared_tags: true

--- a/config/sync/core.entity_view_display.node.stanford_news.spotlight_teaser_small_image.yml
+++ b/config/sync/core.entity_view_display.node.stanford_news.spotlight_teaser_small_image.yml
@@ -65,7 +65,7 @@ third_party_settings:
         formatter: default
         settings:
           link: true
-          'link class': 'su-link su-card__link '
+          'link class': 'su-link su-card__link su-link--action'
           link_target: ''
           wrapper: h3
           class: ''

--- a/config/sync/core.entity_view_display.node.stanford_news.spotlight_teaser_small_image.yml
+++ b/config/sync/core.entity_view_display.node.stanford_news.spotlight_teaser_small_image.yml
@@ -1,0 +1,185 @@
+uuid: 8216fa37-14cf-4951-9b8a-333588763b90
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.spotlight_teaser_small_image
+    - field.field.node.stanford_news.body
+    - field.field.node.stanford_news.layout_builder__layout
+    - field.field.node.stanford_news.layout_selection
+    - field.field.node.stanford_news.stanford_intranet__access
+    - field.field.node.stanford_news.su_metatags
+    - field.field.node.stanford_news.su_news_banner
+    - field.field.node.stanford_news.su_news_banner_media_caption
+    - field.field.node.stanford_news.su_news_byline
+    - field.field.node.stanford_news.su_news_components
+    - field.field.node.stanford_news.su_news_dek
+    - field.field.node.stanford_news.su_news_featured_media
+    - field.field.node.stanford_news.su_news_hide_social
+    - field.field.node.stanford_news.su_news_person
+    - field.field.node.stanford_news.su_news_publishing_date
+    - field.field.node.stanford_news.su_news_quote
+    - field.field.node.stanford_news.su_news_source
+    - field.field.node.stanford_news.su_news_spotlight_filters
+    - field.field.node.stanford_news.su_news_topics
+    - field.field.node.stanford_news.su_shared_tags
+    - node.type.stanford_news
+  module:
+    - datetime
+    - ds
+    - element_class_formatter
+    - empty_fields
+    - field_formatter_class
+    - field_formatter_range
+    - field_label
+    - smart_trim
+    - stanford_media
+    - user
+third_party_settings:
+  ds:
+    layout:
+      id: pattern_spotlight-teaser
+      library: null
+      disable_css: false
+      entity_classes: all_classes
+      settings:
+        pattern:
+          field_templates: only_content
+          variant: small_image
+    regions:
+      spotlight_teaser_headline:
+        - node_title
+      spotlight_teaser_quote:
+        - su_news_quote
+      spotlight_teaser_media:
+        - su_news_featured_media
+      spotlight_filters:
+        - su_news_spotlight_filters
+      date:
+        - su_news_publishing_date
+    fields:
+      node_title:
+        plugin_id: node_title
+        weight: 0
+        label: hidden
+        formatter: default
+        settings:
+          link: true
+          'link class': 'su-link su-card__link '
+          link_target: ''
+          wrapper: h3
+          class: ''
+    layout_builder:
+      enabled: false
+      allow_custom: false
+id: node.stanford_news.spotlight_teaser_small_image
+targetEntityType: node
+bundle: stanford_news
+mode: spotlight_teaser_small_image
+content:
+  su_news_featured_media:
+    type: media_image_formatter
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+      image_style: medium_square
+      remove_alt: true
+    third_party_settings:
+      empty_fields:
+        handler: ''
+      field_formatter_class:
+        class: ''
+      field_label:
+        label_value: ''
+        label_tag: ''
+    weight: 2
+    region: spotlight_teaser_media
+  su_news_publishing_date:
+    type: datetime_custom
+    label: hidden
+    settings:
+      timezone_override: ''
+      date_format: 'F d, Y'
+    third_party_settings:
+      empty_fields:
+        handler: ''
+      field_formatter_class:
+        class: ''
+      field_label:
+        label_value: ''
+        label_tag: ''
+    weight: 4
+    region: date
+  su_news_quote:
+    type: smart_trim
+    label: hidden
+    settings:
+      trim_length: 100
+      trim_type: chars
+      trim_suffix: \u2026
+      wrap_output: false
+      wrap_class: trimmed
+      more:
+        display_link: false
+        target_blank: false
+        link_trim_only: false
+        class: more-link
+        text: More
+        aria_label: 'Read more about [node:title]'
+      summary_handler: full
+      trim_options:
+        text: true
+        trim_zero: false
+        replace_tokens: false
+    third_party_settings:
+      empty_fields:
+        handler: ''
+      field_formatter_class:
+        class: ''
+      field_label:
+        label_value: ''
+        label_tag: ''
+    weight: 1
+    region: spotlight_teaser_quote
+  su_news_spotlight_filters:
+    type: entity_reference_list_label_class
+    label: hidden
+    settings:
+      link: false
+      class: su-list-unstyled
+      list_type: ul
+    third_party_settings:
+      empty_fields:
+        handler: ''
+      field_formatter_class:
+        class: ''
+      field_formatter_range:
+        order: 0
+        limit: 0
+        offset: 0
+      field_label:
+        label_value: ''
+        label_tag: ''
+      ds:
+        ds_limit: '3'
+    weight: 3
+    region: spotlight_filters
+hidden:
+  body: true
+  layout_builder__layout: true
+  layout_selection: true
+  links: true
+  search_api_excerpt: true
+  stanford_intranet__access: true
+  su_metatags: true
+  su_news_banner: true
+  su_news_banner_media_caption: true
+  su_news_byline: true
+  su_news_components: true
+  su_news_dek: true
+  su_news_hide_social: true
+  su_news_person: true
+  su_news_source: true
+  su_news_topics: true
+  su_shared_tags: true

--- a/config/sync/core.entity_view_display.paragraph.stanford_entity.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.stanford_entity.default.yml
@@ -84,7 +84,7 @@ content:
       empty_fields:
         handler: ''
       field_formatter_class:
-        class: su-margin-bottom-5
+        class: 'su-margin-bottom-5 su-entity-item'
       field_formatter_range:
         order: 0
         limit: 0

--- a/config/sync/core.entity_view_display.paragraph.stanford_entity.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.stanford_entity.default.yml
@@ -7,11 +7,17 @@ dependencies:
     - field.field.paragraph.stanford_entity.su_entity_description
     - field.field.paragraph.stanford_entity.su_entity_headline
     - field.field.paragraph.stanford_entity.su_entity_item
+    - field.field.paragraph.stanford_entity.su_entity_news
+    - field.field.paragraph.stanford_entity.su_entity_news_display
     - paragraphs.paragraphs_type.stanford_entity
   module:
     - ds
     - element_class_formatter
+    - empty_fields
+    - entity_reference_display
     - field_formatter_class
+    - field_formatter_range
+    - field_label
     - stanford_fields
     - text
 id: paragraph.stanford_entity.default
@@ -32,7 +38,7 @@ content:
     third_party_settings:
       field_formatter_class:
         class: ''
-    weight: 3
+    weight: 4
     region: content
   su_entity_description:
     type: text_default
@@ -67,5 +73,27 @@ content:
         ds_limit: ''
     weight: 2
     region: content
+  su_entity_news:
+    type: entity_reference_display_default
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+      display_field: ''
+    third_party_settings:
+      empty_fields:
+        handler: ''
+      field_formatter_class:
+        class: su-margin-bottom-5
+      field_formatter_range:
+        order: 0
+        limit: 0
+        offset: 0
+      field_label:
+        label_value: ''
+        label_tag: ''
+    weight: 3
+    region: content
 hidden:
   search_api_excerpt: true
+  su_entity_news_display: true

--- a/config/sync/core.entity_view_mode.node.spotlight_teaser_large_image.yml
+++ b/config/sync/core.entity_view_mode.node.spotlight_teaser_large_image.yml
@@ -1,0 +1,11 @@
+uuid: b3375a7a-abc7-48d3-80c2-87e5f7ddf3c5
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.spotlight_teaser_large_image
+label: 'Spotlight Teaser - Large Image'
+description: null
+targetEntityType: node
+cache: true

--- a/config/sync/core.entity_view_mode.node.spotlight_teaser_small_image.yml
+++ b/config/sync/core.entity_view_mode.node.spotlight_teaser_small_image.yml
@@ -1,0 +1,11 @@
+uuid: f71e7922-22ba-4f49-9aad-144a2a19bcc7
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.spotlight_teaser_small_image
+label: 'Spotlight Teaser - Small Image'
+description: null
+targetEntityType: node
+cache: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -50,6 +50,7 @@ module:
   element_class_formatter: 0
   empty_fields: 0
   encrypt: 0
+  entity_reference_display: 0
   entity_reference_revisions: 0
   entity_usage: 0
   environment_indicator: 0

--- a/config/sync/field.field.paragraph.stanford_entity.su_entity_news.yml
+++ b/config/sync/field.field.paragraph.stanford_entity.su_entity_news.yml
@@ -1,0 +1,29 @@
+uuid: fc68f2c6-fe7d-407e-8ccf-f82aec2dfda0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.su_entity_news
+    - node.type.stanford_news
+    - paragraphs.paragraphs_type.stanford_entity
+id: paragraph.stanford_entity.su_entity_news
+field_name: su_entity_news
+entity_type: paragraph
+bundle: stanford_entity
+label: 'News Items'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      stanford_news: stanford_news
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.paragraph.stanford_entity.su_entity_news_display.yml
+++ b/config/sync/field.field.paragraph.stanford_entity.su_entity_news_display.yml
@@ -1,0 +1,25 @@
+uuid: 7feccdc1-220a-49b2-83dd-2f340112b153
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.su_entity_news_display
+    - paragraphs.paragraphs_type.stanford_entity
+  module:
+    - entity_reference_display
+id: paragraph.stanford_entity.su_entity_news_display
+field_name: su_entity_news_display
+entity_type: paragraph
+bundle: stanford_entity
+label: 'News Display'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  exclude:
+    stanford_card: stanford_card
+    stanford_h3_card: stanford_h3_card
+  negate: true
+field_type: entity_reference_display

--- a/config/sync/field.field.paragraph.stanford_entity.su_entity_news_display.yml
+++ b/config/sync/field.field.paragraph.stanford_entity.su_entity_news_display.yml
@@ -23,6 +23,5 @@ settings:
     stanford_h3_card: stanford_h3_card
     spotlight_teaser_large_image: spotlight_teaser_large_image
     spotlight_teaser_small_image: spotlight_teaser_small_image
-    teaser: teaser
   negate: true
 field_type: entity_reference_display

--- a/config/sync/field.field.paragraph.stanford_entity.su_entity_news_display.yml
+++ b/config/sync/field.field.paragraph.stanford_entity.su_entity_news_display.yml
@@ -21,5 +21,8 @@ settings:
   exclude:
     stanford_card: stanford_card
     stanford_h3_card: stanford_h3_card
+    spotlight_teaser_large_image: spotlight_teaser_large_image
+    spotlight_teaser_small_image: spotlight_teaser_small_image
+    teaser: teaser
   negate: true
 field_type: entity_reference_display

--- a/config/sync/field.storage.paragraph.su_entity_news.yml
+++ b/config/sync/field.storage.paragraph.su_entity_news.yml
@@ -1,0 +1,20 @@
+uuid: 7e9622aa-6b8b-4502-8d10-06130180000a
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.su_entity_news
+field_name: su_entity_news
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.paragraph.su_entity_news_display.yml
+++ b/config/sync/field.storage.paragraph.su_entity_news_display.yml
@@ -1,0 +1,19 @@
+uuid: 8fdc31f9-184f-48fa-bfff-071da0be251b
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_display
+    - paragraphs
+id: paragraph.su_entity_news_display
+field_name: su_entity_news_display
+entity_type: paragraph
+type: entity_reference_display
+settings: {  }
+module: entity_reference_display
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/graphql_compose.settings.yml
+++ b/config/sync/graphql_compose.settings.yml
@@ -945,6 +945,10 @@ field_config:
         enabled: true
       su_entity_item:
         enabled: true
+      su_entity_news:
+        enabled: true
+      su_entity_news_display:
+        enabled: true
     stanford_faq:
       su_faq_description:
         enabled: true

--- a/tests/codeception/functional/Paragraphs/EntityReferenceDisplayCest.php
+++ b/tests/codeception/functional/Paragraphs/EntityReferenceDisplayCest.php
@@ -1,0 +1,195 @@
+<?php
+
+use Codeception\Attribute as CodeceptionAttribute;
+use Faker\Factory;
+
+/**
+ * Tests Entity Reference Display module integration with stanford_entity paragraph.
+ */
+#[CodeceptionAttribute\Group('paragraphs')]
+#[CodeceptionAttribute\Group('entity_reference_display')]
+#[CodeceptionAttribute\Group('news')]
+class EntityReferenceDisplayCest {
+
+  /**
+   * @var \Faker\Generator
+   */
+  protected $faker;
+
+  public function __construct() {
+    $this->faker = Factory::create();
+  }
+
+  /**
+   * Test adding a news item to stanford_entity paragraph.
+   */
+  public function testNewsItemsInEntityParagraph(FunctionalTester $I) {
+    $news = $this->createNewsEntity($I);
+    $I->logInWithRole('contributor');
+    $node = $this->createNodeWithEntityParagraph($I);
+
+    $this->openParagraphNewsAccordion($I, $node);
+
+    $I->fillField('News Items', $news->label() . ' (' . $news->id() . ')');
+    $I->click('Save', '.ui-dialog-buttonpane');
+    $I->waitForElementNotVisible('.ui-dialog');
+    $I->click('Save');
+
+    $I->canSee('has been updated');
+    $I->canSee($news->label());
+  }
+
+  /**
+   * Test adding multiple news items.
+   */
+  public function testMultipleNewsItems(FunctionalTester $I) {
+    $news_items = [];
+    for ($i = 0; $i < 3; $i++) {
+      $news_items[] = $this->createNewsEntity($I);
+    }
+
+    $I->logInWithRole('site_manager');
+    $node = $this->createNodeWithEntityParagraph($I);
+    $this->openParagraphNewsAccordion($I, $node);
+
+    // Add first item.
+    $I->fillField('News Items', $news_items[0]->label() . ' (' . $news_items[0]->id() . ')');
+
+    // Add second item.
+    $I->click('Add another item', '.field--name-su-entity-news');
+    $I->waitForElementVisible('[name="su_entity_news[1][target_id]"]');
+    $I->fillField('[name="su_entity_news[1][target_id]"]', $news_items[1]->label() . ' (' . $news_items[1]->id() . ')');
+
+    // Add third item.
+    $I->click('Add another item', '.field--name-su-entity-news');
+    $I->waitForElementVisible('[name="su_entity_news[2][target_id]"]');
+    $I->fillField('[name="su_entity_news[2][target_id]"]', $news_items[2]->label() . ' (' . $news_items[2]->id() . ')');
+
+    $I->click('Save', '.ui-dialog-buttonpane');
+    $I->waitForElementNotVisible('.ui-dialog');
+    $I->click('Save');
+
+    $I->canSee('has been updated');
+    foreach ($news_items as $news) {
+      $I->canSee($news->label());
+    }
+  }
+
+  /**
+   * Test display mode selector with negate: true filtering.
+   */
+  public function testDisplayModeSelector(FunctionalTester $I) {
+    $I->logInWithRole('site_manager');
+    $node = $this->createNodeWithEntityParagraph($I);
+    $this->openParagraphNewsAccordion($I, $node);
+
+    $I->canSee('News Display');
+
+    // Check that it only contains the expected display modes.
+    $select_options = $I->grabMultiple('select[name="su_entity_news_display"] option', 'value');
+    $I->assertContains('stanford_card', $select_options);
+    $I->assertContains('stanford_h3_card', $select_options);
+    $I->assertContains('spotlight_teaser_large_image', $select_options);
+    $I->assertContains('spotlight_teaser_small_image', $select_options);
+
+    // Other display modes should be filtered out.
+    $I->assertNotContains('default', $select_options);
+    $I->assertNotContains('teaser', $select_options);
+  }
+
+  /**
+   * Test news items work alongside traditional entity reference.
+   */
+  public function testNewsWithTraditionalEntityReference(FunctionalTester $I) {
+    $news = $this->createNewsEntity($I);
+    $event = $I->createEntity([
+      'type' => 'stanford_event',
+      'title' => $this->faker->words(3, TRUE),
+    ]);
+
+    $I->logInWithRole('site_manager');
+    $node = $this->createNodeWithEntityParagraph($I);
+    $this->openParagraphNewsAccordion($I, $node);
+
+    $I->fillField('News Items', $news->label() . ' (' . $news->id() . ')');
+    $I->fillField('Content Item(s)', $event->label() . ' (' . $event->id() . ')');
+
+    $I->click('Save', '.ui-dialog-buttonpane');
+    $I->waitForElementNotVisible('.ui-dialog');
+    $I->click('Save');
+
+    $I->canSee('has been updated');
+    $I->canSee($news->label());
+    $I->canSee($event->label());
+  }
+
+  /**
+   * Test News Display field is hidden from front-end.
+   */
+  public function testNewsDisplayFieldHidden(FunctionalTester $I) {
+    $news = $this->createNewsEntity($I);
+    $I->logInWithRole('site_manager');
+    $node = $this->createNodeWithEntityParagraph($I);
+    $this->openParagraphNewsAccordion($I, $node);
+
+    $I->fillField('News Items', $news->label() . ' (' . $news->id() . ')');
+    $I->click('Save', '.ui-dialog-buttonpane');
+    $I->waitForElementNotVisible('.ui-dialog');
+    $I->click('Save');
+
+    $I->amOnPage($node->toUrl()->toString());
+    $I->canSee($news->label());
+    $I->dontSee('News Display:');
+  }
+
+  /**
+   * Create a news entity for testing.
+   */
+  protected function createNewsEntity(FunctionalTester $I) {
+    return $I->createEntity([
+      'type' => 'stanford_news',
+      'title' => $this->faker->words(3, TRUE),
+      'layout_selection' => 'news_spotlight',
+      'su_news_quote' => $this->faker->sentence(),
+      'su_news_publishing_date' => time(),
+    ]);
+  }
+
+  /**
+   * Open paragraph edit dialog and News accordion.
+   */
+  protected function openParagraphNewsAccordion(FunctionalTester $I, $node) {
+    $I->amOnPage($node->toUrl('edit-form')->toString());
+    $I->scrollTo('.js-lpb-component', 0, -100);
+    $I->moveMouseOver('.js-lpb-component', 10, 10);
+    $I->click('Edit', '.lpb-controls');
+    $I->waitForElement('.ui-dialog');
+    // Click News accordion using stable data-drupal-selector.
+    $I->click('[data-drupal-selector="edit-group-news"] summary');
+    $I->waitForElementVisible('[name="su_entity_news[0][target_id]"]');
+  }
+
+  /**
+   * Create a node with stanford_entity paragraph.
+   */
+  protected function createNodeWithEntityParagraph(FunctionalTester $I) {
+    $paragraph = $I->createEntity([
+      'type' => 'stanford_entity',
+      'su_entity_headline' => $this->faker->words(3, TRUE),
+      'su_entity_description' => [
+        'format' => 'stanford_html',
+        'value' => $this->faker->sentence(),
+      ],
+    ], 'paragraph');
+
+    return $I->createEntity([
+      'type' => 'stanford_page',
+      'title' => $this->faker->text(30),
+      'su_page_components' => [
+        'target_id' => $paragraph->id(),
+        'entity' => $paragraph,
+      ],
+    ]);
+  }
+
+}

--- a/tests/codeception/functional/Paragraphs/EntityReferenceDisplayCest.php
+++ b/tests/codeception/functional/Paragraphs/EntityReferenceDisplayCest.php
@@ -21,25 +21,6 @@ class EntityReferenceDisplayCest {
   }
 
   /**
-   * Test adding a news item to stanford_entity paragraph.
-   */
-  public function testNewsItemsInEntityParagraph(FunctionalTester $I) {
-    $news = $this->createNewsEntity($I);
-    $I->logInWithRole('contributor');
-    $node = $this->createNodeWithEntityParagraph($I);
-
-    $this->openParagraphNewsAccordion($I, $node);
-
-    $I->fillField('News Items', $news->label() . ' (' . $news->id() . ')');
-    $I->click('Save', '.ui-dialog-buttonpane');
-    $I->waitForElementNotVisible('.ui-dialog');
-    $I->click('Save');
-
-    $I->canSee('has been updated');
-    $I->canSee($news->label());
-  }
-
-  /**
    * Test adding multiple news items.
    */
   public function testMultipleNewsItems(FunctionalTester $I) {
@@ -143,6 +124,29 @@ class EntityReferenceDisplayCest {
   }
 
   /**
+   * Test spotlight teaser display modes render correctly.
+   */
+  #[CodeceptionAttribute\Examples(displayMode: 'spotlight_teaser_large_image', variantClass: 'su-spotlight-teaser--large')]
+  #[CodeceptionAttribute\Examples(displayMode: 'spotlight_teaser_small_image', variantClass: 'su-spotlight-teaser--small')]
+  public function testSpotlightTeaserDisplayModes(FunctionalTester $I, \Codeception\Example $example) {
+    $news = $this->createNewsEntity($I);
+    $I->logInWithRole('site_manager');
+    $node = $this->createNodeWithEntityParagraph($I);
+    $this->openParagraphNewsAccordion($I, $node);
+
+    $I->fillField('News Items', $news->label() . ' (' . $news->id() . ')');
+    $I->selectOption('News Display', $example['displayMode']);
+    $I->click('Save', '.ui-dialog-buttonpane');
+    $I->waitForElementNotVisible('.ui-dialog');
+    $I->click('Save');
+
+    $I->canSee('has been updated');
+    $I->canSee($news->label(), '.su-spotlight-teaser');
+    $I->seeElement('.su-card.su-spotlight-teaser.' . $example['variantClass']);
+    $I->canSee($news->get('su_news_quote')->value, '.su-spotlight-teaser__quote');
+  }
+
+  /**
    * Create a news entity for testing.
    */
   protected function createNewsEntity(FunctionalTester $I) {
@@ -164,7 +168,6 @@ class EntityReferenceDisplayCest {
     $I->moveMouseOver('.js-lpb-component', 10, 10);
     $I->click('Edit', '.lpb-controls');
     $I->waitForElement('.ui-dialog');
-    // Click News accordion using stable data-drupal-selector.
     $I->click('[data-drupal-selector="edit-group-news"] summary');
     $I->waitForElementVisible('[name="su_entity_news[0][target_id]"]');
   }


### PR DESCRIPTION
# NOT READY FOR REVIEW

# Summary
- D8CORE-8457 | add style classes to spotlight teaser large and small images, and teaser news

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Navigate to...
4. Verify...

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? **Yes**

# Associated Issues and/or People
- D8CORE-8457
- https://github.com/SU-SWS/stanford_profile/pull/1035