### PR TITLE
D8CORE-8659: More A/V name fixes

### DIFF
--- a/config/sync/core.entity_view_display.node.stanford_media.default.yml
+++ b/config/sync/core.entity_view_display.node.stanford_media.default.yml
@@ -422,7 +422,7 @@ third_party_settings:
       - 'Inline blocks'
       - 'Jumpstart UI'
       - 'Lists (Views)'
-      - 'Media Lists (Views)'
+      - 'Audio/Visual Lists (Views)'
       - Menus
       - 'News Lists (Views)'
       - 'Opportunities (Views)'

--- a/config/sync/pathauto.pattern.media_nodes.yml
+++ b/config/sync/pathauto.pattern.media_nodes.yml
@@ -5,9 +5,9 @@ dependencies:
   module:
     - node
 id: media_nodes
-label: 'Media Nodes'
+label: 'Audio/Visual Nodes'
 type: 'canonical_entities:node'
-pattern: 'media/[node:title]'
+pattern: 'av/[node:title]'
 selection_criteria:
   43deff05-71af-4c9a-a795-0b71021659aa:
     id: 'entity_bundle:node'

--- a/config/sync/views.view.manage_content.yml
+++ b/config/sync/views.view.manage_content.yml
@@ -3490,11 +3490,11 @@ display:
         - 'config:field.storage.node.su_imported'
   manage_media:
     id: manage_media
-    display_title: Media
+    display_title: Audio/Visual
     display_plugin: page
     position: 3
     display_options:
-      title: Media
+      title: Audio/Visual
       fields:
         views_bulk_operations_bulk_form:
           id: views_bulk_operations_bulk_form

--- a/config/sync/views.view.media_content.yml
+++ b/config/sync/views.view.media_content.yml
@@ -256,7 +256,7 @@ display:
         - 'config:field.storage.node.su_media_audio_video'
   after_first_media:
     id: after_first_media
-    display_title: 'After First Media'
+    display_title: 'After First Audio/Visual'
     display_plugin: block
     position: 4
     display_options:
@@ -779,14 +779,14 @@ display:
           field: su_media_audio_video
           relationship: none
           group_type: group
-          admin_label: 'su_media_audio_video: Media'
+          admin_label: 'su_media_audio_video: Audio/Visual'
           plugin_id: standard
           required: false
       display_description: ''
       header: {  }
       display_extenders: {  }
-      block_description: 'After First Media'
-      block_category: 'Media Lists (Views)'
+      block_description: 'After First Audio/Visual'
+      block_category: 'Audio/Visual Lists (Views)'
       block_hide_empty: true
     cache_metadata:
       max-age: -1
@@ -887,7 +887,7 @@ display:
         arguments: false
       display_description: ''
       block_description: 'Default List'
-      block_category: 'Media Lists (Views)'
+      block_category: 'Audio/Visual Lists (Views)'
       block_hide_empty: true
     cache_metadata:
       max-age: -1
@@ -1337,7 +1337,7 @@ display:
         arguments: false
       display_description: ''
       block_description: 'Default List'
-      block_category: 'Media Lists (Views)'
+      block_category: 'Audio/Visual Lists (Views)'
       block_hide_empty: true
     cache_metadata:
       max-age: -1
@@ -1351,7 +1351,7 @@ display:
         - 'config:field.storage.node.su_media_audio_video'
   person_list:
     id: person_list
-    display_title: 'Person Media'
+    display_title: 'Person Audio/Visual'
     display_plugin: block
     position: 8
     display_options:
@@ -1431,7 +1431,7 @@ display:
         arguments: false
       display_description: ''
       display_extenders: {  }
-      block_description: 'Person: Related Media'
+      block_description: 'Person: Related Audio/Visual'
       block_category: 'People Lists (Views)'
       block_hide_empty: true
     cache_metadata:
@@ -1676,7 +1676,7 @@ display:
           required: true
       display_description: ''
       display_extenders: {  }
-      block_category: 'Media Lists (Views)'
+      block_category: 'Audio/Visual Lists (Views)'
       block_hide_empty: true
     cache_metadata:
       max-age: -1
@@ -2253,7 +2253,7 @@ display:
         filter_groups: true
       display_description: ''
       display_extenders: {  }
-      block_category: 'Media Lists (Views)'
+      block_category: 'Audio/Visual Lists (Views)'
       block_hide_empty: true
     cache_metadata:
       max-age: -1

--- a/config/sync/views.view.media_filtered.yml
+++ b/config/sync/views.view.media_filtered.yml
@@ -16,7 +16,7 @@ dependencies:
     - user
     - views_infinite_scroll
 id: media_filtered
-label: 'Media - Filtered'
+label: 'Audio/Visual - Filtered'
 module: views
 description: ''
 tag: ''


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Update the names in the List and Filtered Lists
- Updated pathauto
- Updated other assorted labels

# Review By (Date)
- ideally before release

# Criticality
- 2

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Place a filtered list and/or list
3. Notice that when you check the list, it shows Audio/Visual as the label for the lists
4. Notice that the path is /av/nodetitle

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? YES

## Front End Validation
No front-end impact

## Backend / Functional Validation
### Code

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
