### PR TITLE
D8CORE-8658: Update aria-label for secondary navigation

### DIFF
--- a/themes/stanford_basic/templates/menus/menu--secondary-nav.html.twig
+++ b/themes/stanford_basic/templates/menus/menu--secondary-nav.html.twig
@@ -15,7 +15,7 @@
 #}
 
 {% set attributes = attributes.addClass(['su-secondary-nav--light', 'su-secondary-nav', 'su-secondary-nav--static', 'no-js']) %}
-{% set attributes = attributes.setAttribute('aria-label', aria_label|default('secondary menu')) %}
+{% set attributes = attributes.setAttribute('aria-label', aria_label|default('secondary navigation')) %}
 {# Macros #}
 {%- import "@basic/menus/macros/secondary-nav-menu.twig" as menus -%}
 <a href="#main-content" class="visually-hidden focusable su-skipnav su-skipnav--content">{{ 'Skip Secondary Navigation'|t }}</a>


### PR DESCRIPTION
# READY FOR REVIEW
Update terminology to be consistent

# Summary
- We have called it Secondary Navigation everywhere else, let's update aria label to match.

# Review By (Date)
- No rush

# Criticality
- 5

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Navigate to a page with secondary navigation
4. Browser inspect to ensure that they match (see previous state in https://stanfordits.atlassian.net/browse/D8CORE-8658

### Site Configuration Sync

- Nope

## Front End Validation
No front-end impact

## Backend / Functional Validation
### Code
N.A

### Code security
NA

## General
- [NO ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ YES] Is the approach to the problem appropriate?

# Affected Projects or Products


# Associated Issues and/or People
[- JIRA ticket(s)](https://stanfordits.atlassian.net/browse/D8CORE-8658)


# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
