### PR TITLE
D8CORE-8855: Create hotfix style sheet that loads from github pages

### DIFF
--- a/themes/stanford_basic/src/Hook/PageAttachmentHooks.php
+++ b/themes/stanford_basic/src/Hook/PageAttachmentHooks.php
@@ -8,6 +8,7 @@ use Drupal\Core\Extension\ThemeSettingsProvider;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Site\Settings;
 
 class PageAttachmentHooks {
 
@@ -24,6 +25,9 @@ class PageAttachmentHooks {
    */
   #[Hook('page_attachments_alter')]
   public function pageAttachmentsAlter(array &$attachments): void {
+    if (Settings::get('stanford_profile_hotfix_styles')) {
+      $attachments['#attached']['library'][] = 'stanford_basic/hotfix';
+    }
     if ($this->currentUser->isAuthenticated()) {
       $attachments['#attached']['library'][] = 'stanford_basic/admin';
     }

--- a/themes/stanford_basic/stanford_basic.libraries.yml
+++ b/themes/stanford_basic/stanford_basic.libraries.yml
@@ -153,3 +153,13 @@ algolia-search:
     algolia-search/dist/islands/algolia-search.island.js: { minified: true }
   dependencies:
     - core/drupalSettings
+
+hotfix:
+  version: 1.0.0
+  remote: https://github.com/SU-SWS/stanford-sites-hotfix
+  license:
+    name: MIT
+    url: https://github.com/SU-SWS/stanford-sites-hotfix/blob/main/LICENSE
+  css:
+    theme:
+      //su-sws.github.io/stanford-sites-hotfix/style.css : { minified: true }


### PR DESCRIPTION
This pull request introduces a conditional "hotfix" CSS library to the Stanford Basic theme, allowing for dynamic inclusion of external styles based on a site setting. The main changes are as follows:

**Hotfix styles integration:**

* Added a new `hotfix` library to `stanford_basic.libraries.yml` that loads an external CSS file for urgent style fixes.
* Updated `PageAttachmentHooks.php` to conditionally attach the `hotfix` library if the `stanford_profile_hotfix_styles` setting is enabled in `settings.php`.
* Imported the `Settings` class in `PageAttachmentHooks.php` to support the new conditional logic.