### PR TITLE
D8CORE-7681 | enable convert line breaks into html for html text format/editor

### DIFF
--- a/config/sync/filter.format.stanford_html.yml
+++ b/config/sync/filter.format.stanford_html.yml
@@ -39,7 +39,7 @@ filters:
   filter_autop:
     id: filter_autop
     provider: filter
-    status: false
+    status: true
     weight: -36
     settings: {  }
   filter_caption:
@@ -72,7 +72,7 @@ filters:
   filter_htmlcorrector:
     id: filter_htmlcorrector
     provider: filter
-    status: true
+    status: false
     weight: -43
     settings: {  }
   filter_image_lazy_load:
@@ -137,6 +137,6 @@ filters:
   su_clean_html:
     id: su_clean_html
     provider: stanford_decoupled
-    status: true
+    status: false
     weight: -40
     settings: {  }

--- a/config/sync/filter.format.stanford_html.yml
+++ b/config/sync/filter.format.stanford_html.yml
@@ -40,7 +40,7 @@ filters:
     id: filter_autop
     provider: filter
     status: true
-    weight: -36
+    weight: -43
     settings: {  }
   filter_caption:
     id: filter_caption
@@ -72,8 +72,8 @@ filters:
   filter_htmlcorrector:
     id: filter_htmlcorrector
     provider: filter
-    status: false
-    weight: -43
+    status: true
+    weight: -36 
     settings: {  }
   filter_image_lazy_load:
     id: filter_image_lazy_load
@@ -137,6 +137,6 @@ filters:
   su_clean_html:
     id: su_clean_html
     provider: stanford_decoupled
-    status: false
+    status: true
     weight: -40
     settings: {  }


### PR DESCRIPTION
# NOT READY FOR REVIEW

# Summary
- D8CORE-7681 | enable convert line breaks into html for html text format/editor

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Sync your local with the user guide
4. Navigate to `/build/create-and-edit-pages/text-editing-basics/create-links`
5. Verify that the code block includes line breaks:
<img width="1045" height="409" alt="image" src="https://github.com/user-attachments/assets/fb93b30d-f2dc-4fd7-b895-0001d83bd5f6" />

6. Review code

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? **Yes**

# Associated Issues and/or People
- D8CORE-7681