### PR TITLE
D8Core-8162: Fix default filter on manage events view

### DIFF
--- a/config/sync/views.view.manage_content.yml
+++ b/config/sync/views.view.manage_content.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.storage.node.su_page_image
     - field.storage.node.su_person_type_group
     - field.storage.node.su_publication_topics
+    - node.type.stanford_course
     - node.type.stanford_event
     - node.type.stanford_media
     - node.type.stanford_news
@@ -2412,8 +2413,8 @@ display:
           plugin_id: bundle
           operator: in
           value:
-            stanford_media: stanford_media
-          group: 1
+            stanford_course: stanford_course
+          group: All
           exposed: false
           expose:
             operator_id: type_1_op
@@ -3427,7 +3428,7 @@ display:
             widget: select
             multiple: false
             remember: false
-            default_group: All
+            default_group: '1'
             default_group_multiple: {  }
             group_items:
               1:

--- a/config/sync/views.view.manage_content.yml
+++ b/config/sync/views.view.manage_content.yml
@@ -19,7 +19,6 @@ dependencies:
     - field.storage.node.su_page_image
     - field.storage.node.su_person_type_group
     - field.storage.node.su_publication_topics
-    - node.type.stanford_course
     - node.type.stanford_event
     - node.type.stanford_media
     - node.type.stanford_news
@@ -2413,7 +2412,7 @@ display:
           plugin_id: bundle
           operator: in
           value:
-            stanford_course: stanford_course
+            stanford_media: stanford_media
           group: 1
           exposed: false
           expose:
@@ -3428,7 +3427,7 @@ display:
             widget: select
             multiple: false
             remember: false
-            default_group: '1'
+            default_group: All
             default_group_multiple: {  }
             group_items:
               1:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This makes it so the default filter on the Manage Events view starts with a view where the user sees all events
- Notice that PR Labeler doesn't have a category below XS :)

# Review By (Date)
- No rush

# Criticality
- Low

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Navigate to the manage events view
4. See all of your events!

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? YES

## Front End Validation
N/A
## Backend / Functional Validation
### Code
N/A

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
