### PR TITLE
D8Core-8131: Adding Help text to Stat Card

### DIFF
--- a/config/sync/field.field.paragraph.stanford_stat_card.su_stat_body.yml
+++ b/config/sync/field.field.paragraph.stanford_stat_card.su_stat_body.yml
@@ -13,7 +13,7 @@ field_name: su_stat_body
 entity_type: paragraph
 bundle: stanford_stat_card
 label: Body
-description: ''
+description: 'This field is option and can be used to provide additional data about the statistic.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.paragraph.stanford_stat_card.su_stat_headline.yml
+++ b/config/sync/field.field.paragraph.stanford_stat_card.su_stat_headline.yml
@@ -10,7 +10,7 @@ field_name: su_stat_headline
 entity_type: paragraph
 bundle: stanford_stat_card
 label: Headline
-description: ''
+description: "The headline is the label that provides additional information about your statistic and let's the site visitor know what the number refers to. It displays right under the statistic number. "
 required: true
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.paragraph.stanford_stat_card.su_stat_image.yml
+++ b/config/sync/field.field.paragraph.stanford_stat_card.su_stat_image.yml
@@ -11,7 +11,7 @@ field_name: su_stat_image
 entity_type: paragraph
 bundle: stanford_stat_card
 label: Image
-description: ''
+description: 'This image will appear at the top of the card.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/sync/field.field.paragraph.stanford_stat_card.su_stat_stat.yml
+++ b/config/sync/field.field.paragraph.stanford_stat_card.su_stat_stat.yml
@@ -10,7 +10,7 @@ field_name: su_stat_stat
 entity_type: paragraph
 bundle: stanford_stat_card
 label: Stat
-description: ''
+description: 'Enter a number that represents the statistic to highlight. Additional characters can be included.  Examples: 256, 20%, 1K, 72.5, $15.'
 required: true
 translatable: false
 default_value: {  }


### PR DESCRIPTION
# READY FOR REVIEW


# Summary
- Added a smidge of context to Stat Card

# Review By (Date)
- No rush

# Criticality
- 3

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Navigate to a page and add a stat card
4. Read the text!

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? YES

## Front End Validation
N/A

## Backend / Functional Validation
### Code
N/A

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
