### PR TITLE
D8CORE-8488 D8CORE-8489 | update title to use h1 and filter tags to list

### DIFF
--- a/config/sync/core.entity_form_display.node.stanford_news.default.yml
+++ b/config/sync/core.entity_form_display.node.stanford_news.default.yml
@@ -37,6 +37,7 @@ dependencies:
     - metatag
     - path
     - scheduler
+    - stanford_fields
     - stanford_intranet
     - text
 third_party_settings:
@@ -410,18 +411,10 @@ content:
       placeholder_title: ''
     third_party_settings: {  }
   su_news_spotlight_filters:
-    type: cshs
+    type: taxonomy_label_hierarchy
     weight: 5
     region: content
-    settings:
-      save_lineage: false
-      force_deepest: false
-      parent: null
-      level_labels: ''
-      hierarchy_depth: 0
-      required_depth: 0
-      none_label: '- Please select -'
-      allow_unpublished: true
+    settings: {  }
     third_party_settings:
       change_labels:
         add_another: ''

--- a/config/sync/layout_library.layout.news_spotlight.yml
+++ b/config/sync/layout_library.layout.news_spotlight.yml
@@ -58,15 +58,21 @@ layout:
             entity: layout_builder.entity
             view_mode: view_mode
           formatter:
-            type: entity_reference_label
+            type: entity_reference_list_label_class
             label: hidden
             settings:
               link: false
+              class: ''
+              list_type: ul
             third_party_settings:
               empty_fields:
                 handler: ''
               field_formatter_class:
                 class: ''
+              field_formatter_range:
+                order: 0
+                limit: 0
+                offset: 0
               field_label:
                 label_value: ''
                 label_tag: ''
@@ -84,10 +90,10 @@ layout:
             entity: layout_builder.entity
             view_mode: view_mode
           formatter:
-            type: string
+            type: entity_title_heading
             label: hidden
             settings:
-              link_to_entity: false
+              tag: h1
             third_party_settings:
               empty_fields:
                 handler: ''


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- D8CORE-8488 D8CORE-8489 | update title to use h1 and filter tags to list

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Navigate to a spotlight page
4. Inspect html and verify that the title is an H1 and the taxonomy terms are in a list (e.g. `<ul><li></li></ul>`)
5. Review code

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? **Yes**


# Associated Issues and/or People
- D8CORE-8488
- D8CORE-8489
- https://github.com/SU-SWS/stanford_profile_helper/pull/479
