### PR TITLE
D8CORE-8457 | add style classes to news spotlight teaser

### DIFF
--- a/config/sync/core.entity_view_display.paragraph.stanford_entity.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.stanford_entity.default.yml
@@ -84,7 +84,7 @@ content:
       empty_fields:
         handler: ''
       field_formatter_class:
-        class: su-margin-bottom-5
+        class: su-margin-bottom-5 su-entity-item
       field_formatter_range:
         order: 0
         limit: 0


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- D8CORE-8457 | add style classes to news spotlight teaser

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch and https://github.com/SU-SWS/stanford_profile_helper/pull/495
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Create News Spotlight variants
4. Create a basic page with the Spotlight list options and News Spotlight teasers.
5. Navigate to the FE
6. Verify that the styles match the[ figma designs](https://www.figma.com/design/X8aPFAIH2EI4KsIYWVb9Yw/Spotlight---Core?node-id=1-14&t=YTVApuM501saEcQ3-1)
7. Review code

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? **Yes**

# Associated Issues and/or People
- D8CORE-8457
- https://github.com/SU-SWS/stanford_profile/pull/1035
- https://github.com/SU-SWS/stanford_profile_helper/pull/495